### PR TITLE
use owned advertising params

### DIFF
--- a/examples/nrf-sdc/src/bin/ble_advertise_multiple.rs
+++ b/examples/nrf-sdc/src/bin/ble_advertise_multiple.rs
@@ -123,7 +123,7 @@ async fn main(spawner: Spawner) {
     let sets = [
         AdvertisementSet {
             handle: 0,
-            params: &AdvertisementParameters {
+            params: AdvertisementParameters {
                 tx_power: TxPower::Plus8dBm,
                 primary_phy: PhyKind::Le1M,
                 secondary_phy: PhyKind::Le1M,
@@ -140,7 +140,7 @@ async fn main(spawner: Spawner) {
         },
         AdvertisementSet {
             handle: 1,
-            params: &AdvertisementParameters {
+            params: AdvertisementParameters {
                 tx_power: TxPower::Plus8dBm,
                 primary_phy: PhyKind::LeCoded,
                 secondary_phy: PhyKind::LeCoded,

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -37,7 +37,7 @@ pub enum TxPower {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisementSet<'d> {
     pub handle: u8,
-    pub params: &'d AdvertisementParameters,
+    pub params: AdvertisementParameters,
     pub data: Advertisement<'d>,
 }
 


### PR DESCRIPTION
This allows modifying them by the caller in-between calls to advertise_ext.