### PR TITLE
Improve peripheral gatt example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {   
     "[rust]": {
         "editor.formatOnSave": true,
-        "editor.formatOnSaveMode": "modifications",
+        "editor.formatOnSaveMode": "file",
     },
     "[toml]": {
         "editor.formatOnSave": false

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -44,6 +44,10 @@ pub async fn run<C>(controller: C)
 where
     C: Controller,
 {
+
+    // Using a fixed seed means the "random" address will be the same every time the program runs, 
+    // which can be useful for testing. If truly random addresses are required, a different, 
+    // dynamically generated seed should be used.
     let address = Address::random([0x41, 0x5A, 0xE3, 0x1E, 0x83, 0xE7]);
     info!("Our address = {:?}", address);
 

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -48,7 +48,7 @@ where
     info!("Our address = {:?}", address);
 
     let mut resources = Resources::new(PacketQos::None);
-    let (stack, mut peripheral, _, mut runner) = trouble_host::new(controller, &mut resources)
+    let (stack, mut peripheral, _, runner) = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();
 
@@ -62,7 +62,7 @@ where
     )
     .unwrap();
 
-    let ble_runner_task = ble_task(&mut runner);
+    let ble_runner_task = ble_task(runner);
     let app_task = async {
         loop {
             match advertise("Trouble Example", &mut peripheral).await {
@@ -82,7 +82,21 @@ where
 }
 
 /// This is a background task that is required to run forever alongside any other BLE tasks.
-async fn ble_task<C: Controller>(runner: &mut Runner<'_, C>) -> Result<(), BleHostError<C::Error>> {
+/// 
+/// ## Alternative
+/// 
+/// If you didn't require this to be generic for your application, you could statically spawn this with i.e.
+/// 
+/// ```rust [ignore]
+/// 
+/// #[embassy_executor::task]
+/// async fn ble_task(mut runner: Runner<'static, SoftdeviceController<'static>>) {
+///     runner.run().await;
+/// }
+/// 
+/// spawner.must_spawn(ble_task(runner));
+/// ```
+async fn ble_task<C: Controller>(mut runner: Runner<'_, C>) -> Result<(), BleHostError<C::Error>> {
     runner.run().await
 }
 

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -61,7 +61,7 @@ where
         }),
     )
     .unwrap();
-    let ble_task = ble_task(&mut runner);
+    let ble_runner_task = ble_task(&mut runner);
     let app_task = async {
         loop {
             info!("[adv] advertising");
@@ -79,7 +79,7 @@ where
             }
         }
     };
-    select(ble_task, app_task).await;
+    select(ble_runner_task, app_task).await; // runner must run in the background forever whilst any other ble service runs.
 }
 
 async fn ble_task<C: Controller>(runner: &mut Runner<'_, C>) -> Result<(), BleHostError<C::Error>> {
@@ -127,7 +127,7 @@ async fn advertise<'a, C: Controller>(
     name: &'a str,
     peripheral: &mut Peripheral<'a, C>,
 ) -> Result<Connection<'a>, BleHostError<C::Error>> {
-    let name= if name.len() > 22 {
+    let name = if name.len() > 22 {
         let truncated_name = &name[..22];
         info!("Name truncated to {}", truncated_name);
         truncated_name

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -64,10 +64,8 @@ where
     let ble_runner_task = ble_task(&mut runner);
     let app_task = async {
         loop {
-            info!("[adv] advertising");
             match advertise("Trouble Example", &mut peripheral).await {
                 Ok(conn) => {
-                    info!("[adv] connection established");
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let gatt = gatt_task(&server, &conn);
                     let counter_task = example_application_task(&server, &conn);
@@ -152,7 +150,10 @@ async fn advertise<'a, C: Controller>(
             },
         )
         .await?;
-    Ok(advertiser.accept().await?)
+    info!("[adv] advertising");
+    let conn = advertiser.accept().await?;
+    info!("[adv] connection established");
+    Ok(conn)
 }
 
 /// Example task to use the BLE notifier interface.

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -69,7 +69,7 @@ where
                 Ok(conn) => {
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let connection_task = conn_task(&server, &conn);
-                    let counter_task = example_application_task(&server, &conn);
+                    let counter_task = counter_task(&server, &conn);
                     // run until any task ends (usually because the connection has been closed),
                     // then return to advertising state.
                     select(connection_task, counter_task).await;
@@ -174,7 +174,7 @@ async fn advertise<'a, C: Controller>(
 }
 
 /// Example task to use the BLE notifier interface.
-async fn example_application_task<C: Controller>(server: &Server<'_, '_, C>, conn: &Connection<'_>) {
+async fn counter_task<C: Controller>(server: &Server<'_, '_, C>, conn: &Connection<'_>) {
     let mut tick: u8 = 0;
     let level = server.battery_service.level;
     loop {

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -61,6 +61,7 @@ where
         }),
     )
     .unwrap();
+
     let ble_runner_task = ble_task(&mut runner);
     let app_task = async {
         loop {
@@ -73,17 +74,16 @@ where
                     // then return to advertising state.
                     select(gatt, counter_task).await;
                 }
-                Err(err) => info!("[adv] error: {:?}", err),
+                Err(_) => info!("[adv] error"),
             }
         }
     };
-    select(ble_runner_task, app_task).await; // runner must run in the background forever whilst any other ble service runs.
+    select(ble_runner_task, app_task).await;
 }
 
