### PR TITLE
Make connection handle public

### DIFF
--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -46,7 +46,8 @@ impl Connection {
         Self { handle }
     }
 
-    pub(crate) fn handle(&self) -> ConnHandle {
+    /// Connection handle of this connection.
+    pub fn handle(&self) -> ConnHandle {
         self.handle
     }
 


### PR DESCRIPTION
Required for some vendor specific HCI commands.