### PR TITLE
Advertiser type

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,4 @@ jobs:
           cargo test --lib -- --nocapture
 
       - name: Build examples
-        run: for i in nrf-sdc; do pushd examples/$i; cargo fmt --check && cargo clippy && cargo build --release; popd; done;
+        run: for i in nrf-sdc serial-hci apache-nimble; do pushd examples/$i; cargo fmt --check && cargo clippy && cargo build --release; popd; done;

--- a/examples/apache-nimble/src/main.rs
+++ b/examples/apache-nimble/src/main.rs
@@ -103,6 +103,9 @@ async fn main(spawner: embassy_executor::Spawner) {
                     },
                 )
                 .await
+                .unwrap()
+                .accept()
+                .await
                 .unwrap();
 
             let mut test = 0;

--- a/examples/nrf-sdc/src/bin/ble_advertise_multiple.rs
+++ b/examples/nrf-sdc/src/bin/ble_advertise_multiple.rs
@@ -162,9 +162,10 @@ async fn main(spawner: Spawner) {
     let _ = join(ble.run(), async {
         loop {
             let start = Instant::now();
-            match ble.advertise_ext(&sets).await {
+            let mut advertiser = unwrap!(ble.advertise_ext(&sets).await);
+            match advertiser.accept().await {
                 Ok(_) => {}
-                Err(trouble_host::BleHostError::BleHost(trouble_host::Error::Timeout)) => {
+                Err(trouble_host::Error::Timeout) => {
                     let d: Duration = Instant::now() - start;
                     defmt::info!("timeout/done after {} millis", d.as_millis());
                     Timer::after(Duration::from_secs(2)).await;

--- a/examples/nrf-sdc/src/bin/ble_bas_peripheral.rs
+++ b/examples/nrf-sdc/src/bin/ble_bas_peripheral.rs
@@ -162,13 +162,17 @@ async fn main(spawner: Spawner) {
         },
         async {
             let conn = unwrap!(
-                ble.advertise(
-                    &Default::default(),
-                    Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &[],
-                    }
+                unwrap!(
+                    ble.advertise(
+                        &Default::default(),
+                        Advertisement::ConnectableScannableUndirected {
+                            adv_data: &adv_data[..],
+                            scan_data: &[],
+                        }
+                    )
+                    .await
                 )
+                .accept()
                 .await
             );
             // Keep connection alive

--- a/examples/nrf-sdc/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/nrf-sdc/src/bin/ble_l2cap_peripheral.rs
@@ -130,13 +130,17 @@ async fn main(spawner: Spawner) {
         loop {
             info!("Advertising, waiting for connection...");
             let conn = unwrap!(
-                ble.advertise(
-                    &Default::default(),
-                    Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &scan_data[..],
-                    }
+                unwrap!(
+                    ble.advertise(
+                        &Default::default(),
+                        Advertisement::ConnectableScannableUndirected {
+                            adv_data: &adv_data[..],
+                            scan_data: &scan_data[..],
+                        }
+                    )
+                    .await
                 )
+                .accept()
                 .await
             );
 

--- a/examples/serial-hci/src/main.rs
+++ b/examples/serial-hci/src/main.rs
@@ -123,6 +123,9 @@ async fn main() {
                     },
                 )
                 .await
+                .unwrap()
+                .accept()
+                .await
                 .unwrap();
             // Keep connection alive
             let mut tick: u8 = 0;

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -25,8 +25,11 @@ pub enum TxPower {
     Plus6dBm = 6,
     Plus7dBm = 7,
     Plus8dBm = 8,
+    Plus10dBm = 10,
     Plus12dBm = 12,
+    Plus14dBm = 14,
     Plus16dBm = 16,
+    Plus18dBm = 18,
     Plus20dBm = 20,
 }
 

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -580,16 +580,16 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
     // our policy says so.
     async fn flow_control<T: Controller>(
         &self,
-        chan: ChannelIndex,
+        index: ChannelIndex,
         ble: &BleHost<'d, T>,
         mut packet: Packet,
     ) -> Result<(), BleHostError<T::Error>> {
         let (conn, cid, credits) = self.with_mut(|state| {
-            let chan = &mut state.channels[chan.0 as usize];
+            let chan = &mut state.channels[index.0 as usize];
             if chan.state == ChannelState::Connected {
                 return Ok((chan.conn, chan.cid, chan.flow_control.process()));
             }
-            trace!("[l2cap][flow_control] channel {} not found", chan);
+            trace!("[l2cap][flow_control] channel {:?} not found", index);
             Err(Error::NotFound)
         })?;
 
@@ -632,7 +632,7 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
                 return Poll::Pending;
             }
         }
-        trace!("[l2cap][pool_request_to_send] channel index {} not found", index);
+        trace!("[l2cap][pool_request_to_send] channel index {:?} not found", index);
         Poll::Ready(Err(Error::NotFound))
     }
 

--- a/host/tests/l2cap.rs
+++ b/host/tests/l2cap.rs
@@ -95,10 +95,11 @@ async fn l2cap_connection_oriented_channels() {
 
                 loop {
                     println!("[peripheral] advertising");
-                    let conn = adapter.advertise(&Default::default(), Advertisement::ConnectableScannableUndirected {
+                    let mut acceptor = adapter.advertise(&Default::default(), Advertisement::ConnectableScannableUndirected {
                         adv_data: &adv_data[..],
                         scan_data: &scan_data[..],
                     }).await?;
+                    let conn = acceptor.accept().await?;
                     println!("[peripheral] connected");
 
                     let mut ch1 = L2capChannel::<MTU>::accept(&adapter, &conn, &[0x2349], &Default::default()).await?;


### PR DESCRIPTION
Introducing the advertiser type allows the caller to perform actions after advertising has started, but before connections have been established.
