### PR TITLE
Split runner into tx, rx and control

### DIFF
--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -1199,6 +1199,7 @@ dependencies = [
  "log",
  "static_cell",
  "trouble-example-apps",
+ "trouble-host",
 ]
 
 [[package]]

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -24,6 +24,7 @@ esp-wifi = { version = "0.9.1", features = [
 ] }
 heapless = { version = "0.8.0", default-features = false }
 trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["log"] }
+trouble-host = { version = "0.1.0", path = "../../host", features = ["log"] }
 bt-hci = { version = "0.1.1" }
 embassy-futures = "0.1.1"
 embassy-time = { version = "0.3", features = ["generic-queue-8"] }

--- a/examples/esp32/src/bin/ble_bas_peripheral.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral.rs
@@ -3,15 +3,35 @@
 
 use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_time::{Duration, Timer};
 use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::prelude::*;
 use esp_hal::timer::timg::TimerGroup;
 use esp_wifi::ble::controller::asynch::BleConnector;
-use trouble_example_apps::ble_bas_peripheral;
+use esp_wifi::EspWifiInitialization;
+use log::{error, info};
+use static_cell::StaticCell;
+use trouble_host::prelude::*;
+
+/// Size of L2CAP packets (ATT MTU is this - 4)
+const L2CAP_MTU: usize = 251;
+
+/// Max number of connections
+const CONNECTIONS_MAX: usize = 1;
+
+/// Max number of L2CAP channels.
+const L2CAP_CHANNELS_MAX: usize = 2; // Signal + att
+
+const MAX_ATTRIBUTES: usize = 10;
+
+type Hci = ExternalController<BleConnector<'static>, 20>;
+type Resources = HostResources<Hci, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
 
 #[esp_hal_embassy::main]
