### PR TITLE
Bugfix service visibility

### DIFF
--- a/host-macro/src/server.rs
+++ b/host-macro/src/server.rs
@@ -77,12 +77,13 @@ impl ServerBuilder {
         let mut code_service_init = TokenStream2::new();
         let mut code_server_populate = TokenStream2::new();
         for service in &self.properties.fields {
+            let vis = &service.vis;
             let service_span = service.span();
             let service_name = service.ident.as_ref().expect("All fields should have names");
             let service_type = &service.ty;
 
             code_service_definition.extend(quote_spanned! {service_span=>
-                #service_name: #service_type,
+                #vis #service_name: #service_type,
             });
 
             code_service_init.extend(quote_spanned! {service_span=>

--- a/host-macro/src/service.rs
+++ b/host-macro/src/service.rs
@@ -159,7 +159,7 @@ impl ServiceBuilder {
                 ty: syn::Type::Verbatim(quote!(Characteristic)),
                 attrs: Vec::new(),
                 colon_token: Default::default(),
-                vis: syn::Visibility::Inherited,
+                vis: ch.vis.clone(),
                 mutability: syn::FieldMutability::None,
             });
 

--- a/host-macro/src/service.rs
+++ b/host-macro/src/service.rs
@@ -170,8 +170,9 @@ impl ServiceBuilder {
         for field in fields {
             let ident = field.ident.clone();
             let ty = field.ty.clone();
+            let vis = &field.vis;
             self.code_fields.extend(quote_spanned! {field.span()=>
-                #ident: #ty,
+                #vis #ident: #ty,
             })
         }
         self


### PR DESCRIPTION
Characteristic handle visibility wasn't being pulled through from the struct definition.  This wasn't showing up when we were defining in the same file as we were using the fields.  It now follows the struct defined visibility.