### PR TITLE
Disconnect on out of memory errors

### DIFF
--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -1055,6 +1055,13 @@ where
                         Ok(_) => {}
                         Err(e) => {
                             trace!("Error processing ACL packet: {:?}", e);
+                            if let Error::OutOfMemory = e {
+                                warn!("[host] out of memory error on handle {:?}, disconnecting", acl.handle());
+                                self.connections.request_handle_disconnect(
+                                    acl.handle(),
+                                    DisconnectReason::RemoteDeviceTerminatedConnLowResources,
+                                );
+                            }
                             let mut m = self.metrics.borrow_mut();
                             m.rx_errors = m.rx_errors.wrapping_add(1);
                         }


### PR DESCRIPTION
If receiving a packet encounters an allocation error or other out of memory conditions, disconnect signalling low on resources. This means that buffer sizes must be adjusted, because otherwise the data will be lost without the other end knowing