-async fn main(_s: Spawner) {
+async fn main(s: Spawner) {
     esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init({
         let mut config = esp_hal::Config::default();
@@ -34,8 +54,136 @@ async fn main(_s: Spawner) {
     esp_hal_embassy::init(systimer.alarm0);
 
     let mut bluetooth = peripherals.BT;
-    let connector = BleConnector::new(&init, &mut bluetooth);
+    static INIT: StaticCell<EspWifiInitialization> = StaticCell::new();
+    static BLE: StaticCell<esp_hal::peripherals::BT> = StaticCell::new();
+    let init = INIT.init(init);
+    let bluetooth = BLE.init(bluetooth);
+    let connector = BleConnector::new(init, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
-    ble_bas_peripheral::run(controller).await;
+    let address = Address::random([0x41, 0x5A, 0xE3, 0x1E, 0x83, 0xE7]);
+    info!("Our address = {:?}", address);
+
+    static RESOURCES: StaticCell<Resources> = StaticCell::new();
+    let resources = RESOURCES.init(Resources::new(PacketQos::None));
+    let (stack, peripheral, _, runner) = trouble_host::new(controller, resources)
+        .set_random_address(address)
+        .build();
+
+    let mut table: AttributeTable<'_, NoopRawMutex, MAX_ATTRIBUTES> = AttributeTable::new();
+
+    // Generic Access Service (mandatory)
+    let id = b"Trouble";
+    let appearance = [0x80, 0x07];
+    static APPEARANCE: StaticCell<[u8; 2]> = StaticCell::new();
+    let appearance = APPEARANCE.init(appearance);
+    static BAT: StaticCell<[u8; 1]> = StaticCell::new();
+    let mut bat_level = [23; 1];
+    let bat_level = BAT.init(bat_level);
+    let mut svc = table.add_service(Service::new(0x1800));
+    let _ = svc.add_characteristic_ro(0x2a00, id);
+    let _ = svc.add_characteristic_ro(0x2a01, appearance);
+    svc.build();
+
+    // Generic attribute service (mandatory)
+    table.add_service(Service::new(0x1801));
+
+    // Battery service
+    let level_handle = table
+        .add_service(Service::new(0x180f))
+        .add_characteristic(
+            0x2a19,
+            &[CharacteristicProp::Read, CharacteristicProp::Notify],
+            bat_level,
+        )
+        .build();
+
+    static TABLE: StaticCell<AttributeTable<'static, NoopRawMutex, MAX_ATTRIBUTES>> = StaticCell::new();
+    let table = TABLE.init(table);
+    let server = GattServer::<Hci, NoopRawMutex, MAX_ATTRIBUTES, L2CAP_MTU>::new(stack, table);
+
+    info!("Starting advertising and GATT service");
+    let (ble_rx, ble_ctrl, ble_tx) = runner.split();
+    s.spawn(ble_rx_task(ble_rx)).unwrap();
+    s.spawn(ble_tx_task(ble_tx)).unwrap();
+    s.spawn(ble_ctrl_task(ble_ctrl)).unwrap();
+    let _ = join(
+        gatt_task(&server, &table),
+        advertise_task(peripheral, &server, level_handle),
+    )
+    .await;
+}
+
+#[embassy_executor::task]
+async fn ble_rx_task(mut runner: RxRunner<'static, Hci>) {
+    runner.run().await.unwrap();
+}
+
+#[embassy_executor::task]
+async fn ble_tx_task(mut runner: TxRunner<'static, Hci>) {
+    runner.run().await.unwrap();
+}
+
+#[embassy_executor::task]
+async fn ble_ctrl_task(mut runner: ControlRunner<'static, Hci>) {
+    runner.run().await.unwrap();
+}
+
+async fn gatt_task<C: Controller>(
+    server: &GattServer<'_, '_, C, NoopRawMutex, MAX_ATTRIBUTES, L2CAP_MTU>,
+    table: &AttributeTable<'_, NoopRawMutex, MAX_ATTRIBUTES>,
+) {
+    loop {
+        match server.next().await {
+            Ok(GattEvent::Write { handle, connection: _ }) => {
+                let _ = table.get(handle, |value| {
+                    info!("[gatt] Write event on {:?}. Value written: {:?}", handle, value);
+                });
+            }
+            Ok(GattEvent::Read { handle, connection: _ }) => {
+                info!("[gatt] Read event on {:?}", handle);
+            }
+            Err(e) => {
+                error!("[gatt] Error processing GATT events: {:?}", e);
+            }
+        }
+    }
+}
+
+async fn advertise_task<C: Controller>(
+    mut peripheral: Peripheral<'_, C>,
+    server: &GattServer<'_, '_, C, NoopRawMutex, MAX_ATTRIBUTES, L2CAP_MTU>,
+    handle: Characteristic,
+) -> Result<(), BleHostError<C::Error>> {
+    let mut adv_data = [0; 31];
+    AdStructure::encode_slice(
+        &[
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            AdStructure::ServiceUuids16(&[Uuid::Uuid16([0x0f, 0x18])]),
+            AdStructure::CompleteLocalName(b"Trouble"),
+        ],
+        &mut adv_data[..],
+    )?;
+    loop {
+        info!("[adv] advertising");
+        let mut advertiser = peripheral
+            .advertise(
+                &Default::default(),
+                Advertisement::ConnectableScannableUndirected {
+                    adv_data: &adv_data[..],
+                    scan_data: &[],
+                },
+            )
+            .await?;
+        let conn = advertiser.accept().await?;
+        info!("[adv] connection established");
+        // Keep connection alive
+        let mut tick: u8 = 0;
+        while conn.is_connected() {
+            Timer::after(Duration::from_secs(2)).await;
+            tick = tick.wrapping_add(1);
+            info!("[adv] notifying connection of tick {}", tick);
+            let _ = server.notify(handle, &conn, &[tick]).await;
+        }
+    }
 }

--- a/examples/esp32/src/bin/ble_bas_peripheral.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral.rs
@@ -53,7 +53,7 @@ async fn main(s: Spawner) {
         esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).split::<esp_hal::timer::systimer::Target>();
     esp_hal_embassy::init(systimer.alarm0);
 
-    let mut bluetooth = peripherals.BT;
+    let bluetooth = peripherals.BT;
     static INIT: StaticCell<EspWifiInitialization> = StaticCell::new();
     static BLE: StaticCell<esp_hal::peripherals::BT> = StaticCell::new();
     let init = INIT.init(init);
@@ -74,12 +74,7 @@ async fn main(s: Spawner) {
 
     // Generic Access Service (mandatory)
     let id = b"Trouble";
-    let appearance = [0x80, 0x07];
-    static APPEARANCE: StaticCell<[u8; 2]> = StaticCell::new();
-    let appearance = APPEARANCE.init(appearance);
-    static BAT: StaticCell<[u8; 1]> = StaticCell::new();
-    let mut bat_level = [23; 1];
-    let bat_level = BAT.init(bat_level);
+    let appearance = &[0x80, 0x07];
     let mut svc = table.add_service(Service::new(0x1800));
     let _ = svc.add_characteristic_ro(0x2a00, id);
     let _ = svc.add_characteristic_ro(0x2a01, appearance);
@@ -89,6 +84,9 @@ async fn main(s: Spawner) {
     table.add_service(Service::new(0x1801));
 
     // Battery service
+    static BAT: StaticCell<[u8; 1]> = StaticCell::new();
+    let bat_level = [23; 1];
+    let bat_level = BAT.init(bat_level);
     let level_handle = table
         .add_service(Service::new(0x180f))
         .add_characteristic(

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -78,7 +78,10 @@ pub mod prelude {
     #[cfg(feature = "peripheral")]
     pub use crate::scan::*;
 
+    pub use crate::host::ControlRunner;
     pub use crate::host::Runner;
+    pub use crate::host::RxRunner;
+    pub use crate::host::TxRunner;
 
     pub use super::BleHostError;
     pub use super::Error;


### PR DESCRIPTION
@peteskubiak Might be worth trying the esp32 example in this branch. I've made it possible to run the RX task in a separate embassy task, just to check if the connection timeout is due to not polling the HCI adapter frequently enough.