### PR TITLE
Fix a race when creating l2cap connections

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -32,6 +32,7 @@ defmt = {version = "0.3", optional = true }
 tokio = { version = "1", default-features = false, features = ["time", "rt-multi-thread", "macros"] }
 embedded-io-adapters = { version = "0.6.1", features = ["tokio-1"] }
 embedded-io-async = { version = "0.6.1" }
+embedded-io = { version = "0.6.1" }
 tokio-serial = "5.4"
 env_logger = "0.11"
 critical-section = { version = "1", features = ["std"] }

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -984,3 +984,32 @@ impl<'reference, 'state> Drop for CreditGrant<'reference, 'state> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::boxed::Box;
+
+    use super::*;
+    use crate::mock_controller::MockController;
+    use crate::packet_pool::{PacketPool, Qos};
+
+    #[test]
+    fn channel_refcount() {
+        let mut channels = [ChannelStorage::DISCONNECTED; 3];
+        let mut inbound = [PacketChannel::<1>::NEW; 3];
+        let pool: Box<PacketPool<NoopRawMutex, 27, 8, 8>> = Box::new(PacketPool::new(Qos::None));
+        let pool = Box::leak(pool);
+
+        let ble = MockController::new();
+        let mgr = ChannelManager::new(pool, &mut channels[..], &mut inbound[..]);
+
+        let conn = ConnHandle::new(0);
+        let psm = 0x1234;
+        let mtu = 64;
+        let credit_flow = 33;
+        let initial_credits = Some(1);
+        let create_fut = mgr.create(conn, psm, mtu, credit_flow, initial_credits, ble);
+    }
+}

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -169,6 +169,7 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
         // Wait until we find a channel for our connection in the connecting state matching our PSM.
         let (channel, req_id, mps, mtu, cid, credits) = poll_fn(|cx| {
             let mut state = self.state.borrow_mut();
+            state.accept_waker.register(cx.waker());
             for (idx, chan) in state.channels.iter_mut().enumerate() {
                 match chan.state {
                     ChannelState::PeerConnecting(req_id) if chan.conn == Some(conn) && psm.contains(&chan.psm) => {
@@ -197,7 +198,6 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
                     _ => {}
                 }
             }
-            state.accept_waker.register(cx.waker());
             Poll::Pending
         })
         .await;
@@ -258,28 +258,45 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
         hci.signal(req_id, &command, &mut tx[..]).await?;
 
         // Wait until a response is accepted.
-        poll_fn(|cx| {
-            let mut state = self.state.borrow_mut();
+        poll_fn(|cx| self.poll_created(conn, idx, ble, Some(cx))).await
+    }
+
+    fn poll_created<T: Controller>(
+        &self,
+        conn: ConnHandle,
+        idx: ChannelIndex,
+        ble: &BleHost<'_, T>,
+        cx: Option<&mut Context<'_>>,
+    ) -> Poll<Result<L2capChannel<'_>, BleHostError<T::Error>>> {
+        let mut state = self.state.borrow_mut();
+        if let Some(cx) = cx {
             state.create_waker.register(cx.waker());
-            let storage = &mut state.channels[idx.0 as usize];
-            match storage.state {
-                ChannelState::Disconnecting | ChannelState::PeerDisconnecting => {
-                    return Poll::Ready(Err(Error::Disconnected.into()));
-                }
-                ChannelState::Connected => {
-                    if storage.refcount != 0 {
-                        state.print(true);
-                        panic!("unexpected refcount");
-                    }
-                    assert_eq!(storage.refcount, 0);
-                    state.inc_ref(idx);
-                    return Poll::Ready(Ok(L2capChannel::new(idx, self)));
-                }
-                _ => {}
+        }
+        let storage = &mut state.channels[idx.0 as usize];
+        // Check if we've been disconnected while waiting
+        if !ble.connections.is_handle_connected(conn) {
+            return Poll::Ready(Err(Error::Disconnected.into()));
+        }
+
+        //// Make sure something hasn't gone wrong
+        assert_eq!(Some(conn), storage.conn);
+
+        match storage.state {
+            ChannelState::Disconnecting | ChannelState::PeerDisconnecting => {
+                return Poll::Ready(Err(Error::Disconnected.into()));
             }
-            Poll::Pending
-        })
-        .await
+            ChannelState::Connected => {
+                if storage.refcount != 0 {
+                    state.print(true);
+                    panic!("unexpected refcount");
+                }
+                assert_eq!(storage.refcount, 0);
+                state.inc_ref(idx);
+                return Poll::Ready(Ok(L2capChannel::new(idx, self)));
+            }
+            _ => {}
+        }
+        Poll::Pending
     }
 
     /// Dispatch an incoming L2CAP packet to the appropriate channel.
