### PR TITLE
Automatically calculate attribute table size

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -114,20 +114,19 @@ async fn advertise_task<C: Controller>(
                         break;
                     }
                     ConnectionEvent::Gatt { event, .. } => match event {
-                        GattEvent::Read { value_handle } => { 
+                        GattEvent::Read { value_handle } => {
                             if value_handle == level.handle {
                                 let value = server.get(&level);
                                 info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                             }
-                        },
+                        }
                         GattEvent::Write { value_handle } => {
                             if value_handle == level.handle {
                                 let value = server.get(&level);
                                 info!("[gatt] Write Event to Level Characteristic: {:?}", value);
                             }
-                        },
+                        }
                     },
-                    
                 },
                 Either::Second(_) => {
                     tick = tick.wrapping_add(1);

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -18,10 +18,8 @@ const MAX_ATTRIBUTES: usize = 10;
 
 type Resources<C> = HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
 
-const ATTRIBUTE_DATA_SIZE: usize = 10;
-
 // GATT Server definition
-#[gatt_server(attribute_data_size = ATTRIBUTE_DATA_SIZE)]
+#[gatt_server]
 struct Server {
     battery_service: BatteryService,
 }

--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -4,13 +4,10 @@
 //! It should contain one or more Gatt Services, which are decorated with the `#[gatt_service(uuid = "...")]` attribute.
 
 use darling::Error;
-use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
 use syn::{meta::ParseNestedMeta, parse_quote, spanned::Spanned, Expr, Result};
 
-/// Default size for the memory block storing attribute data in bytes
-const DEFAULT_ATTRIBUTE_DATA_SIZE: usize = 32;
 /// MTU for a legacy BLE packet
 const LEGACY_BLE_MTU: usize = 27;
 

--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -105,8 +105,9 @@ impl ServerBuilder {
 
         quote! {
             const _ATTRIBUTE_TABLE_SIZE: usize = #attribute_table_size;
+            // This pattern causes the assertion to happen at compile time
             const _: () = {
-                assert!(_ATTRIBUTE_TABLE_SIZE >= GAP_SERVICE_ATTRIBUTE_COUNT #code_attribute_summation, "Specified attribute table size is insufficient. Please increase attribute_table_size");
+                core::assert!(_ATTRIBUTE_TABLE_SIZE >= GAP_SERVICE_ATTRIBUTE_COUNT #code_attribute_summation, "Specified attribute table size is insufficient. Please increase attribute_table_size or remove the argument entirely to allow automatic sizing of the attribute table.");
             };
 
             #visibility struct #name<'reference, 'values, C: Controller>

--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -17,7 +17,7 @@ const LEGACY_BLE_MTU: usize = 27;
 #[derive(Default)]
 pub(crate) struct ServerArgs {
     mutex_type: Option<syn::Type>,
-    attribute_data_size: Option<Expr>,
+    attribute_table_size: Option<Expr>,
     mtu: Option<Expr>,
 }
 
@@ -34,15 +34,15 @@ impl ServerArgs {
                 let buffer = meta.value().map_err(|_| Error::custom("mutex_type must be followed by `= [type]`. e.g. mutex_type = NoopRawMutex".to_string()))?;
                 self.mutex_type = Some(buffer.parse()?);
             }
-            "attribute_data_size" => {
-                let buffer = meta.value().map_err(|_| Error::custom("attribute_data_size msut be followed by `= [size]`. e.g. attribute_data_size = 32".to_string()))?;
-                self.attribute_data_size = Some(buffer.parse()?);
+            "attribute_table_size" => {
+                let buffer = meta.value().map_err(|_| Error::custom("attribute_table_size msut be followed by `= [size]`. e.g. attribute_table_size = 32".to_string()))?;
+                self.attribute_table_size = Some(buffer.parse()?);
             }
             "mtu" => {
                 let buffer = meta.value().map_err(|_| Error::custom("mtu must be followed by `= [size]`. e.g. mtu = 27".to_string()))?;
                 self.mtu = Some(buffer.parse()?);
             }
-            other => return Err(meta.error(format!("Unsupported server property: '{other}'.\nSupported properties are: mutex_type, attribute_data_size, mtu"))),
+            other => return Err(meta.error(format!("Unsupported server property: '{other}'.\nSupported properties are: mutex_type, attribute_table_size, mtu"))),
         }
         Ok(())
     }
@@ -100,18 +100,21 @@ impl ServerBuilder {
             })
         }
 
-        let attribute_table_summation = if let Some(value) = self.arguments.attribute_data_size {
+        let attribute_table_size = if let Some(value) = self.arguments.attribute_table_size {
             value
         } else {
-            parse_quote!(code_attribute_summation)
+            parse_quote!(GAP_SERVICE_ATTRIBUTE_COUNT #code_attribute_summation)
         };
 
         quote! {
-            const ATTRIBUTE_TABLE_SIZE: usize = GAP_SERVICE_ATTRIBUTE_COUNT #attribute_table_summation;
+            const _ATTRIBUTE_TABLE_SIZE: usize = #attribute_table_size;
+            const _: () = {
+                assert!(_ATTRIBUTE_TABLE_SIZE >= GAP_SERVICE_ATTRIBUTE_COUNT #code_attribute_summation, "Specified attribute table size is insufficient. Please increase attribute_table_size");
+            };
 
             #visibility struct #name<'reference, 'values, C: Controller>
             {
-                server: GattServer<'reference, 'values, C, #mutex_type, ATTRIBUTE_TABLE_SIZE, #mtu>,
+                server: GattServer<'reference, 'values, C, #mutex_type, _ATTRIBUTE_TABLE_SIZE, #mtu>,
                 #code_service_definition
             }
 
@@ -120,7 +123,7 @@ impl ServerBuilder {
                 /// Create a new Gatt Server instance.
                 ///
                 /// Requires you to add your own GAP Service.  Use `new_default(name)` or `new_with_config(name, gap_config)` if you want to add a GAP Service.
-                #visibility fn new(stack: Stack<'reference, C>, mut table: AttributeTable<'values, #mutex_type, ATTRIBUTE_TABLE_SIZE>) -> Self {
+                #visibility fn new(stack: Stack<'reference, C>, mut table: AttributeTable<'values, #mutex_type, _ATTRIBUTE_TABLE_SIZE>) -> Self {
 
                     #code_service_init
 
@@ -135,7 +138,7 @@ impl ServerBuilder {
                 /// The maximum length which the name can be is 22 bytes (limited by the size of the advertising packet).
                 /// If a name longer than this is passed, Err() is returned.
                 #visibility fn new_default(stack: Stack<'reference, C>, name: &'values str) -> Result<Self, &'static str> {
-                    let mut table: AttributeTable<'_, #mutex_type, ATTRIBUTE_TABLE_SIZE> = AttributeTable::new();
+                    let mut table: AttributeTable<'_, #mutex_type, _ATTRIBUTE_TABLE_SIZE> = AttributeTable::new();
 
                     GapConfig::default(name).build(&mut table)?;
 
@@ -153,7 +156,7 @@ impl ServerBuilder {
                 /// The maximum length which the device name can be is 22 bytes (limited by the size of the advertising packet).
                 /// If a name longer than this is passed, Err() is returned.
                 #visibility fn new_with_config(stack: Stack<'reference, C>, gap: GapConfig<'values>) -> Result<Self, &'static str> {
-                    let mut table: AttributeTable<'_, #mutex_type, ATTRIBUTE_TABLE_SIZE> = AttributeTable::new();
+                    let mut table: AttributeTable<'_, #mutex_type, _ATTRIBUTE_TABLE_SIZE> = AttributeTable::new();
 
                     gap.build(&mut table)?;
 
@@ -176,7 +179,7 @@ impl ServerBuilder {
 
             impl<'reference, 'values, C: Controller> core::ops::Deref for #name<'reference, 'values, C>
             {
-                type Target = GattServer<'reference, 'values, C, #mutex_type, ATTRIBUTE_TABLE_SIZE, #mtu>;
+                type Target = GattServer<'reference, 'values, C, #mutex_type, _ATTRIBUTE_TABLE_SIZE, #mtu>;
 
                 fn deref(&self) -> &Self::Target {
                     &self.server

--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -64,6 +64,7 @@ impl syn::parse::Parse for ServiceArgs {
 pub(crate) struct ServiceBuilder {
     properties: syn::ItemStruct,
     args: ServiceArgs,
+    attribute_count: usize,
     code_impl: TokenStream2,
     code_build_chars: TokenStream2,
     code_struct_init: TokenStream2,
@@ -75,6 +76,7 @@ impl ServiceBuilder {
         Self {
             properties,
             args,
+            attribute_count: 1, // Service counts as an attribute
             code_struct_init: TokenStream2::new(),
             code_impl: TokenStream2::new(),
             code_fields: TokenStream2::new(),
@@ -91,6 +93,7 @@ impl ServiceBuilder {
         let fields = self.code_fields;
         let code_build_chars = self.code_build_chars;
         let uuid = self.args.uuid;
+        let attribute_count = self.attribute_count;
         let read_callback = self
             .args
             .on_read
@@ -104,6 +107,8 @@ impl ServiceBuilder {
 
             #[allow(unused)]
             impl #struct_name {
+                const ATTRIBUTE_COUNT: usize = #attribute_count;
+
                 #visibility fn new<M, const MAX_ATTRIBUTES: usize>(table: &mut AttributeTable<'_, M, MAX_ATTRIBUTES>) -> Self
                 where
                     M: embassy_sync::blocking_mutex::raw::RawMutex,
@@ -152,6 +157,7 @@ impl ServiceBuilder {
                 #write_callback
 
                 // TODO: Descriptors
+                // NOTE: Descriptors are attributes too - will need to increment self.attribute_count
 
                 builder.build()
             };
@@ -194,6 +200,8 @@ impl ServiceBuilder {
             });
 
             self.construct_characteristic_static(ch);
+
+            self.attribute_count += 1;
         }
 
         // Processing common to all fields

--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -199,9 +199,14 @@ impl ServiceBuilder {
                 mutability: syn::FieldMutability::None,
             });
 
-            self.construct_characteristic_static(ch);
+            // At least two attributes will be added to the attribute table for each characteristic:
+            // - The characteristic declaration
+            // - The characteristic's value declaration
+            //
+            // If the characteristic has either the notify or indicate property, a Client Characteristic Configuration Descriptor (CCCD) declaration will also be added.
+            self.attribute_count += if ch.args.notify || ch.args.indicate { 3 } else { 2 };
 
-            self.attribute_count += 1;
+            self.construct_characteristic_static(ch);
         }
 
         // Processing common to all fields

--- a/host/src/gap.rs
+++ b/host/src/gap.rs
@@ -24,6 +24,9 @@ const APPEARANCE_UUID: u16 = 0x2a01;
 /// Advertising packet is limited to 31 bytes. 9 of these are used by other GAP data, leaving 22 bytes for the Device Name characteristic
 const DEVICE_NAME_MAX_LENGTH: usize = 22;
 
+/// The number of attributes added by the GAP and GATT services
+pub const GAP_SERVICE_ATTRIBUTE_COUNT: usize = 4;
+
 pub mod appearance {
     //! The representation of the external appearance of the device.
     //!

--- a/host/src/gap.rs
+++ b/host/src/gap.rs
@@ -25,7 +25,13 @@ const APPEARANCE_UUID: u16 = 0x2a01;
 const DEVICE_NAME_MAX_LENGTH: usize = 22;
 
 /// The number of attributes added by the GAP and GATT services
-pub const GAP_SERVICE_ATTRIBUTE_COUNT: usize = 4;
+/// GAP_SERVICE:       1
+/// ├── DEVICE_NAME:   2
+/// └── APPEARANCE:    2
+/// GATT_SERVICE:    + 1
+///                  ---
+///                  = 6
+pub const GAP_SERVICE_ATTRIBUTE_COUNT: usize = 6;
 
 pub mod appearance {
     //! The representation of the external appearance of the device.

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -18,7 +18,7 @@ const VALUE_UUID: Uuid = Uuid::new_long([
     0x00, 0x00, 0x10, 0x01, 0xb0, 0xcd, 0x11, 0xec, 0x87, 0x1f, 0xd4, 0x5d, 0xdf, 0x13, 0x88, 0x40,
 ]);
 
-#[gatt_server(mutex_type = NoopRawMutex, attribute_data_size = 10, mtu = 27)]
+#[gatt_server(mutex_type = NoopRawMutex, attribute_table_size = 10, mtu = 27)]
 struct Server {
     service: CustomService,
 }


### PR DESCRIPTION
Closes #173.

This PR implements automatic sizing of the attribute table when using the `gatt_server` macro.
The number of attributes for each service is calculated in the `gatt_service` macro, and this is then summed up by the `gatt_server` macro to determine the size of the table.
The option to override this and manually set the attribute table size still exists.
I have also renamed the attribute macro argument to `attribute_table_size` as this more accurately reflects the value being set.

## Topic for discussion
I have implemented a static assertion to throw a compile-time error if the table size is overridden with a value too small to hold the calculated number of attributes. The advantage of this is of course that the user will be notified before flashing their device, meaning that they do not need to be monitoring the device's trace to see the issue.
However, I cannot use formatted strings in a "constant assertion", so the compile-time error looks like this:
```
error[E0080]: evaluation of constant value failed
  --> src/ble_bas_peripheral.rs:22:1
   |
22 | #[gatt_server(attribute_table_size = 9)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Specified attribute table size is insufficient. Please increase attribute_table_size or remove the argument entirely to allow automatic sizing of the attribute table.', src/ble_bas_peripheral.rs:22:1
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::assert` (in Nightly builds, run with -Z macro-backtrace for more info)
```

The alternative would be to use a normal `assert!` which would be evaluated at run-time. This would allow a formatted message of something like:
```
====================== PANIC ======================
panicked at /home/pkubiak/repos/trouble/examples/apps/src/ble_bas_peripheral.rs:22:1:
Specified attribute table size of 9 is insufficient. A table size of at least 10 is required for the current GATT server configuration.
```
but of course this would only be visible in the device's trace.

I personally lean toward the static assertion, but I'd be keen to hear other opinions on this!