### PR TITLE
Add CharacteristicBuilder and ServiceHandle

### DIFF
--- a/examples/apache-nimble/src/main.rs
+++ b/examples/apache-nimble/src/main.rs
@@ -48,7 +48,7 @@ async fn main(spawner: embassy_executor::Spawner) {
         let mut svc = table.add_service(Service::new(0x1800));
         svc.add_characteristic_ro(0x2a00, b"Trouble");
         svc.add_characteristic_ro(0x2a01, &[0x80, 0x07]);
-        drop(svc);
+        svc.build();
 
         table.add_service(Service::new(0x1801));
 
@@ -58,6 +58,7 @@ async fn main(spawner: embassy_executor::Spawner) {
             &[CharacteristicProp::Read, CharacteristicProp::Notify],
             &mut bat_level,
         )
+        .build()
     };
 
     let server = adapter.gatt_server(&table);

--- a/examples/nrf-sdc/src/bin/ble_bas_peripheral.rs
+++ b/examples/nrf-sdc/src/bin/ble_bas_peripheral.rs
@@ -119,7 +119,7 @@ async fn main(spawner: Spawner) {
         let mut svc = table.add_service(Service::new(0x1800));
         let _ = svc.add_characteristic_ro(0x2a00, id);
         let _ = svc.add_characteristic_ro(0x2a01, &appearance[..]);
-        drop(svc);
+        svc.build();
 
         // Generic attribute service (mandatory)
         table.add_service(Service::new(0x1801));
@@ -132,6 +132,7 @@ async fn main(spawner: Spawner) {
             &[CharacteristicProp::Read, CharacteristicProp::Notify],
             &mut bat_level,
         )
+        .build()
     };
 
     let server = ble.gatt_server(&table);

--- a/examples/serial-hci/src/main.rs
+++ b/examples/serial-hci/src/main.rs
@@ -70,7 +70,7 @@ async fn main() {
         let mut svc = table.add_service(Service::new(0x1800));
         let _ = svc.add_characteristic_ro(0x2a00, id);
         let _ = svc.add_characteristic_ro(0x2a01, &appearance[..]);
-        drop(svc);
+        svc.build();
 
         // Generic attribute service (mandatory)
         table.add_service(Service::new(0x1801));
@@ -83,6 +83,7 @@ async fn main() {
             &[CharacteristicProp::Read, CharacteristicProp::Notify],
             &mut bat_level,
         )
+        .build()
     };
 
     let mut adv_data = [0; 31];


### PR DESCRIPTION
The main motivation for this was to allow for adding descriptors to characteristics.

- Adds `CharacteristicBuilder`, which contains methods for adding descriptors
- Adds `ServiceHandle`, which can be obtained by calling a newly added `build` method to `ServiceBuilder`
- `ServiceBuilder::add_characteristic` and `ServiceBuilder::add_characteristic_ro` were changed to return a `CharacteristicBuilder` instead of `CharacteristicHandle`. `CharacteristicBuilder::build` can be called to obtain the handle.