+/// This is a background task that is required to run forever alongside any other BLE tasks.
 async fn ble_task<C: Controller>(runner: &mut Runner<'_, C>) -> Result<(), BleHostError<C::Error>> {
-    runner.run().await?;
-    info!("BLE task finished");
-    Ok(())
+    runner.run().await
 }
 
 /// Stream Events until the connection closes.
@@ -163,8 +163,8 @@ async fn example_application_task<C: Controller>(server: &Server<'_, '_, C>, con
     loop {
         tick = tick.wrapping_add(1);
         info!("[adv] notifying connection of tick {}", tick);
-        if let Err(err) = server.notify(&level, &conn, &tick).await {
-            info!("[adv] error notifying connection: {:?}", err);
+        if let Err(_) = server.notify(&level, conn, &tick).await {
+            info!("[adv] error notifying connection");
             break;
         };
         Timer::after_secs(2).await;

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -1,8 +1,5 @@
-use embassy_futures::{
-    join::join3,
-    select::{select, Either},
-};
-use embassy_time::{Duration, Timer};
+use embassy_futures::select::{select, Either};
+use embassy_time::Timer;
 use trouble_host::prelude::*;
 
 /// Size of L2CAP packets (ATT MTU is this - 4)
@@ -42,6 +39,7 @@ fn battery_level_on_write(_connection: &Connection, data: &[u8]) -> Result<(), (
     Ok(())
 }
 
+/// Run the BLE stack.
 pub async fn run<C>(controller: C)
 where
     C: Controller,
@@ -50,10 +48,11 @@ where
     info!("Our address = {:?}", address);
 
     let mut resources = Resources::new(PacketQos::None);
-    let (stack, peripheral, _, runner) = trouble_host::new(controller, &mut resources)
+    let (stack, mut peripheral, _, mut runner) = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();
 
+    info!("Starting advertising and GATT service");
     let server = Server::new_with_config(
         stack,
         GapConfig::Peripheral(PeripheralConfig {
@@ -62,81 +61,111 @@ where
         }),
     )
     .unwrap();
-
-    info!("Starting advertising and GATT service");
-    let _ = join3(
-        ble_task(runner),
-        gatt_task(&server),
-        advertise_task(peripheral, &server),
-    )
-    .await;
+    let ble_task = ble_task(&mut runner);
+    let app_task = async {
+        loop {
+            info!("[adv] advertising");
+            match advertise("Trouble Example", &mut peripheral).await {
+                Ok(conn) => {
+                    info!("[adv] connection established");
+                    // set up tasks when the connection is established to a central, so they don't run when no one is connected.
+                    let gatt = gatt_task(&server, &conn);
+                    let counter_task = example_application_task(&server, &conn);
+                    // run until any task ends (usually because the connection has been closed),
+                    // then return to advertising state.
+                    select(gatt, counter_task).await;
+                }
+                Err(err) => info!("[adv] error: {:?}", err),
+            }
+        }
+    };
+    select(ble_task, app_task).await;
 }
 
-async fn ble_task<C: Controller>(mut runner: Runner<'_, C>) -> Result<(), BleHostError<C::Error>> {
-    runner.run().await
+async fn ble_task<C: Controller>(runner: &mut Runner<'_, C>) -> Result<(), BleHostError<C::Error>> {
+    runner.run().await?;
+    info!("BLE task finished");
+    Ok(())
 }
 
-async fn gatt_task<C: Controller>(server: &Server<'_, '_, C>) -> Result<(), BleHostError<C::Error>> {
-    server.run().await
-}
-
-async fn advertise_task<C: Controller>(
-    mut peripheral: Peripheral<'_, C>,
+/// Stream Events until the connection closes.
+async fn gatt_task<C: Controller>(
     server: &Server<'_, '_, C>,
+    conn: &Connection<'_>,
 ) -> Result<(), BleHostError<C::Error>> {
-    let mut adv_data = [0; 31];
+    let level = server.battery_service.level;
+    loop {
+        if let Either::First(event) = select(conn.next(), server.run()).await {
+            match event {
+                ConnectionEvent::Disconnected { reason } => {
+                    info!("[adv] disconnected: {:?}", reason);
+                    break;
+                }
+                ConnectionEvent::Gatt { event, .. } => match event {
+                    GattEvent::Read { value_handle } => {
+                        if value_handle == level.handle {
+                            let value = server.get(&level);
+                            info!("[gatt] Read Event to Level Characteristic: {:?}", value);
+                        }
+                    }
+                    GattEvent::Write { value_handle } => {
+                        if value_handle == level.handle {
+                            let value = server.get(&level);
+                            info!("[gatt] Write Event to Level Characteristic: {:?}", value);
+                        }
+                    }
+                },
+            }
+        }
+    }
+    info!("[gatt] task finished");
+    Ok(())
+}
+
+/// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
+async fn advertise<'a, C: Controller>(
+    name: &'a str,
+    peripheral: &mut Peripheral<'a, C>,
+) -> Result<Connection<'a>, BleHostError<C::Error>> {
+    let name= if name.len() > 22 {
+        let truncated_name = &name[..22];
+        info!("Name truncated to {}", truncated_name);
+        truncated_name
+    } else {
+        name
+    };
+    let mut advertiser_data = [0; 31];
     AdStructure::encode_slice(
         &[
             AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
             AdStructure::ServiceUuids16(&[Uuid::Uuid16([0x0f, 0x18])]),
-            AdStructure::CompleteLocalName(b"Trouble"),
+            AdStructure::CompleteLocalName(name.as_bytes()),
         ],
-        &mut adv_data[..],
+        &mut advertiser_data[..],
     )?;
+    let mut advertiser = peripheral
+        .advertise(
+            &Default::default(),
+            Advertisement::ConnectableScannableUndirected {
+                adv_data: &advertiser_data[..],
+                scan_data: &[],
+            },
+        )
+        .await?;
+    Ok(advertiser.accept().await?)
+}
+
+/// Example task to use the BLE notifier interface.
+async fn example_application_task<C: Controller>(server: &Server<'_, '_, C>, conn: &Connection<'_>) {
+    let mut tick: u8 = 0;
+    let level = server.battery_service.level;
     loop {
-        info!("[adv] advertising");
-        let mut advertiser = peripheral
-            .advertise(
-                &Default::default(),
-                Advertisement::ConnectableScannableUndirected {
-                    adv_data: &adv_data[..],
-                    scan_data: &[],
-                },
-            )
-            .await?;
-        let conn = advertiser.accept().await?;
-        info!("[adv] connection established");
-        let mut tick: u8 = 0;
-        let level = server.battery_service.level;
-        loop {
-            match select(conn.next(), Timer::after(Duration::from_secs(2))).await {
-                Either::First(event) => match event {
-                    ConnectionEvent::Disconnected { reason } => {
-                        info!("[adv] disconnected: {:?}", reason);
-                        break;
-                    }
-                    ConnectionEvent::Gatt { event, .. } => match event {
-                        GattEvent::Read { value_handle } => { 
-                            if value_handle == level.handle {
-                                let value = server.get(&level);
-                                info!("[gatt] Read Event to Level Characteristic: {:?}", value);
-                            }
-                        },
-                        GattEvent::Write { value_handle } => {
-                            if value_handle == level.handle {
-                                let value = server.get(&level);
-                                info!("[gatt] Write Event to Level Characteristic: {:?}", value);
-                            }
-                        },
-                    },
-                    
-                },
-                Either::Second(_) => {
-                    tick = tick.wrapping_add(1);
-                    info!("[adv] notifying connection of tick {}", tick);
-                    let _ = server.notify(&server.battery_service.level, &conn, &tick).await;
-                }
-            }
-        }
+        tick = tick.wrapping_add(1);
+        info!("[adv] notifying connection of tick {}", tick);
+        if let Err(err) = server.notify(&level, &conn, &tick).await {
+            info!("[adv] error notifying connection: {:?}", err);
+            break;
+        };
+        Timer::after_secs(2).await;
     }
 }

--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -157,12 +157,12 @@ impl ServerBuilder {
                     })
                 }
 
