### PR TITLE
Use slices for advertising sets

### DIFF
--- a/examples/apache-nimble/Cargo.lock
+++ b/examples/apache-nimble/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 [[package]]
 name = "bt-hci"
 version = "0.1.0"
-source = "git+https://github.com/alexmoon/bt-hci.git?branch=main#bcf4b48dd1681e145635cf7d552be48fd664eab9"
+source = "git+https://github.com/alexmoon/bt-hci.git?branch=main#b9cd5954f6bd89b535cad9c418e9fdf12812d7c3"
 dependencies = [
  "embassy-sync 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "embassy-time",

--- a/examples/nrf-sdc/Cargo.lock
+++ b/examples/nrf-sdc/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 [[package]]
 name = "bt-hci"
 version = "0.1.0"
-source = "git+https://github.com/alexmoon/bt-hci.git?branch=main#bcf4b48dd1681e145635cf7d552be48fd664eab9"
+source = "git+https://github.com/alexmoon/bt-hci.git?branch=main#b9cd5954f6bd89b535cad9c418e9fdf12812d7c3"
 dependencies = [
  "defmt",
  "embassy-sync 0.6.0",

--- a/examples/nrf-sdc/src/bin/ble_advertise_multiple.rs
+++ b/examples/nrf-sdc/src/bin/ble_advertise_multiple.rs
@@ -122,7 +122,6 @@ async fn main(spawner: Spawner) {
 
     let sets = [
         AdvertisementSet {
-            handle: 0,
             params: AdvertisementParameters {
                 tx_power: TxPower::Plus8dBm,
                 primary_phy: PhyKind::Le1M,
@@ -133,13 +132,13 @@ async fn main(spawner: Spawner) {
                 interval_max: Duration::from_secs(1),
                 channel_map: None,
                 filter_policy: AdvFilterPolicy::Unfiltered,
+                fragment: false,
             },
             data: Advertisement::ExtNonconnectableScannableUndirected {
                 scan_data: &adv_data[..len],
             },
         },
         AdvertisementSet {
-            handle: 1,
             params: AdvertisementParameters {
                 tx_power: TxPower::Plus8dBm,
                 primary_phy: PhyKind::LeCoded,
@@ -149,6 +148,7 @@ async fn main(spawner: Spawner) {
                 interval_min: Duration::from_secs(1),
                 interval_max: Duration::from_secs(1),
                 channel_map: None,
+                fragment: false,
                 filter_policy: AdvFilterPolicy::Unfiltered,
                 ..Default::default()
             },
@@ -157,12 +157,13 @@ async fn main(spawner: Spawner) {
             },
         },
     ];
+    let mut handles = AdvertisementSet::handles(&sets);
 
     info!("Starting advertising");
     let _ = join(ble.run(), async {
         loop {
             let start = Instant::now();
-            let mut advertiser = unwrap!(ble.advertise_ext(&sets).await);
+            let mut advertiser = unwrap!(ble.advertise_ext(&sets, &mut handles).await);
             match advertiser.accept().await {
                 Ok(_) => {}
                 Err(trouble_host::Error::Timeout) => {

--- a/examples/serial-hci/Cargo.lock
+++ b/examples/serial-hci/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 [[package]]
 name = "bt-hci"
 version = "0.1.0"
-source = "git+https://github.com/alexmoon/bt-hci.git?branch=main#bcf4b48dd1681e145635cf7d552be48fd664eab9"
+source = "git+https://github.com/alexmoon/bt-hci.git?branch=main#b9cd5954f6bd89b535cad9c418e9fdf12812d7c3"
 dependencies = [
  "embassy-sync",
  "embassy-time",

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -33,25 +33,32 @@ pub enum TxPower {
     Plus20dBm = 20,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AdvertisementSet<'d> {
-    pub handle: u8,
     pub params: AdvertisementParameters,
     pub data: Advertisement<'d>,
 }
 
 impl<'d> AdvertisementSet<'d> {
     pub fn handles<const N: usize>(sets: &[AdvertisementSet<'d>; N]) -> [AdvSet; N] {
-        sets.map(|set| AdvSet {
-            adv_handle: AdvHandle::new(set.handle),
-            duration: set
+        const NEW_SET: AdvSet = AdvSet {
+            adv_handle: AdvHandle::new(0),
+            duration: bt_hci::param::Duration::from_u16(0),
+            max_ext_adv_events: 0,
+        };
+
+        let mut ret = [NEW_SET; N];
+        for (i, set) in sets.iter().enumerate() {
+            ret[i].adv_handle = AdvHandle::new(i as u8);
+            ret[i].duration = set
                 .params
                 .timeout
                 .unwrap_or(embassy_time::Duration::from_micros(0))
-                .into(),
-            max_ext_adv_events: set.params.max_events.unwrap_or(0),
-        })
+                .into();
+            ret[i].max_ext_adv_events = set.params.max_events.unwrap_or(0);
+        }
+        ret
     }
 }
 

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -1,6 +1,6 @@
 //! Advertisement config.
 use bt_hci::param::AdvEventProps;
-pub use bt_hci::param::{AdvChannelMap, AdvFilterPolicy, PhyKind};
+pub use bt_hci::param::{AdvChannelMap, AdvFilterPolicy, AdvHandle, AdvSet, PhyKind};
 use embassy_time::Duration;
 
 use crate::cursor::{ReadCursor, WriteCursor};
@@ -39,6 +39,20 @@ pub struct AdvertisementSet<'d> {
     pub handle: u8,
     pub params: AdvertisementParameters,
     pub data: Advertisement<'d>,
+}
+
+impl<'d> AdvertisementSet<'d> {
+    pub fn handles<const N: usize>(sets: &[AdvertisementSet<'d>; N]) -> [AdvSet; N] {
+        sets.map(|set| AdvSet {
+            adv_handle: AdvHandle::new(set.handle),
+            duration: set
+                .params
+                .timeout
+                .unwrap_or(embassy_time::Duration::from_micros(0))
+                .into(),
+            max_ext_adv_events: set.params.max_events.unwrap_or(0),
+        })
+    }
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -165,6 +165,10 @@ impl<'d> AdvState<'d> {
     pub fn start(&self, sets: &[AdvSet]) {
         let mut state = self.state.borrow_mut();
         assert!(sets.len() <= state.handles.len());
+        for handle in state.handles.iter_mut() {
+            *handle = AdvHandleState::None;
+        }
+
         for (idx, entry) in sets.iter().enumerate() {
             state.handles[idx] = AdvHandleState::Advertising(entry.adv_handle);
         }
@@ -648,7 +652,7 @@ where
         self.advertise_state.reset();
 
         for (i, set) in sets.iter().enumerate() {
-            let handle = AdvHandle::new(set.handle);
+            let handle = AdvHandle::new(i as u8);
             let data: RawAdvertisement<'k> = set.data.into();
             let params = set.params;
             let peer = data.peer.unwrap_or(Address {


### PR DESCRIPTION
This allows dynamically passing less than the max sets if necessary,
which can be the case if the underlying controller has limits on
how many connections it can establish.

The price to pay is that the api for doing extended advertisements
becomes a bit harder to use, but some convenience fn should improve
that.