### PR TITLE
Split runner into tx, rx and control

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -18,7 +18,11 @@ cargo batch \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52832 \
     --- build --release --manifest-path examples/esp32/Cargo.toml --target riscv32imc-unknown-none-elf \
     --- build --release --manifest-path examples/serial-hci/Cargo.toml \
-    --- build --release --manifest-path host/Cargo.toml --features gatt,peripheral,central \
+    --- build --release --manifest-path host/Cargo.toml --features peripheral \
+    --- build --release --manifest-path host/Cargo.toml --features central \
+    --- build --release --manifest-path host/Cargo.toml --features gatt,peripheral \
+    --- build --release --manifest-path host/Cargo.toml --features gatt,central \
+    --- build --release --manifest-path host/Cargo.toml --features gatt,peripheral,central,scan \
     --- build --release --manifest-path examples/rp-pico-w//Cargo.toml --target thumbv6m-none-eabi --features skip-cyw43-firmware
 #    --- build --release --manifest-path examples/apache-nimble/Cargo.toml --target thumbv7em-none-eabihf
 

--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -1199,6 +1199,7 @@ dependencies = [
  "log",
  "static_cell",
  "trouble-example-apps",
+ "trouble-host",
 ]
 
 [[package]]

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -24,6 +24,7 @@ esp-wifi = { version = "0.9.1", features = [
 ] }
 heapless = { version = "0.8.0", default-features = false }
 trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["log"] }
+trouble-host = { version = "0.1.0", path = "../../host", features = ["log"] }
 bt-hci = { version = "0.1.1" }
 embassy-futures = "0.1.1"
 embassy-time = { version = "0.3", features = ["generic-queue-8"] }

--- a/examples/esp32/src/bin/ble_bas_peripheral.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral.rs
@@ -33,8 +33,8 @@ async fn main(_s: Spawner) {
         esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER).split::<esp_hal::timer::systimer::Target>();
     esp_hal_embassy::init(systimer.alarm0);
 
