### PR TITLE
Fix build without GATT, fix CI to check it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
+**/target_ci
 Cargo.lock

--- a/ci.sh
+++ b/ci.sh
@@ -14,15 +14,17 @@ if [[ -z "${CARGO_TARGET_DIR}" ]]; then
 fi
 
 cargo batch \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features peripheral \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features central \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features central,peripheral \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features central,peripheral,defmt \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,central \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral,central,scan \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52840 \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52832 \
     --- build --release --manifest-path examples/esp32/Cargo.toml --target riscv32imc-unknown-none-elf \
     --- build --release --manifest-path examples/serial-hci/Cargo.toml \
-    --- build --release --manifest-path host/Cargo.toml --features peripheral \
-    --- build --release --manifest-path host/Cargo.toml --features central \
-    --- build --release --manifest-path host/Cargo.toml --features gatt,peripheral \
-    --- build --release --manifest-path host/Cargo.toml --features gatt,central \
-    --- build --release --manifest-path host/Cargo.toml --features gatt,peripheral,central,scan \
     --- build --release --manifest-path examples/rp-pico-w//Cargo.toml --target thumbv6m-none-eabi --features skip-cyw43-firmware
 #    --- build --release --manifest-path examples/apache-nimble/Cargo.toml --target thumbv7em-none-eabihf
 

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -45,6 +45,7 @@ pub use packet_pool::Qos as PacketQos;
 
 pub mod advertise;
 pub mod connection;
+#[cfg(feature = "gatt")]
 pub mod gap;
 pub mod l2cap;
 pub mod scan;


### PR DESCRIPTION
CI was missing --no-default-features so it wasn't actually checking these combinations
of features, causing the gatt-less build to fail.

- **Fix build without gatt, fix ci.**
- **Add target_ci to gitignore**
