### PR TITLE
ownership of AttributeTable into GattServer

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -61,7 +61,7 @@ async fn ble_task<C: Controller>(mut runner: Runner<'_, C>) -> Result<(), BleHos
     runner.run().await
 }
 
-async fn gatt_task<C: Controller>(server: &Server<'_, C>) {
+async fn gatt_task<C: Controller>(server: &Server<'_,'_, C>) {
     loop {
         match server.next().await {
             Ok(GattEvent::Write { handle, connection: _ }) => {
@@ -81,7 +81,7 @@ async fn gatt_task<C: Controller>(server: &Server<'_, C>) {
 
 async fn advertise_task<C: Controller>(
     mut peripheral: Peripheral<'_, C>,
-    server: &Server<'_, C>,
+    server: &Server<'_, '_, C>,
 ) -> Result<(), BleHostError<C::Error>> {
     let mut adv_data = [0; 31];
     AdStructure::encode_slice(

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -21,14 +21,14 @@ pub struct NotificationTable<const ENTRIES: usize> {
     state: [(u16, ConnHandle); ENTRIES],
 }
 
-pub struct AttributeServer<'c, 'd, M: RawMutex, const MAX: usize> {
-    pub(crate) table: &'c AttributeTable<'d, M, MAX>,
+pub struct AttributeServer<'d, M: RawMutex, const MAX: usize> {
+    pub(crate) table: AttributeTable<'d, M, MAX>,
     pub(crate) notification: Mutex<M, RefCell<NotificationTable<MAX_NOTIFICATIONS>>>,
 }
 
-impl<'c, 'd, M: RawMutex, const MAX: usize> AttributeServer<'c, 'd, M, MAX> {
+impl<'d, M: RawMutex, const MAX: usize> AttributeServer<'d, M, MAX> {
     /// Create a new instance of the AttributeServer
-    pub fn new(table: &'c AttributeTable<'d, M, MAX>) -> AttributeServer<'c, 'd, M, MAX> {
+    pub fn new(table: AttributeTable<'d, M, MAX>) -> AttributeServer<'d, M, MAX> {
         AttributeServer {
             table,
             notification: Mutex::new(RefCell::new(NotificationTable {
@@ -459,6 +459,6 @@ impl<'c, 'd, M: RawMutex, const MAX: usize> AttributeServer<'c, 'd, M, MAX> {
 
     /// Get a reference to the attribute table
     pub fn table(&self) -> &AttributeTable<'d, M, MAX> {
-        self.table
+        &self.table
     }
 }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -25,7 +25,7 @@ use crate::{config, BleHostError, Error, Stack};
 /// A GATT server capable of processing the GATT protocol using the provided table of attributes.
 pub struct GattServer<'reference, 'values, C: Controller, M: RawMutex, const MAX: usize, const L2CAP_MTU: usize> {
     stack: Stack<'reference, C>,
-    server: AttributeServer<'reference, 'values, M, MAX>,
+    server: AttributeServer<'values, M, MAX>,
     tx: DynamicSender<'reference, (ConnHandle, Pdu<'reference>)>,
     rx: DynamicReceiver<'reference, (ConnHandle, Pdu<'reference>)>,
     connections: &'reference dyn DynamicConnectionManager,
@@ -35,7 +35,7 @@ impl<'reference, 'values, C: Controller, M: RawMutex, const MAX: usize, const L2
     GattServer<'reference, 'values, C, M, MAX, L2CAP_MTU>
 {
     /// Creates a GATT server capable of processing the GATT protocol using the provided table of attributes.
-    pub fn new(stack: Stack<'reference, C>, table: &'reference AttributeTable<'values, M, MAX>) -> Self {
+    pub fn new(stack: Stack<'reference, C>, table: AttributeTable<'values, M, MAX>) -> Self {
         stack.host.connections.set_default_att_mtu(L2CAP_MTU as u16 - 4);
         use crate::attribute_server::AttributeServer;
 
@@ -148,7 +148,7 @@ impl<'reference, 'values, C: Controller, M: RawMutex, const MAX: usize, const L2
     }
 
     /// Get reference to the underlying AttributeServer
-    pub fn server(&self) -> &AttributeServer<'reference, 'values, M, MAX> {
+    pub fn server(&self) -> &AttributeServer<'values, M, MAX> {
         &self.server
     }
 }

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -57,7 +57,7 @@ async fn gatt_client_server() {
                 &mut value)
             .build();
 
-        let server = GattServer::<common::Controller, NoopRawMutex, 10, 27>::new(stack, &table);
+        let server = GattServer::<common::Controller, NoopRawMutex, 10, 27>::new(stack, table);
         select! {
             r = runner.run() => {
                 r
@@ -71,7 +71,7 @@ async fn gatt_client_server() {
                             handle,
                         }) => {
                             assert_eq!(handle, value_handle);
-                            let _ = table.get(handle, |value| {
+                            let _ = server.server().table().get(handle, |value| {
                                 assert_eq!(expected, value[0]);
                                 expected += 1;
                                 writes += 1;

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -32,6 +32,7 @@ async fn gatt_client_server() {
     let _ = env_logger::try_init();
     let peripheral = std::env::var("TEST_ADAPTER_ONE").unwrap();
     let central = std::env::var("TEST_ADAPTER_TWO").unwrap();
+    let name = std::env::var("DEVICE_NAME").unwrap_or("TrouBLE".into());
 
     let peripheral_address: Address = Address::random([0xff, 0x9f, 0x1a, 0x05, 0xe4, 0xff]);
 
@@ -45,8 +46,14 @@ async fn gatt_client_server() {
         let (stack, mut peripheral, _central, mut runner) = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
             .build();
-
-        let server: Server<common::Controller> = Server::new_default(stack, "trouBLE");
+        let gap = GapConfig::Peripheral(PeripheralConfig {
+            name: &name,
+            appearance: &appearance::GENERIC_POWER,
+        });
+        let server: Server<common::Controller> = Server::new_with_config(
+            stack,
+            gap,
+        );
 
         // Random starting value to 'prove' the incremented value is correct
         let value: [u8; 1] = [rand::prelude::random(); 1];


### PR DESCRIPTION
set AttributeTable to being owned by GattServer to remove need for StaticCell<AttributeTable>

supporting this issue: https://github.com/embassy-rs/trouble/issues/146