### PR TITLE
Revert "remove superflous api for adding descriptors"

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -48,11 +48,14 @@ where
     table.add_service(Service::new(0x1801));
 
     // Battery service
-    let level_handle = table.add_service(Service::new(0x180f)).add_characteristic(
-        0x2a19,
-        &[CharacteristicProp::Read, CharacteristicProp::Notify],
-        &mut bat_level,
-    );
+    let level_handle = table
+        .add_service(Service::new(0x180f))
+        .add_characteristic(
+            0x2a19,
+            &[CharacteristicProp::Read, CharacteristicProp::Notify],
+            &mut bat_level,
+        )
+        .build();
 
     let server = ble.gatt_server::<NoopRawMutex, MAX_ATTRIBUTES, L2CAP_MTU>(&table);
 

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -61,7 +61,8 @@ async fn gatt_client_server() {
             .add_characteristic(
                 VALUE_UUID.clone(),
                 &[CharacteristicProp::Read, CharacteristicProp::Write, CharacteristicProp::Notify],
-                &mut value);
+                &mut value)
+            .build();
 
         let server = adapter.gatt_server::<NoopRawMutex, 10, 27>(&table);
 


### PR DESCRIPTION
This reverts commit 13a5d962a913a96119825535dda324255bccb701.