### PR TITLE
Get rid of dyn trait for connection manager

### DIFF
--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -28,7 +28,7 @@ impl<'d, C: Controller> Central<'d, C> {
     }
 
     /// Attempt to create a connection with the provided config.
-    pub async fn connect(&mut self, config: &ConnectConfig<'_>) -> Result<Connection<'_>, BleHostError<C::Error>>
+    pub async fn connect(&mut self, config: &ConnectConfig<'_>) -> Result<Connection<'d>, BleHostError<C::Error>>
     where
         C: ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -5,7 +5,7 @@ use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
 use bt_hci::param::{BdAddr, ConnHandle, DisconnectReason, LeConnRole};
 use embassy_time::Duration;
 
-use crate::connection_manager::DynamicConnectionManager;
+use crate::connection_manager::ConnectionManager;
 use crate::scan::ScanConfig;
 use crate::{BleHostError, Stack};
 
@@ -48,7 +48,7 @@ impl Default for ConnectParams {
 /// When the last reference to a connection is dropped, the connection is automatically disconnected.
 pub struct Connection<'d> {
     index: u8,
-    manager: &'d dyn DynamicConnectionManager,
+    manager: &'d ConnectionManager<'d>,
 }
 
 impl<'d> Clone for Connection<'d> {
@@ -65,7 +65,7 @@ impl<'d> Drop for Connection<'d> {
 }
 
 impl<'d> Connection<'d> {
-    pub(crate) fn new(index: u8, manager: &'d dyn DynamicConnectionManager) -> Self {
+    pub(crate) fn new(index: u8, manager: &'d ConnectionManager<'d>) -> Self {
         Self { index, manager }
     }
 
@@ -96,7 +96,7 @@ impl<'d> Connection<'d> {
     /// Request connection to be disconnected.
     pub fn disconnect(&self) {
         self.manager
-            .disconnect(self.index, DisconnectReason::RemoteUserTerminatedConn);
+            .request_disconnect(self.index, DisconnectReason::RemoteUserTerminatedConn);
     }
 
     /// The RSSI value for this connection.

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -17,7 +17,7 @@ use crate::attribute::{
 };
 use crate::attribute_server::AttributeServer;
 use crate::connection::Connection;
-use crate::connection_manager::DynamicConnectionManager;
+use crate::connection_manager::ConnectionManager;
 use crate::cursor::{ReadCursor, WriteCursor};
 use crate::pdu::Pdu;
 use crate::types::gatt_traits::GattValue;
@@ -30,7 +30,7 @@ pub struct GattServer<'reference, 'values, C: Controller, M: RawMutex, const MAX
     server: AttributeServer<'values, M, MAX>,
     tx: DynamicSender<'reference, (ConnHandle, Pdu<'reference>)>,
     rx: DynamicReceiver<'reference, (ConnHandle, Pdu<'reference>)>,
-    connections: &'reference dyn DynamicConnectionManager,
+    connections: &'reference ConnectionManager<'reference>,
 }
 
 impl<'reference, 'values, C: Controller, M: RawMutex, const MAX: usize, const L2CAP_MTU: usize>

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -34,7 +34,7 @@ use futures::pin_mut;
 
 use crate::channel_manager::{ChannelManager, ChannelStorage, PacketChannel};
 use crate::command::CommandState;
-use crate::connection_manager::{ConnectionManager, ConnectionStorage, DynamicConnectionManager, PacketGrant};
+use crate::connection_manager::{ConnectionManager, ConnectionStorage, PacketGrant};
 use crate::cursor::WriteCursor;
 use crate::l2cap::sar::{PacketReassembly, SarType};
 use crate::packet_pool::{AllocId, GlobalPacketPool};


### PR DESCRIPTION
The dyn trait is no longer needed after the central/peripheral split
refactoring.