@@ -991,25 +1008,42 @@ mod tests {
 
     use std::boxed::Box;
 
+    use bt_hci::param::{AddrKind, BdAddr, LeConnRole};
+
     use super::*;
     use crate::mock_controller::MockController;
-    use crate::packet_pool::{PacketPool, Qos};
+    use crate::packet_pool::Qos;
+    use crate::BleHostResources;
 
     #[test]
     fn channel_refcount() {
-        let mut channels = [ChannelStorage::DISCONNECTED; 3];
-        let mut inbound = [PacketChannel::<1>::NEW; 3];
-        let pool: Box<PacketPool<NoopRawMutex, 27, 8, 8>> = Box::new(PacketPool::new(Qos::None));
-        let pool = Box::leak(pool);
+        let resources: Box<BleHostResources<2, 2, 27>> = Box::new(BleHostResources::new(Qos::None));
+        let resources = Box::leak(resources);
 
         let ble = MockController::new();
-        let mgr = ChannelManager::new(pool, &mut channels[..], &mut inbound[..]);
+        let ble = BleHost::new(ble, resources);
 
-        let conn = ConnHandle::new(0);
-        let psm = 0x1234;
-        let mtu = 64;
-        let credit_flow = 33;
-        let initial_credits = Some(1);
-        let create_fut = mgr.create(conn, psm, mtu, credit_flow, initial_credits, ble);
+        let conn = ConnHandle::new(33);
+        ble.connections
+            .connect(conn, AddrKind::PUBLIC, BdAddr::new([0; 6]), LeConnRole::Central)
+            .unwrap();
+        let idx = ble
+            .channels
+            .alloc(conn, |storage| {
+                storage.state = ChannelState::Connecting(42);
+            })
+            .unwrap();
+
+        let chan = ble.channels.poll_created(conn, idx, &ble, None);
+        assert!(matches!(chan, Poll::Pending));
+
+        ble.connections.disconnected(conn).unwrap();
+        ble.channels.disconnected(conn).unwrap();
+
+        let chan = ble.channels.poll_created(conn, idx, &ble, None);
+        assert!(matches!(
+            chan,
+            Poll::Ready(Err(BleHostError::BleHost(Error::Disconnected)))
+        ));
     }
 }

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -160,11 +160,9 @@ impl<'d> ConnectionManager<'d> {
     pub(crate) fn disconnected(&self, h: ConnHandle) -> Result<(), Error> {
         let mut state = self.state.borrow_mut();
         for (idx, storage) in state.connections.iter_mut().enumerate() {
-            if let Some(handle) = storage.handle {
-                if handle == h && storage.state != ConnectionState::Disconnected {
-                    storage.state = ConnectionState::Disconnected;
-                    return Ok(());
-                }
+            if Some(h) == storage.handle && storage.state != ConnectionState::Disconnected {
+                storage.state = ConnectionState::Disconnected;
+                return Ok(());
             }
         }
         trace!("[link][disconnect] connection handle {:?} not found", h);

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -34,6 +34,9 @@ pub mod connection;
 pub mod l2cap;
 pub mod scan;
 
+#[cfg(test)]
+pub(crate) mod mock_controller;
+
 pub(crate) mod host;
 pub use host::*;
 

--- a/host/src/mock_controller.rs
+++ b/host/src/mock_controller.rs
@@ -1,0 +1,81 @@
+use core::convert::Infallible;
+use core::future::Future;
+
+pub struct MockController {}
+
+impl MockController {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl embedded_io::ErrorType for MockController {
+    type Error = Infallible;
+}
+
+impl bt_hci::controller::blocking::Controller for MockController {
+    fn write_acl_data(&self, packet: &bt_hci::data::AclPacket) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn write_sync_data(&self, packet: &bt_hci::data::SyncPacket) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn write_iso_data(&self, packet: &bt_hci::data::IsoPacket) -> Result<(), Self::Error> {
+        todo!()
+    }
+
+    fn try_write_acl_data(
+        &self,
+        packet: &bt_hci::data::AclPacket,
+    ) -> Result<(), bt_hci::controller::blocking::TryError<Self::Error>> {
+        todo!()
+    }
+
+    fn try_write_sync_data(
+        &self,
+        packet: &bt_hci::data::SyncPacket,
+    ) -> Result<(), bt_hci::controller::blocking::TryError<Self::Error>> {
+        todo!()
+    }
+
+    fn try_write_iso_data(
+        &self,
+        packet: &bt_hci::data::IsoPacket,
+    ) -> Result<(), bt_hci::controller::blocking::TryError<Self::Error>> {
+        todo!()
+    }
+
+    fn read<'a>(&self, buf: &'a mut [u8]) -> Result<bt_hci::ControllerToHostPacket<'a>, Self::Error> {
+        todo!()
+    }
+
+    fn try_read<'a>(
+        &self,
+        buf: &'a mut [u8],
+    ) -> Result<bt_hci::ControllerToHostPacket<'a>, bt_hci::controller::blocking::TryError<Self::Error>> {
+        todo!()
+    }
+}
+
+impl bt_hci::controller::Controller for MockController {
+    fn write_acl_data(&self, packet: &bt_hci::data::AclPacket) -> impl Future<Output = Result<(), Self::Error>> {
+        async { todo!() }
+    }
+
+    fn write_sync_data(&self, packet: &bt_hci::data::SyncPacket) -> impl Future<Output = Result<(), Self::Error>> {
+        async { todo!() }
+    }
+
+    fn write_iso_data(&self, packet: &bt_hci::data::IsoPacket) -> impl Future<Output = Result<(), Self::Error>> {
+        async { todo!() }
+    }
+
+    fn read<'a>(
+        &self,
+        buf: &'a mut [u8],
+    ) -> impl Future<Output = Result<bt_hci::ControllerToHostPacket<'a>, Self::Error>> {
+        async { todo!() }
+    }
+}


### PR DESCRIPTION
 In the event of a disconnect during l2cap channel creation,
the channel creator may attempt to poll a l2cap channel that
has been marked as disconnected and allocated to another l2cap handle,
resulting in a panic from an invalid refcount
    
Add a unit test which reproduces and confirms the issue is fixed, using a mock controller.