### PR TITLE
Add attribute to lib.rs to make RustRover happy

### DIFF
--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -30,6 +30,7 @@ pub mod types;
 pub use packet_pool::Qos as PacketQos;
 
 pub mod advertise;
+pub mod attribute;
 pub mod connection;
 pub mod l2cap;
 pub mod scan;


### PR DESCRIPTION
Without this line RustRover IDE by JetBrains shows error:
```
Unresolved import: `trouble_host::attribute` [E0432]
```
Probably it's the linters issue, but it still would be nice to see green checkbox instead of errors of unresolved imports in the IDE. Can this be merged?