-    let mut bluetooth = peripherals.BT;
-    let connector = BleConnector::new(&init, &mut bluetooth);
+    let bluetooth = peripherals.BT;
+    let connector = BleConnector::new(&init, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
     ble_bas_peripheral::run(controller).await;

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -78,7 +78,7 @@ impl<'d, C: Controller> Central<'d, C> {
     }
 
     /// Attempt to create a connection with the provided config.
-    pub async fn connect_ext(&mut self, config: &ConnectConfig<'_>) -> Result<Connection<'_>, BleHostError<C::Error>>
+    pub async fn connect_ext(&mut self, config: &ConnectConfig<'_>) -> Result<Connection<'d>, BleHostError<C::Error>>
     where
         C: ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -1,4 +1,6 @@
 //! Functionality for the BLE central role.
+#[cfg(feature = "scan")]
+use bt_hci::cmd::le::LeSetScanParams;
 use bt_hci::cmd::le::{
     LeAddDeviceToFilterAcceptList, LeClearFilterAcceptList, LeCreateConn, LeExtCreateConn, LeSetExtScanEnable,
     LeSetExtScanParams, LeSetScanEnable,
@@ -10,18 +12,19 @@ use bt_hci::param::{ConnHandleCompletedPackets, ControllerToHostFlowControl};
 use embassy_futures::select::{select, Either};
 
 use crate::connection::{ConnectConfig, Connection};
-use crate::host::BleHost;
+#[cfg(feature = "scan")]
+use crate::scan::ScanReport;
 use crate::scan::{PhySet, ScanConfig};
-use crate::{BleHostError, Error};
+use crate::{BleHostError, Error, Stack};
 
 /// A type implementing the BLE central role.
 pub struct Central<'d, C: Controller> {
-    host: &'d BleHost<'d, C>,
+    stack: Stack<'d, C>,
 }
 
 impl<'d, C: Controller> Central<'d, C> {
-    pub(crate) fn new(host: &'d BleHost<'d, C>) -> Self {
-        Self { host }
+    pub(crate) fn new(stack: Stack<'d, C>) -> Self {
+        Self { stack }
     }
 
     /// Attempt to create a connection with the provided config.
@@ -35,40 +38,39 @@ impl<'d, C: Controller> Central<'d, C> {
             return Err(Error::InvalidValue.into());
         }
 
+        let host = self.stack.host;
         let _drop = crate::host::OnDrop::new(|| {
-            self.host.connect_command_state.cancel(true);
+            host.connect_command_state.cancel(true);
         });
-        self.host.connect_command_state.request().await;
+        host.connect_command_state.request().await;
 
         self.set_accept_filter(config.scan_config.filter_accept_list).await?;
 
-        self.host
-            .async_command(LeCreateConn::new(
-                config.scan_config.interval.into(),
-                config.scan_config.window.into(),
-                true,
-                AddrKind::PUBLIC,
-                BdAddr::default(),
-                self.host.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC),
-                config.connect_params.min_connection_interval.into(),
-                config.connect_params.max_connection_interval.into(),
-                config.connect_params.max_latency,
-                config.connect_params.supervision_timeout.into(),
-                config.connect_params.event_length.into(),
-                config.connect_params.event_length.into(),
-            ))
-            .await?;
+        host.async_command(LeCreateConn::new(
+            config.scan_config.interval.into(),
+            config.scan_config.window.into(),
+            true,
+            AddrKind::PUBLIC,
+            BdAddr::default(),
+            host.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC),
+            config.connect_params.min_connection_interval.into(),
+            config.connect_params.max_connection_interval.into(),
+            config.connect_params.max_latency,
+            config.connect_params.supervision_timeout.into(),
+            config.connect_params.event_length.into(),
+            config.connect_params.event_length.into(),
+        ))
+        .await?;
         match select(
-            self.host
-                .connections
+            host.connections
                 .accept(LeConnRole::Central, config.scan_config.filter_accept_list),
-            self.host.connect_command_state.wait_idle(),
+            host.connect_command_state.wait_idle(),
         )
         .await
         {
             Either::First(conn) => {
                 _drop.defuse();
-                self.host.connect_command_state.done();
+                host.connect_command_state.done();
                 Ok(conn)
             }
             Either::Second(_) => Err(Error::Timeout.into()),
@@ -88,11 +90,12 @@ impl<'d, C: Controller> Central<'d, C> {
             return Err(Error::InvalidValue.into());
         }
 
+        let host = self.stack.host;
         // Ensure no other connect ongoing.
         let _drop = crate::host::OnDrop::new(|| {
-            self.host.connect_command_state.cancel(true);
+            host.connect_command_state.cancel(true);
         });
-        self.host.connect_command_state.request().await;
+        host.connect_command_state.request().await;
 
         self.set_accept_filter(config.scan_config.filter_accept_list).await?;
 
@@ -108,27 +111,25 @@ impl<'d, C: Controller> Central<'d, C> {
         };
         let phy_params = Self::create_phy_params(initiating, config.scan_config.phys);
 
-        self.host
-            .async_command(LeExtCreateConn::new(
-                true,
-                self.host.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC),
-                AddrKind::PUBLIC,
-                BdAddr::default(),
-                phy_params,
-            ))
-            .await?;
+        host.async_command(LeExtCreateConn::new(
+            true,
+            host.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC),
+            AddrKind::PUBLIC,
+            BdAddr::default(),
+            phy_params,
+        ))
+        .await?;
 
         match select(
-            self.host
-                .connections
+            host.connections
                 .accept(LeConnRole::Central, config.scan_config.filter_accept_list),
-            self.host.connect_command_state.wait_idle(),
+            host.connect_command_state.wait_idle(),
         )
         .await
         {
             Either::First(conn) => {
                 _drop.defuse();
-                self.host.connect_command_state.done();
+                host.connect_command_state.done();
                 Ok(conn)
             }
             Either::Second(_) => Err(Error::Timeout.into()),
@@ -160,10 +161,10 @@ impl<'d, C: Controller> Central<'d, C> {
     where
         C: ControllerCmdSync<LeClearFilterAcceptList> + ControllerCmdSync<LeAddDeviceToFilterAcceptList>,
     {
-        self.host.command(LeClearFilterAcceptList::new()).await?;
+        let host = self.stack.host;
+        host.command(LeClearFilterAcceptList::new()).await?;
         for entry in filter_accept_list {
-            self.host
-                .command(LeAddDeviceToFilterAcceptList::new(entry.0, *entry.1))
+            host.command(LeAddDeviceToFilterAcceptList::new(entry.0, *entry.1))
                 .await?;
         }
         Ok(())
@@ -177,6 +178,7 @@ impl<'d, C: Controller> Central<'d, C> {
             + ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>,
     {
+        let host = self.stack.host;
         self.set_accept_filter(config.filter_accept_list).await?;
 
         let params = LeSetScanParams::new(
@@ -194,8 +196,8 @@ impl<'d, C: Controller> Central<'d, C> {
                 bt_hci::param::ScanningFilterPolicy::BasicFiltered
             },
         );
-        self.host.command(params).await?;
-        self.host.command(LeSetScanEnable::new(true, true)).await?;
+        host.command(params).await?;
+        host.command(LeSetScanEnable::new(true, true)).await?;
         Ok(())
     }
 
@@ -214,25 +216,24 @@ impl<'d, C: Controller> Central<'d, C> {
             scan_window: config.window.into(),
         };
         let phy_params = Self::create_phy_params(scanning, config.phys);
-        self.host
-            .command(LeSetExtScanParams::new(
-                self.host.address.map(|s| s.kind).unwrap_or(AddrKind::PUBLIC),
-                if config.filter_accept_list.is_empty() {
-                    bt_hci::param::ScanningFilterPolicy::BasicUnfiltered
-                } else {
-                    bt_hci::param::ScanningFilterPolicy::BasicFiltered
-                },
-                phy_params,
-            ))
-            .await?;
-        self.host
-            .command(LeSetExtScanEnable::new(
-                true,
-                FilterDuplicates::Disabled,
-                config.timeout.into(),
-                bt_hci::param::Duration::from_secs(0),
-            ))
-            .await?;
+        let host = self.stack.host;
+        host.command(LeSetExtScanParams::new(
+            host.address.map(|s| s.kind).unwrap_or(AddrKind::PUBLIC),
+            if config.filter_accept_list.is_empty() {
+                bt_hci::param::ScanningFilterPolicy::BasicUnfiltered
+            } else {
+                bt_hci::param::ScanningFilterPolicy::BasicFiltered
+            },
+            phy_params,
+        ))
+        .await?;
+        host.command(LeSetExtScanEnable::new(
+            true,
+            FilterDuplicates::Disabled,
+            config.timeout.into(),
+            bt_hci::param::Duration::from_secs(0),
+        ))
+        .await?;
         Ok(())
     }
 
@@ -240,7 +241,8 @@ impl<'d, C: Controller> Central<'d, C> {
     where
         C: ControllerCmdSync<LeSetScanEnable>,
     {
-        self.host.command(LeSetScanEnable::new(false, false)).await?;
+        let host = self.stack.host;
+        host.command(LeSetScanEnable::new(false, false)).await?;
         Ok(())
     }
 
@@ -248,14 +250,14 @@ impl<'d, C: Controller> Central<'d, C> {
     where
         C: ControllerCmdSync<LeSetExtScanEnable>,
     {
-        self.host
-            .command(LeSetExtScanEnable::new(
-                false,
-                FilterDuplicates::Disabled,
-                bt_hci::param::Duration::from_secs(0),
-                bt_hci::param::Duration::from_secs(0),
-            ))
-            .await?;
+        let host = self.stack.host;
+        host.command(LeSetExtScanEnable::new(
+            false,
+            FilterDuplicates::Disabled,
+            bt_hci::param::Duration::from_secs(0),
+            bt_hci::param::Duration::from_secs(0),
+        ))
+        .await?;
         Ok(())
     }
 
@@ -270,8 +272,9 @@ impl<'d, C: Controller> Central<'d, C> {
             + ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>,
     {
+        let host = self.stack.host;
         self.start_scan_ext(config).await?;
-        let Some(report) = self.scanner.receive().await else {
+        let Some(report) = host.scanner.receive().await else {
             return Err(Error::Timeout.into());
         };
         self.stop_scan_ext().await?;
@@ -289,8 +292,9 @@ impl<'d, C: Controller> Central<'d, C> {
             + ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>,
     {
+        let host = self.stack.host;
         self.start_scan(config).await?;
-        let Some(report) = self.scanner.receive().await else {
+        let Some(report) = host.scanner.receive().await else {
             return Err(Error::Timeout.into());
         };
         self.stop_scan().await?;

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -7,8 +7,7 @@ use embassy_time::Duration;
 
 use crate::connection_manager::DynamicConnectionManager;
 use crate::scan::ScanConfig;
-use crate::BleHostError;
-use crate::Stack;
+use crate::{BleHostError, Stack};
 
 /// Connection configuration.
 pub struct ConnectConfig<'d> {

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -100,7 +100,7 @@ impl<'d> Connection<'d> {
     }
 
     /// The RSSI value for this connection.
-    pub async fn rssi<T>(&self, stack: &Stack<'_, T>) -> Result<i8, BleHostError<T::Error>>
+    pub async fn rssi<T>(&self, stack: Stack<'_, T>) -> Result<i8, BleHostError<T::Error>>
     where
         T: ControllerCmdSync<ReadRssi>,
     {
@@ -112,7 +112,7 @@ impl<'d> Connection<'d> {
     /// Update connection parameters for this connection.
     pub async fn update_connection_params<T>(
         &self,
-        stack: &Stack<'_, T>,
+        stack: Stack<'_, T>,
         params: ConnectParams,
     ) -> Result<(), BleHostError<T::Error>>
     where

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -10,10 +10,9 @@ use embassy_sync::pubsub::{self, PubSubChannel, WaitResult};
 use heapless::Vec;
 
 use crate::att::{self, AttReq, AttRsp, ATT_HANDLE_VALUE_NTF};
-use crate::attribute::AttributeTable;
 use crate::attribute::{
-    AttributeData, Characteristic, CharacteristicProp, Uuid, CCCD, CHARACTERISTIC_CCCD_UUID16, CHARACTERISTIC_UUID16,
-    PRIMARY_SERVICE_UUID16,
+    AttributeData, AttributeTable, Characteristic, CharacteristicProp, Uuid, CCCD, CHARACTERISTIC_CCCD_UUID16,
+    CHARACTERISTIC_UUID16, PRIMARY_SERVICE_UUID16,
 };
 use crate::attribute_server::AttributeServer;
 use crate::connection::Connection;
@@ -21,8 +20,7 @@ use crate::connection_manager::DynamicConnectionManager;
 use crate::cursor::{ReadCursor, WriteCursor};
 use crate::pdu::Pdu;
 use crate::types::l2cap::L2capHeader;
-use crate::{config, Stack};
-use crate::{BleHostError, Error};
+use crate::{config, BleHostError, Error, Stack};
 
 /// A GATT server capable of processing the GATT protocol using the provided table of attributes.
 pub struct GattServer<'reference, 'values, C: Controller, M: RawMutex, const MAX: usize, const L2CAP_MTU: usize> {

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -169,8 +169,11 @@ impl<'d> AdvState<'d> {
 /// Host metrics
 #[derive(Default, Clone)]
 pub struct HostMetrics {
+    /// How many connect events have been received.
     pub connect_events: u32,
+    /// How many disconnect events have been received.
     pub disconnect_events: u32,
+    /// How many errors processing received data.
     pub rx_errors: u32,
 }
 

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -420,13 +420,13 @@ where
     }
 
     /// Read current host metrics
-    pub fn metrics(&self) -> HostMetrics {
+    pub(crate) fn metrics(&self) -> HostMetrics {
         let m = self.metrics.borrow_mut().clone();
         m
     }
 
     /// Log status information of the host
-    pub fn log_status(&self, verbose: bool) {
+    pub(crate) fn log_status(&self, verbose: bool) {
         let m = self.metrics.borrow();
         debug!("[host] connect events: {}", m.connect_events);
         debug!("[host] disconnect events: {}", m.disconnect_events);

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -39,10 +39,12 @@ use crate::cursor::WriteCursor;
 use crate::l2cap::sar::{PacketReassembly, SarType};
 use crate::packet_pool::{AllocId, GlobalPacketPool};
 use crate::pdu::Pdu;
+#[cfg(feature = "scan")]
+use crate::scan::ScanReport;
 use crate::types::l2cap::{
     L2capHeader, L2capSignal, L2capSignalHeader, L2CAP_CID_ATT, L2CAP_CID_DYN_START, L2CAP_CID_LE_U_SIGNAL,
 };
-use crate::{att, config, Address, BleHostError, Error};
+use crate::{att, config, Address, BleHostError, Error, Stack};
 
 /// A BLE Host.
 ///
@@ -392,307 +394,6 @@ where
         Ok(())
     }
 
-    pub(crate) async fn run_with_handler<F: Fn(&Vendor)>(&self, vendor_handler: F) -> Result<(), BleHostError<T::Error>>
-    where
-        T: ControllerCmdSync<Disconnect>
-            + ControllerCmdSync<SetEventMask>
-            + ControllerCmdSync<LeSetEventMask>
-            + ControllerCmdSync<LeSetRandomAddr>
-            + ControllerCmdSync<LeReadFilterAcceptListSize>
-            + ControllerCmdSync<HostBufferSize>
-            + ControllerCmdAsync<LeConnUpdate>
-            + ControllerCmdSync<SetControllerToHostFlowControl>
-            + for<'t> ControllerCmdSync<LeSetAdvEnable>
-            + for<'t> ControllerCmdSync<LeSetExtAdvEnable<'t>>
-            + for<'t> ControllerCmdSync<HostNumberOfCompletedPackets<'t>>
-            + ControllerCmdSync<Reset>
-            + ControllerCmdSync<LeCreateConnCancel>
-            + ControllerCmdSync<LeReadBufferSize>,
-    {
-        const MAX_HCI_PACKET_LEN: usize = 259;
-
-        // Control future that initializes system and handles controller changes.
-        let control_fut = async {
-            Reset::new().exec(&self.controller).await?;
-
-            if let Some(addr) = self.address {
-                LeSetRandomAddr::new(addr.addr).exec(&self.controller).await?;
-            }
-
-            SetEventMask::new(
-                EventMask::new()
-                    .enable_le_meta(true)
-                    .enable_conn_request(true)
-                    .enable_conn_complete(true)
-                    .enable_hardware_error(true)
-                    .enable_disconnection_complete(true),
-            )
-            .exec(&self.controller)
-            .await?;
-
-            LeSetEventMask::new(
-                LeEventMask::new()
-                    .enable_le_conn_complete(true)
-                    .enable_le_enhanced_conn_complete(true)
-                    .enable_le_adv_set_terminated(true)
-                    .enable_le_adv_report(true)
-                    .enable_le_scan_timeout(true)
-                    .enable_le_ext_adv_report(true),
-            )
-            .exec(&self.controller)
-            .await?;
-
-            let ret = LeReadFilterAcceptListSize::new().exec(&self.controller).await?;
-            info!("[host] filter accept list size: {}", ret);
-
-            let ret = LeReadBufferSize::new().exec(&self.controller).await?;
-            info!("[host] setting txq to {}", ret.total_num_le_acl_data_packets as usize);
-            self.connections
-                .set_link_credits(ret.total_num_le_acl_data_packets as usize);
-
-            info!(
-                "[host] configuring host buffers ({} packets of size {})",
-                config::L2CAP_RX_PACKET_POOL_SIZE,
-                self.rx_pool.mtu()
-            );
-            HostBufferSize::new(
-                self.rx_pool.mtu() as u16,
-                0,
-                config::L2CAP_RX_PACKET_POOL_SIZE as u16,
-                0,
-            )
-            .exec(&self.controller)
-            .await?;
-
-            #[cfg(feature = "controller-host-flow-control")]
-            {
-                info!("[host] enabling flow control");
-                SetControllerToHostFlowControl::new(ControllerToHostFlowControl::AclOnSyncOff)
-                    .exec(&self.controller)
-                    .await?;
-            }
-
-            let _ = self.initialized.init(());
-            info!("[host] initialized");
-
-            loop {
-                match select4(
-                    poll_fn(|cx| self.connections.poll_disconnecting(Some(cx))),
-                    poll_fn(|cx| self.channels.poll_disconnecting(Some(cx))),
-                    poll_fn(|cx| self.connect_command_state.poll_cancelled(cx)),
-                    poll_fn(|cx| self.advertise_command_state.poll_cancelled(cx)),
-                )
-                .await
-                {
-                    Either4::First(request) => {
-                        self.command(Disconnect::new(request.handle(), request.reason()))
-                            .await?;
-                        request.confirm();
-                    }
-                    Either4::Second(request) => {
-                        let mut grant = self.acl(request.handle(), 1).await?;
-                        request.send(&mut grant).await?;
-                        request.confirm();
-                    }
-                    Either4::Third(_) => {
-                        // trace!("[host] cancelling create connection");
-                        if self.command(LeCreateConnCancel::new()).await.is_err() {
-                            // Signal to ensure no one is stuck
-                            self.connect_command_state.canceled();
-                        }
-                    }
-                    Either4::Fourth(ext) => {
-                        trace!("[host] disabling advertising");
-                        if ext {
-                            self.command(LeSetExtAdvEnable::new(false, &[])).await?
-                        } else {
-                            self.command(LeSetAdvEnable::new(false)).await?
-                        }
-                        self.advertise_command_state.canceled();
-                    }
-                }
-            }
-        };
-        pin_mut!(control_fut);
-
-        let tx_fut = async {
-            loop {
-                let (conn, pdu) = self.outbound.receive().await;
-                match self.acl(conn, 1).await {
-                    Ok(mut sender) => {
-                        if let Err(e) = sender.send(pdu.as_ref()).await {
-                            warn!("[host] error sending outbound pdu");
-                            return Err(e);
-                        }
-                    }
-                    Err(e) => {
-                        warn!("[host] error requesting sending outbound pdu");
-                        return Err(e);
-                    }
-                }
-            }
-        };
-        pin_mut!(tx_fut);
-
-        let rx_fut = async {
-            loop {
-                // Task handling receiving data from the controller.
-                let mut rx = [0u8; MAX_HCI_PACKET_LEN];
-                let result = self.controller.read(&mut rx).await;
-                match result {
-                    Ok(ControllerToHostPacket::Acl(acl)) => match self.handle_acl(acl) {
-                        Ok(_) => {
-                            #[cfg(feature = "controller-host-flow-control")]
-                            if let Err(e) =
-                                HostNumberOfCompletedPackets::new(&[ConnHandleCompletedPackets::new(acl.handle(), 1)])
-                                    .exec(&self.controller)
-                                    .await
-                            {
-                                // Only serious error if it's supposed to be connected
-                                if self.connections.get_connected_handle(acl.handle()).is_some() {
-                                    error!("[host] error performing flow control on {:?}", acl.handle());
-                                    return Err(e.into());
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            #[cfg(feature = "controller-host-flow-control")]
-                            if let Err(e) =
-                                HostNumberOfCompletedPackets::new(&[ConnHandleCompletedPackets::new(acl.handle(), 1)])
-                                    .exec(&self.controller)
-                                    .await
-                            {
-                                // Only serious error if it's supposed to be connected
-                                if self.connections.get_connected_handle(acl.handle()).is_some() {
-                                    error!("[host] error performing flow control on {:?}", acl.handle());
-                                    return Err(e.into());
-                                }
-                            }
-
-                            warn!(
-                                "[host] encountered error processing ACL data for {:?}: {:?}",
-                                acl.handle(),
-                                e
-                            );
-
-                            if let Error::Disconnected = e {
-                                warn!("[host] requesting {:?} to be disconnected", acl.handle());
-                                let _ = self
-                                    .command(Disconnect::new(
-                                        acl.handle(),
-                                        DisconnectReason::RemoteUserTerminatedConn,
-                                    ))
-                                    .await;
-                                self.connections.log_status(true);
-                            }
-
-                            let mut m = self.metrics.borrow_mut();
-                            m.rx_errors = m.rx_errors.wrapping_add(1);
-                        }
-                    },
-                    Ok(ControllerToHostPacket::Event(event)) => match event {
-                        Event::Le(event) => match event {
-                            LeEvent::LeConnectionComplete(e) => {
-                                if !self.handle_connection(e.status, e.handle, e.peer_addr_kind, e.peer_addr, e.role) {
-                                    let _ = self
-                                        .command(Disconnect::new(
-                                            e.handle,
-                                            DisconnectReason::RemoteDeviceTerminatedConnLowResources,
-                                        ))
-                                        .await;
-                                    self.connect_command_state.canceled();
-                                }
-                            }
-                            LeEvent::LeEnhancedConnectionComplete(e) => {
-                                if !self.handle_connection(e.status, e.handle, e.peer_addr_kind, e.peer_addr, e.role) {
-                                    let _ = self
-                                        .command(Disconnect::new(
-                                            e.handle,
-                                            DisconnectReason::RemoteDeviceTerminatedConnLowResources,
-                                        ))
-                                        .await;
-                                    self.connect_command_state.canceled();
-                                }
-                            }
-                            LeEvent::LeScanTimeout(_) => {
-                                #[cfg(feature = "scan")]
-                                let _ = self.scanner.try_send(None);
-                            }
-                            LeEvent::LeAdvertisingSetTerminated(set) => {
-                                self.advertise_state.terminate(set.adv_handle);
-                            }
-                            LeEvent::LeExtendedAdvertisingReport(data) => {
-                                #[cfg(feature = "scan")]
-                                let _ = self
-                                    .scanner
-                                    .try_send(Some(ScanReport::new(data.reports.num_reports, &data.reports.bytes)));
-                            }
-                            LeEvent::LeAdvertisingReport(data) => {
-                                #[cfg(feature = "scan")]
-                                let _ = self
-                                    .scanner
-                                    .try_send(Some(ScanReport::new(data.reports.num_reports, &data.reports.bytes)));
-                            }
-                            _ => {
-                                warn!("Unknown LE event!");
-                            }
-                        },
-                        Event::DisconnectionComplete(e) => {
-                            let handle = e.handle;
-                            if let Err(e) = e.status.to_result() {
-                                info!("[host] disconnection event on handle {}, status: {:?}", handle.raw(), e);
-                            } else if let Err(e) = e.reason.to_result() {
-                                info!("[host] disconnection event on handle {}, reason: {:?}", handle.raw(), e);
-                            } else {
-                                info!("[host] disconnection event on handle {}", handle.raw());
-                            }
-                            let _ = self.connections.disconnected(handle);
-                            let _ = self.channels.disconnected(handle);
-                            self.reassembly.disconnected(handle);
-                            let mut m = self.metrics.borrow_mut();
-                            m.disconnect_events = m.disconnect_events.wrapping_add(1);
-                        }
-                        Event::NumberOfCompletedPackets(c) => {
-                            // Explicitly ignoring for now
-                            for entry in c.completed_packets.iter() {
-                                if let (Ok(handle), Ok(completed)) = (entry.handle(), entry.num_completed_packets()) {
-                                    let _ = self.connections.confirm_sent(handle, completed as usize);
-                                }
-                            }
-                        }
-                        Event::Vendor(vendor) => {
-                            vendor_handler(&vendor);
-                        }
-                        // Ignore
-                        _ => {}
-                    },
-                    // Ignore
-                    Ok(_) => {}
-                    Err(e) => {
-                        return Err(BleHostError::Controller(e));
-                    }
-                }
-            }
-        };
-        pin_mut!(rx_fut);
-
-        // info!("Entering select loop");
-        match select3(&mut control_fut, &mut rx_fut, &mut tx_fut).await {
-            Either3::First(result) => {
-                trace!("[host] control_fut exit");
-                result
-            }
-            Either3::Second(result) => {
-                trace!("[host] rx_fut exit");
-                result
-            }
-            Either3::Third(result) => {
-                trace!("[host] tx_fut exit");
-                result
-            }
-        }
-    }
-
     // Request to send n ACL packets to the HCI controller for a connection
     pub(crate) async fn acl(&self, handle: ConnHandle, n: u16) -> Result<AclSender<'_, 'd, T>, BleHostError<T::Error>> {
         let grant = poll_fn(|cx| self.connections.poll_request_to_send(handle, n as usize, Some(cx))).await?;
@@ -737,12 +438,38 @@ where
 
 /// Runs the host with the given controller.
 pub struct Runner<'d, C: Controller> {
-    host: &'d BleHost<'d, C>,
+    rx: RxRunner<'d, C>,
+    control: ControlRunner<'d, C>,
+    tx: TxRunner<'d, C>,
+}
+
+/// The receiver part of the host runner.
+pub struct RxRunner<'d, C: Controller> {
+    stack: Stack<'d, C>,
+}
+
+/// The control part of the host runner.
+pub struct ControlRunner<'d, C: Controller> {
+    stack: Stack<'d, C>,
+}
+
+/// The transmit part of the host runner.
+pub struct TxRunner<'d, C: Controller> {
+    stack: Stack<'d, C>,
 }
 
 impl<'d, C: Controller> Runner<'d, C> {
-    pub(crate) fn new(host: &'d BleHost<'d, C>) -> Self {
-        Self { host }
+    pub(crate) fn new(stack: Stack<'d, C>) -> Self {
+        Self {
+            rx: RxRunner { stack },
+            control: ControlRunner { stack },
+            tx: TxRunner { stack },
+        }
+    }
+
+    /// Split the runner into separate independent async tasks
+    pub fn split(self) -> (RxRunner<'d, C>, ControlRunner<'d, C>, TxRunner<'d, C>) {
+        (self.rx, self.control, self.tx)
     }
 
     /// Run the host.
@@ -763,7 +490,7 @@ impl<'d, C: Controller> Runner<'d, C> {
             + for<'t> ControllerCmdSync<HostNumberOfCompletedPackets<'t>>
             + ControllerCmdSync<LeReadBufferSize>,
     {
-        self.host.run_with_handler(|_| {}).await
+        self.run_with_handler(|_| {}).await
     }
 
     /// Run the host with a vendor event handler for custom events.
@@ -784,7 +511,326 @@ impl<'d, C: Controller> Runner<'d, C> {
             + ControllerCmdSync<LeCreateConnCancel>
             + ControllerCmdSync<LeReadBufferSize>,
     {
-        self.host.run_with_handler(vendor_handler).await
+        let control_fut = self.control.run();
+        let rx_fut = self.rx.run_with_handler(vendor_handler);
+        let tx_fut = self.tx.run();
+        pin_mut!(control_fut, rx_fut, tx_fut);
+        match select3(&mut control_fut, &mut rx_fut, &mut tx_fut).await {
+            Either3::First(result) => {
+                trace!("[host] control_fut exit");
+                result
+            }
+            Either3::Second(result) => {
+                trace!("[host] rx_fut exit");
+                result
+            }
+            Either3::Third(result) => {
+                trace!("[host] tx_fut exit");
+                result
+            }
+        }
+    }
+}
+
+impl<'d, C: Controller> RxRunner<'d, C> {
+    /// Run the receive loop that polls the controller for events.
+    pub async fn run(&mut self) -> Result<(), BleHostError<C::Error>>
+    where
+        C: ControllerCmdSync<Disconnect> + for<'t> ControllerCmdSync<HostNumberOfCompletedPackets<'t>>,
+    {
+        self.run_with_handler(|_| {}).await
+    }
+
+    /// Runs the receive loop that pools the controller for events, dispatching
+    /// vendor events to the provided closure.
+    pub async fn run_with_handler<F: Fn(&Vendor)>(&mut self, vendor_handler: F) -> Result<(), BleHostError<C::Error>>
+    where
+        C: ControllerCmdSync<Disconnect> + for<'t> ControllerCmdSync<HostNumberOfCompletedPackets<'t>>,
+    {
+        const MAX_HCI_PACKET_LEN: usize = 259;
+        let host = self.stack.host;
+        loop {
+            // Task handling receiving data from the controller.
+            let mut rx = [0u8; MAX_HCI_PACKET_LEN];
+            let result = host.controller.read(&mut rx).await;
+            match result {
+                Ok(ControllerToHostPacket::Acl(acl)) => match host.handle_acl(acl) {
+                    Ok(_) => {
+                        #[cfg(feature = "controller-host-flow-control")]
+                        if let Err(e) =
+                            HostNumberOfCompletedPackets::new(&[ConnHandleCompletedPackets::new(acl.handle(), 1)])
+                                .exec(&host.controller)
+                                .await
+                        {
+                            // Only serious error if it's supposed to be connected
+                            if host.connections.get_connected_handle(acl.handle()).is_some() {
+                                error!("[host] error performing flow control on {:?}", acl.handle());
+                                return Err(e.into());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        #[cfg(feature = "controller-host-flow-control")]
+                        if let Err(e) =
+                            HostNumberOfCompletedPackets::new(&[ConnHandleCompletedPackets::new(acl.handle(), 1)])
+                                .exec(&host.controller)
+                                .await
+                        {
+                            // Only serious error if it's supposed to be connected
+                            if host.connections.get_connected_handle(acl.handle()).is_some() {
+                                error!("[host] error performing flow control on {:?}", acl.handle());
+                                return Err(e.into());
+                            }
+                        }
+
+                        warn!(
+                            "[host] encountered error processing ACL data for {:?}: {:?}",
+                            acl.handle(),
+                            e
+                        );
+
+                        if let Error::Disconnected = e {
+                            warn!("[host] requesting {:?} to be disconnected", acl.handle());
+                            let _ = host
+                                .command(Disconnect::new(
+                                    acl.handle(),
+                                    DisconnectReason::RemoteUserTerminatedConn,
+                                ))
+                                .await;
+                            host.connections.log_status(true);
+                        }
+
+                        let mut m = host.metrics.borrow_mut();
+                        m.rx_errors = m.rx_errors.wrapping_add(1);
+                    }
+                },
+                Ok(ControllerToHostPacket::Event(event)) => match event {
+                    Event::Le(event) => match event {
+                        LeEvent::LeConnectionComplete(e) => {
+                            if !host.handle_connection(e.status, e.handle, e.peer_addr_kind, e.peer_addr, e.role) {
+                                let _ = host
+                                    .command(Disconnect::new(
+                                        e.handle,
+                                        DisconnectReason::RemoteDeviceTerminatedConnLowResources,
+                                    ))
+                                    .await;
+                                host.connect_command_state.canceled();
+                            }
+                        }
+                        LeEvent::LeEnhancedConnectionComplete(e) => {
+                            if !host.handle_connection(e.status, e.handle, e.peer_addr_kind, e.peer_addr, e.role) {
+                                let _ = host
+                                    .command(Disconnect::new(
+                                        e.handle,
+                                        DisconnectReason::RemoteDeviceTerminatedConnLowResources,
+                                    ))
+                                    .await;
+                                host.connect_command_state.canceled();
+                            }
+                        }
+                        LeEvent::LeScanTimeout(_) => {
+                            #[cfg(feature = "scan")]
+                            let _ = host.scanner.try_send(None);
+                        }
+                        LeEvent::LeAdvertisingSetTerminated(set) => {
+                            host.advertise_state.terminate(set.adv_handle);
+                        }
+                        LeEvent::LeExtendedAdvertisingReport(data) => {
+                            #[cfg(feature = "scan")]
+                            let _ = host
+                                .scanner
+                                .try_send(Some(ScanReport::new(data.reports.num_reports, &data.reports.bytes)));
+                        }
+                        LeEvent::LeAdvertisingReport(data) => {
+                            #[cfg(feature = "scan")]
+                            let _ = host
+                                .scanner
+                                .try_send(Some(ScanReport::new(data.reports.num_reports, &data.reports.bytes)));
+                        }
+                        _ => {
+                            warn!("Unknown LE event!");
+                        }
+                    },
+                    Event::DisconnectionComplete(e) => {
+                        let handle = e.handle;
+                        if let Err(e) = e.status.to_result() {
+                            info!("[host] disconnection event on handle {}, status: {:?}", handle.raw(), e);
+                        } else if let Err(e) = e.reason.to_result() {
+                            info!("[host] disconnection event on handle {}, reason: {:?}", handle.raw(), e);
+                        } else {
+                            info!("[host] disconnection event on handle {}", handle.raw());
+                        }
+                        let _ = host.connections.disconnected(handle);
+                        let _ = host.channels.disconnected(handle);
+                        host.reassembly.disconnected(handle);
+                        let mut m = host.metrics.borrow_mut();
+                        m.disconnect_events = m.disconnect_events.wrapping_add(1);
+                    }
+                    Event::NumberOfCompletedPackets(c) => {
+                        // Explicitly ignoring for now
+                        for entry in c.completed_packets.iter() {
+                            if let (Ok(handle), Ok(completed)) = (entry.handle(), entry.num_completed_packets()) {
+                                let _ = host.connections.confirm_sent(handle, completed as usize);
+                            }
+                        }
+                    }
+                    Event::Vendor(vendor) => {
+                        vendor_handler(&vendor);
+                    }
+                    // Ignore
+                    _ => {}
+                },
+                // Ignore
+                Ok(_) => {}
+                Err(e) => {
+                    return Err(BleHostError::Controller(e));
+                }
+            }
+        }
+    }
+}
+
+impl<'d, C: Controller> ControlRunner<'d, C> {
+    /// Run the control loop for the host
+    pub async fn run(&mut self) -> Result<(), BleHostError<C::Error>>
+    where
+        C: ControllerCmdSync<Disconnect>
+            + ControllerCmdSync<SetEventMask>
+            + ControllerCmdSync<LeSetEventMask>
+            + ControllerCmdSync<LeSetRandomAddr>
+            + ControllerCmdSync<HostBufferSize>
+            + ControllerCmdAsync<LeConnUpdate>
+            + ControllerCmdSync<LeReadFilterAcceptListSize>
+            + ControllerCmdSync<SetControllerToHostFlowControl>
+            + ControllerCmdSync<Reset>
+            + ControllerCmdSync<LeCreateConnCancel>
+            + for<'t> ControllerCmdSync<LeSetAdvEnable>
+            + for<'t> ControllerCmdSync<LeSetExtAdvEnable<'t>>
+            + for<'t> ControllerCmdSync<HostNumberOfCompletedPackets<'t>>
+            + ControllerCmdSync<LeReadBufferSize>,
+    {
+        let host = self.stack.host;
+        Reset::new().exec(&host.controller).await?;
+
+        if let Some(addr) = host.address {
+            LeSetRandomAddr::new(addr.addr).exec(&host.controller).await?;
+        }
+
+        SetEventMask::new(
+            EventMask::new()
+                .enable_le_meta(true)
+                .enable_conn_request(true)
+                .enable_conn_complete(true)
+                .enable_hardware_error(true)
+                .enable_disconnection_complete(true),
+        )
+        .exec(&host.controller)
+        .await?;
+
+        LeSetEventMask::new(
+            LeEventMask::new()
+                .enable_le_conn_complete(true)
+                .enable_le_enhanced_conn_complete(true)
+                .enable_le_adv_set_terminated(true)
+                .enable_le_adv_report(true)
+                .enable_le_scan_timeout(true)
+                .enable_le_ext_adv_report(true),
+        )
+        .exec(&host.controller)
+        .await?;
+
+        let ret = LeReadFilterAcceptListSize::new().exec(&host.controller).await?;
+        info!("[host] filter accept list size: {}", ret);
+
+        let ret = LeReadBufferSize::new().exec(&host.controller).await?;
+        info!("[host] setting txq to {}", ret.total_num_le_acl_data_packets as usize);
+        host.connections
+            .set_link_credits(ret.total_num_le_acl_data_packets as usize);
+
+        info!(
+            "[host] configuring host buffers ({} packets of size {})",
+            config::L2CAP_RX_PACKET_POOL_SIZE,
+            host.rx_pool.mtu()
+        );
+        HostBufferSize::new(
+            host.rx_pool.mtu() as u16,
+            0,
+            config::L2CAP_RX_PACKET_POOL_SIZE as u16,
+            0,
+        )
+        .exec(&host.controller)
+        .await?;
+
+        #[cfg(feature = "controller-host-flow-control")]
+        {
+            info!("[host] enabling flow control");
+            SetControllerToHostFlowControl::new(ControllerToHostFlowControl::AclOnSyncOff)
+                .exec(&host.controller)
+                .await?;
+        }
+
+        let _ = host.initialized.init(());
+        info!("[host] initialized");
+
+        loop {
+            match select4(
+                poll_fn(|cx| host.connections.poll_disconnecting(Some(cx))),
+                poll_fn(|cx| host.channels.poll_disconnecting(Some(cx))),
+                poll_fn(|cx| host.connect_command_state.poll_cancelled(cx)),
+                poll_fn(|cx| host.advertise_command_state.poll_cancelled(cx)),
+            )
+            .await
+            {
+                Either4::First(request) => {
+                    host.command(Disconnect::new(request.handle(), request.reason()))
+                        .await?;
+                    request.confirm();
+                }
+                Either4::Second(request) => {
+                    let mut grant = host.acl(request.handle(), 1).await?;
+                    request.send(&mut grant).await?;
+                    request.confirm();
+                }
+                Either4::Third(_) => {
+                    // trace!("[host] cancelling create connection");
+                    if host.command(LeCreateConnCancel::new()).await.is_err() {
+                        // Signal to ensure no one is stuck
+                        host.connect_command_state.canceled();
+                    }
+                }
+                Either4::Fourth(ext) => {
+                    trace!("[host] disabling advertising");
+                    if ext {
+                        host.command(LeSetExtAdvEnable::new(false, &[])).await?
+                    } else {
+                        host.command(LeSetAdvEnable::new(false)).await?
+                    }
+                    host.advertise_command_state.canceled();
+                }
+            }
+        }
+    }
+}
+
+impl<'d, C: Controller> TxRunner<'d, C> {
+    /// Run the transmit loop for the host.
+    pub async fn run(&mut self) -> Result<(), BleHostError<C::Error>> {
+        let host = self.stack.host;
+        loop {
+            let (conn, pdu) = host.outbound.receive().await;
+            match host.acl(conn, 1).await {
+                Ok(mut sender) => {
+                    if let Err(e) = sender.send(pdu.as_ref()).await {
+                        warn!("[host] error sending outbound pdu");
+                        return Err(e);
+                    }
+                }
+                Err(e) => {
+                    warn!("[host] error requesting sending outbound pdu");
+                    return Err(e);
+                }
+            }
+        }
     }
 }
 

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -4,8 +4,7 @@ use bt_hci::controller::{blocking, Controller};
 pub use crate::channel_manager::CreditFlowPolicy;
 use crate::channel_manager::{ChannelIndex, DynamicChannelManager};
 use crate::connection::Connection;
-use crate::BleHostError;
-use crate::Stack;
+use crate::{BleHostError, Stack};
 
 pub(crate) mod sar;
 


### PR DESCRIPTION
* Allow splitting runner into tx, rx and control parts
* Allow passing owned peripheral, central, runner to tasks
* Fix issue with scan feature (Fixes #128)