### PR TITLE
expose characteristic handle to make GattEvent Read and Write nicer

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -105,6 +105,7 @@ async fn advertise_task<C: Controller>(
         let conn = advertiser.accept().await?;
         info!("[adv] connection established");
         let mut tick: u8 = 0;
+        let level = server.battery_service.level;
         loop {
             match select(conn.next(), Timer::after(Duration::from_secs(2))).await {
                 Either::First(event) => match event {
@@ -112,7 +113,21 @@ async fn advertise_task<C: Controller>(
                         info!("[adv] disconnected: {:?}", reason);
                         break;
                     }
-                    _ => {}
+                    ConnectionEvent::Gatt { event, .. } => match event {
+                        GattEvent::Read { value_handle } => { 
+                            if value_handle == level.handle {
+                                let value = server.get(&level);
+                                info!("[gatt] Read Event to Level Characteristic: {:?}", value);
+                            }
+                        },
+                        GattEvent::Write { value_handle } => {
+                            if value_handle == level.handle {
+                                let value = server.get(&level);
+                                info!("[gatt] Write Event to Level Characteristic: {:?}", value);
+                            }
+                        },
+                    },
+                    
                 },
                 Either::Second(_) => {
                     tick = tick.wrapping_add(1);

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -656,7 +656,8 @@ impl<'r, 'd, M: RawMutex, const MAX: usize> Drop for ServiceBuilder<'r, 'd, M, M
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Characteristic<T: GattValue> {
     pub(crate) cccd_handle: Option<u16>,
-    pub(crate) handle: u16,
+    /// Handle value assigned to this characteristic when it is added to the Gatt Attribute Table
+    pub handle: u16,
     pub(crate) phantom: PhantomData<T>,
 }
 


### PR DESCRIPTION
Simple PR to improve the example to show how to best read the data from a written characteristic.