### PR TITLE
Change server macro to accept expressions for attribute_data_size and mtu

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -18,8 +18,10 @@ const MAX_ATTRIBUTES: usize = 10;
 
 type Resources<C> = HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
 
+const ATTRIBUTE_DATA_SIZE: usize = 10;
+
 // GATT Server definition
-#[gatt_server(attribute_data_size = 10)]
+#[gatt_server(attribute_data_size = ATTRIBUTE_DATA_SIZE)]
 struct Server {
     battery_service: BatteryService,
 }


### PR DESCRIPTION
Previously, the `server` attribute macro would only accept literals for the attribute_data_size and mtu arguments. This meant that constants could not be used as they are evaluated after the macro has been expanded.

This PR changes the arguments to accept expressions, so constants can now be used.