-                #visibility fn get<T: trouble_host::types::gatt_traits::GattValue>(&self, handle: &Characteristic<T>) -> Result<T, Error> {
-                    self.server.server().table().get(handle)
+                #visibility fn get<T: trouble_host::types::gatt_traits::GattValue>(&self, characteristic: &Characteristic<T>) -> Result<T, Error> {
+                    self.server.server().table().get(characteristic)
                 }
 
-                #visibility fn set<T: trouble_host::types::gatt_traits::GattValue>(&self, handle: &Characteristic<T>, input: &T) -> Result<(), Error> {
-                    self.server.server().table().set(handle, input)
+                #visibility fn set<T: trouble_host::types::gatt_traits::GattValue>(&self, characteristic: &Characteristic<T>, input: &T) -> Result<(), Error> {
+                    self.server.server().table().set(characteristic, input)
                 }
             }
 

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -439,11 +439,11 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
     ///
     /// If the characteristic for the handle cannot be found, or the shape of the data does not match the type of the characterstic,
     /// an error is returned
-    pub fn set<T: GattValue>(&self, handle: &Characteristic<T>, input: &T) -> Result<(), Error> {
+    pub fn set<T: GattValue>(&self, characteristic: &Characteristic<T>, input: &T) -> Result<(), Error> {
         let gatt_value = input.to_gatt();
         self.iterate(|mut it| {
             while let Some(att) = it.next() {
-                if att.handle == handle.handle {
+                if att.handle == characteristic.handle {
                     if let AttributeData::Data { props, value } = &mut att.data {
                         if value.len() == gatt_value.len() {
                             value.copy_from_slice(gatt_value);
@@ -463,10 +463,10 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
     /// The return value of the closure is returned in this function and is assumed to be infallible.
     ///
     /// If the characteristic for the handle cannot be found, an error is returned.
-    pub fn get<T: GattValue>(&self, handle: &Characteristic<T>) -> Result<T, Error> {
+    pub fn get<T: GattValue>(&self, characteristic: &Characteristic<T>) -> Result<T, Error> {
         self.iterate(|mut it| {
             while let Some(att) = it.next() {
-                if att.handle == handle.handle {
+                if att.handle == characteristic.handle {
                     if let AttributeData::Data { props, value } = &mut att.data {
                         let v = <T as GattValue>::from_gatt(value).map_err(|_| Error::InvalidValue)?;
                         return Ok(v);

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -74,13 +74,13 @@ pub mod prelude {
     pub use trouble_host_macros::*;
 
     #[cfg(feature = "gatt")]
-    pub use crate::types::gatt_traits::{GattValue as _, FixedGattValue as _};
+    pub use crate::attribute::*;
     #[cfg(feature = "gatt")]
     pub use crate::gap::*;
     #[cfg(feature = "gatt")]
     pub use crate::gatt::*;
     #[cfg(feature = "gatt")]
-    pub use crate::attribute::*;
+    pub use crate::types::gatt_traits::{FixedGattValue, GattValue};
 
     #[cfg(feature = "central")]
     pub use crate::central::*;

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -60,32 +60,37 @@ pub use peripheral::*;
 
 #[allow(missing_docs)]
 pub mod prelude {
+    pub use super::att::AttErrorCode;
+    pub use super::{BleHostError, Controller, Error, HostResources, Stack};
+    pub use crate::connection::*;
+    pub use crate::host::{ControlRunner, HostMetrics, Runner, RxRunner, TxRunner};
+    pub use crate::l2cap::*;
+    pub use crate::packet_pool::{PacketPool, Qos as PacketQos};
+    pub use crate::Address;
+
     #[cfg(feature = "derive")]
     pub use heapless::String as HeaplessString;
     #[cfg(feature = "derive")]
     pub use trouble_host_macros::*;
 
-    pub use super::att::AttErrorCode;
-    pub use super::{BleHostError, Controller, Error, HostResources, Stack};
-    #[cfg(feature = "peripheral")]
-    pub use crate::advertise::*;
     #[cfg(feature = "gatt")]
-    pub use crate::attribute::*;
-    #[cfg(feature = "central")]
-    pub use crate::central::*;
-    pub use crate::connection::*;
+    pub use crate::types::gatt_traits::{GattValue as _, FixedGattValue as _};
     #[cfg(feature = "gatt")]
     pub use crate::gap::*;
     #[cfg(feature = "gatt")]
     pub use crate::gatt::*;
-    pub use crate::host::{ControlRunner, HostMetrics, Runner, RxRunner, TxRunner};
-    pub use crate::l2cap::*;
-    pub use crate::packet_pool::{PacketPool, Qos as PacketQos};
+    #[cfg(feature = "gatt")]
+    pub use crate::attribute::*;
+
+    #[cfg(feature = "central")]
+    pub use crate::central::*;
+
+    #[cfg(feature = "peripheral")]
+    pub use crate::advertise::*;
     #[cfg(feature = "peripheral")]
     pub use crate::peripheral::*;
     #[cfg(feature = "peripheral")]
     pub use crate::scan::*;
-    pub use crate::Address;
 }
 
 #[cfg(feature = "gatt")]


### PR DESCRIPTION
Happy to debate the restructure of the Gatt Peripheral example.  To me this represents a more real world example where separate services will be talking to the gatt server, and can be shut down when the connection drops.

I've added a couple of quality of life improvements alongside this.