### PR TITLE
Fix 128-bit UUID parsing in discover_characteristic

### DIFF
--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -246,7 +246,7 @@ impl<'reference, 'resources, T: Controller, const MAX: usize, const L2CAP_MTU: u
                         let mut r = ReadCursor::new(item);
                         let _props: u8 = r.read()?;
                         let value_handle: u16 = r.read()?;
-                        let value_uuid: Uuid = r.read()?;
+                        let value_uuid: Uuid = Uuid::from_slice(r.remaining());
 
                         if uuid == &value_uuid {
                             return Ok(Characteristic {


### PR DESCRIPTION
This change addresses an issue where discovered characteristic UUID's were always being treated as 16-bit.