### PR TITLE
use bt_hci BluetoothUuid16

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -58,7 +58,7 @@ where
         stack,
         GapConfig::Peripheral(PeripheralConfig {
             name: "TrouBLE",
-            appearance: &appearance::GENERIC_POWER,
+            appearance: &appearance::power_device::GENERIC_POWER_DEVICE,
         }),
     )
     .unwrap();

--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -62,9 +62,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bt-hci"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a6508c63d7d137e8188833d9ed3ca97e40d676cf5217874c8c1c24851b012d"
+checksum = "d69e2db053409c36c45a403da58072b8bf75bdc962746c0a12df9dec0fce92d2"
 dependencies = [
  "embassy-sync 0.6.0",
  "embassy-time",
@@ -73,6 +73,7 @@ dependencies = [
  "futures-intrusive",
  "heapless",
  "log",
+ "uuid",
 ]
 
 [[package]]

--- a/examples/nrf-sdc/Cargo.lock
+++ b/examples/nrf-sdc/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bt-hci"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a6508c63d7d137e8188833d9ed3ca97e40d676cf5217874c8c1c24851b012d"
+checksum = "d69e2db053409c36c45a403da58072b8bf75bdc962746c0a12df9dec0fce92d2"
 dependencies = [
  "defmt",
  "embassy-sync",
@@ -93,6 +93,7 @@ dependencies = [
  "embedded-io-async",
  "futures-intrusive",
  "heapless",
+ "uuid",
 ]
 
 [[package]]

--- a/examples/rp-pico-w/Cargo.lock
+++ b/examples/rp-pico-w/Cargo.lock
@@ -143,9 +143,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bt-hci"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a6508c63d7d137e8188833d9ed3ca97e40d676cf5217874c8c1c24851b012d"
+checksum = "d69e2db053409c36c45a403da58072b8bf75bdc962746c0a12df9dec0fce92d2"
 dependencies = [
  "defmt",
  "embassy-sync",
@@ -154,6 +154,7 @@ dependencies = [
  "embedded-io-async",
  "futures-intrusive",
  "heapless",
+ "uuid",
 ]
 
 [[package]]

--- a/examples/serial-hci/Cargo.lock
+++ b/examples/serial-hci/Cargo.lock
@@ -71,9 +71,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bt-hci"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a6508c63d7d137e8188833d9ed3ca97e40d676cf5217874c8c1c24851b012d"
+checksum = "d69e2db053409c36c45a403da58072b8bf75bdc962746c0a12df9dec0fce92d2"
 dependencies = [
  "embassy-sync",
  "embassy-time",
@@ -82,6 +82,7 @@ dependencies = [
  "futures-intrusive",
  "heapless",
  "log",
+ "uuid",
 ]
 
 [[package]]

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 resolver = "2"
 
 [dependencies]
-bt-hci = { version = "0.1.1", features = ["embassy-time"] }
+bt-hci = { version = "0.1.2", features = ["embassy-time", "uuid"] }
 embedded-io-async = { version = "0.6" }
 embedded-io = { version = "0.6" }
 embassy-sync = "0.6"

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -3,6 +3,8 @@ use core::cell::RefCell;
 use core::fmt;
 use core::marker::PhantomData;
 
+use bt_hci::uuid::declarations::{CHARACTERISTIC, PRIMARY_SERVICE};
+use bt_hci::uuid::descriptors::CLIENT_CHARACTERISTIC_CONFIGURATION;
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_sync::blocking_mutex::Mutex;
 
@@ -12,36 +14,6 @@ use crate::prelude::Connection;
 use crate::types::gatt_traits::GattValue;
 pub use crate::types::uuid::Uuid;
 use crate::Error;
-
-/// UUID for generic access service
-pub const GENERIC_ACCESS_SERVICE_UUID16: Uuid = Uuid::Uuid16(0x1800u16.to_le_bytes());
-
-/// UUID for device name characteristic
-pub const CHARACTERISTIC_DEVICE_NAME_UUID16: Uuid = Uuid::Uuid16(0x2A00u16.to_le_bytes());
-
-/// UUID for appearance characteristic
-pub const CHARACTERISTIC_APPEARANCE_UUID16: Uuid = Uuid::Uuid16(0x2A03u16.to_le_bytes());
-
-/// UUID for generic attribute service
-pub const GENERIC_ATTRIBUTE_SERVICE_UUID16: Uuid = Uuid::Uuid16(0x1801u16.to_le_bytes());
-
-/// UUID for primary service
-pub const PRIMARY_SERVICE_UUID16: Uuid = Uuid::Uuid16(0x2800u16.to_le_bytes());
-
-/// UUID for secondary service
-pub const SECONDARY_SERVICE_UUID16: Uuid = Uuid::Uuid16(0x2801u16.to_le_bytes());
-
-/// UUID for include service
-pub const INCLUDE_SERVICE_UUID16: Uuid = Uuid::Uuid16(0x2802u16.to_le_bytes());
-
-/// UUID for characteristic declaration
-pub const CHARACTERISTIC_UUID16: Uuid = Uuid::Uuid16(0x2803u16.to_le_bytes());
-
-/// UUID for characteristic notification/indication
-pub const CHARACTERISTIC_CCCD_UUID16: Uuid = Uuid::Uuid16(0x2902u16.to_le_bytes());
-
-/// UUID for generic attribute.
-pub const GENERIC_ATTRIBUTE_UUID16: Uuid = Uuid::Uuid16(0x1801u16.to_le_bytes());
 
 /// Characteristic properties
 #[derive(Debug, Clone, Copy)]
@@ -396,7 +368,7 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
         let len = self.inner.lock(|i| i.borrow().len);
         let handle = self.handle;
         self.push(Attribute {
-            uuid: PRIMARY_SERVICE_UUID16,
+            uuid: PRIMARY_SERVICE.into(),
             handle: 0,
             last_handle_in_group: 0,
             data: AttributeData::Service { uuid: service.uuid },
@@ -548,7 +520,7 @@ impl<'r, 'd, M: RawMutex, const MAX: usize> ServiceBuilder<'r, 'd, M, MAX> {
         let next = self.table.handle + 1;
         let cccd = self.table.handle + 2;
         self.table.push(Attribute {
-            uuid: CHARACTERISTIC_UUID16,
+            uuid: CHARACTERISTIC.into(),
             handle: 0,
             last_handle_in_group: 0,
             data: AttributeData::Declaration {
@@ -573,7 +545,7 @@ impl<'r, 'd, M: RawMutex, const MAX: usize> ServiceBuilder<'r, 'd, M, MAX> {
         // Add optional CCCD handle
         let cccd_handle = if props.any(&[CharacteristicProp::Notify, CharacteristicProp::Indicate]) {
             self.table.push(Attribute {
-                uuid: CHARACTERISTIC_CCCD_UUID16,
+                uuid: CLIENT_CHARACTERISTIC_CONFIGURATION.into(),
                 handle: 0,
                 last_handle_in_group: 0,
                 data: AttributeData::Cccd {

--- a/host/src/gap.rs
+++ b/host/src/gap.rs
@@ -13,14 +13,6 @@ use static_cell::StaticCell;
 
 use crate::prelude::*;
 
-// GAP Service UUIDs
-const GAP_UUID: u16 = 0x1800;
-const GATT_UUID: u16 = 0x1801;
-
-// GAP Characteristic UUIDs
-const DEVICE_NAME_UUID: u16 = 0x2a00;
-const APPEARANCE_UUID: u16 = 0x2a01;
-
 /// Advertising packet is limited to 31 bytes. 9 of these are used by other GAP data, leaving 22 bytes for the Device Name characteristic
 const DEVICE_NAME_MAX_LENGTH: usize = 22;
 
@@ -32,47 +24,6 @@ const DEVICE_NAME_MAX_LENGTH: usize = 22;
 ///                  ---
 ///                  = 6
 pub const GAP_SERVICE_ATTRIBUTE_COUNT: usize = 6;
-
-pub mod appearance {
-    //! The representation of the external appearance of the device.
-    //!
-    //! This is a list of some of the most common appearance values and demonstrates the pattern to use to define new appearance values.
-    //!
-    //! https://www.bluetooth.com/wp-content/uploads/Files/Specification/Assigned_Numbers.html#bookmark49
-
-    // TODO: Perhaps this should be it's own crate in future?
-
-    /// Construct a new appearance value for the GAP Service.
-    ///
-    /// Follow the pattern of the examples below to create new appearance values.
-    /// Use UUIDs from the [Bluetooth Assigned Numbers list](https://www.bluetooth.com/wp-content/uploads/Files/Specification/Assigned_Numbers.html#bookmark49).
-    ///
-    /// ## Example
-    ///
-    /// ```rust
-    /// use trouble_host::prelude::*;
-    ///
-    /// const GAMEPAD: &[u8; 2] = &appearance::new(0x00F, 0x040);
-    /// ```
-    pub const fn new(category: u8, subcategory: u8) -> [u8; 2] {
-        (((category as u16) << 6) | (subcategory as u16)).to_le_bytes()
-    }
-
-    /// Generic Unknown device appearance.
-    pub const GENERIC_UNKNOWN: [u8; 2] = new(0x000, 0x000);
-    /// Generic Phone device appearance.
-    pub const GENERIC_PHONE: [u8; 2] = new(0x001, 0x000);
-    /// Generic Computer device appearance.
-    pub const GENERIC_COMPUTER: [u8; 2] = new(0x002, 0x000);
-    /// Smart Watch device appearance.
-    pub const SMART_WATCH: [u8; 2] = new(0x003, 0x020);
-    /// Generic Power device appearance.
-    pub const GENERIC_POWER: [u8; 2] = new(0x01E, 0x000);
-    /// Generic Sensor device appearance.
-    pub const GENERIC_SENSOR: [u8; 2] = new(0x015, 0x000);
-    /// Gamepad device appearance.
-    pub const GAMEPAD: [u8; 2] = new(0x00F, 0x040);
-}
 
 /// Configuration for the GAP Service.
 pub enum GapConfig<'a> {
@@ -88,8 +39,8 @@ pub struct PeripheralConfig<'a> {
     pub name: &'a str,
     /// The representation of the external appearance of the device.
     ///
-    /// /// Example: `&appearance::GENERIC_SENSOR`
-    pub appearance: &'a [u8; 2],
+    /// Example: `&appearance::sensor::GENERIC_SENSOR.`
+    pub appearance: &'a BluetoothUuid16,
     // TODO: Add more GAP parameters
     // pub preferred_connection_parameters: Option<ConnectionParameters>,
 }
@@ -100,19 +51,19 @@ pub struct CentralConfig<'a> {
     pub name: &'a str,
     /// The representation of the external appearance of the device.
     ///
-    /// Example: `&appearance::GENERIC_SENSOR`
-    pub appearance: &'a [u8; 2],
+    /// Example: `&appearance::sensor::GENERIC_SENSOR`
+    pub appearance: &'a BluetoothUuid16,
     // TODO: Add more GAP parameters
 }
 
 impl<'a> GapConfig<'a> {
     /// Create a default peripheral configuration.
     ///
-    /// This configuration will use the `GENERIC_UNKNOWN` appearance.
+    /// This configuration will use the `UNKNOWN` appearance.
     pub fn default(name: &'a str) -> Self {
         GapConfig::Peripheral(PeripheralConfig {
             name,
-            appearance: &appearance::GENERIC_UNKNOWN,
+            appearance: &appearance::UNKNOWN,
         })
     }
 
@@ -137,12 +88,12 @@ impl<'a> PeripheralConfig<'a> {
             .push_str(self.name)
             .map_err(|_| "Device name is too long. Max length is 22 bytes")?;
 
-        let mut gap_builder = table.add_service(Service::new(GAP_UUID));
-        gap_builder.add_characteristic_ro(DEVICE_NAME_UUID, peripheral_name);
-        gap_builder.add_characteristic_ro(APPEARANCE_UUID, self.appearance);
+        let mut gap_builder = table.add_service(Service::new(service::GAP));
+        gap_builder.add_characteristic_ro(characteristic::DEVICE_NAME, peripheral_name);
+        gap_builder.add_characteristic_ro(characteristic::APPEARANCE, self.appearance);
         gap_builder.build();
 
-        table.add_service(Service::new(GATT_UUID));
+        table.add_service(Service::new(service::GATT));
 
         Ok(())
     }
@@ -157,12 +108,12 @@ impl<'a> CentralConfig<'a> {
             .push_str(self.name)
             .map_err(|_| "Device name is too long. Max length is 22 bytes")?;
 
-        let mut gap_builder = table.add_service(Service::new(GAP_UUID));
-        gap_builder.add_characteristic_ro(DEVICE_NAME_UUID, central_name);
-        gap_builder.add_characteristic_ro(APPEARANCE_UUID, self.appearance);
+        let mut gap_builder = table.add_service(Service::new(service::GAP));
+        gap_builder.add_characteristic_ro(characteristic::DEVICE_NAME, central_name);
+        gap_builder.add_characteristic_ro(characteristic::APPEARANCE, self.appearance);
         gap_builder.build();
 
-        table.add_service(Service::new(GATT_UUID));
+        table.add_service(Service::new(service::GATT));
 
         Ok(())
     }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -5,16 +5,15 @@ use core::marker::PhantomData;
 
 use bt_hci::controller::Controller;
 use bt_hci::param::ConnHandle;
+use bt_hci::uuid::declarations::{CHARACTERISTIC, PRIMARY_SERVICE};
+use bt_hci::uuid::descriptors::CLIENT_CHARACTERISTIC_CONFIGURATION;
 use embassy_sync::blocking_mutex::raw::{NoopRawMutex, RawMutex};
 use embassy_sync::channel::{Channel, DynamicReceiver, DynamicSender};
 use embassy_sync::pubsub::{self, PubSubChannel, WaitResult};
 use heapless::Vec;
 
 use crate::att::{self, AttReq, AttRsp, ATT_HANDLE_VALUE_NTF};
-use crate::attribute::{
-    AttributeData, AttributeTable, Characteristic, CharacteristicProp, Uuid, CCCD, CHARACTERISTIC_CCCD_UUID16,
-    CHARACTERISTIC_UUID16, PRIMARY_SERVICE_UUID16,
-};
+use crate::attribute::{AttributeData, AttributeTable, Characteristic, CharacteristicProp, Uuid, CCCD};
 use crate::attribute_server::AttributeServer;
 use crate::connection::{Connection, ConnectionEvent};
 use crate::connection_manager::ConnectionManager;
@@ -300,7 +299,7 @@ impl<'reference, C: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
             let data = att::AttReq::FindByTypeValue {
                 start_handle: start,
                 end_handle: 0xffff,
-                att_type: PRIMARY_SERVICE_UUID16.as_short(),
+                att_type: PRIMARY_SERVICE.into(),
                 att_value: uuid.as_raw(),
             };
 
@@ -353,7 +352,7 @@ impl<'reference, C: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
             let data = att::AttReq::ReadByType {
                 start,
                 end: service.end,
-                attribute_type: CHARACTERISTIC_UUID16,
+                attribute_type: CHARACTERISTIC.into(),
             };
             let pdu = self.request(data).await?;
 
@@ -406,7 +405,7 @@ impl<'reference, C: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
         let data = att::AttReq::ReadByType {
             start: char_handle,
             end: char_handle + 1,
-            attribute_type: CHARACTERISTIC_CCCD_UUID16,
+            attribute_type: CLIENT_CHARACTERISTIC_CONFIGURATION.into(),
         };
 
         let pdu = self.request(data).await?;

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -60,37 +60,35 @@ pub use peripheral::*;
 
 #[allow(missing_docs)]
 pub mod prelude {
-    pub use super::att::AttErrorCode;
-    pub use super::{BleHostError, Controller, Error, HostResources, Stack};
-    pub use crate::connection::*;
-    pub use crate::host::{ControlRunner, HostMetrics, Runner, RxRunner, TxRunner};
-    pub use crate::l2cap::*;
-    pub use crate::packet_pool::{PacketPool, Qos as PacketQos};
-    pub use crate::Address;
-
+    pub use bt_hci::uuid::*;
     #[cfg(feature = "derive")]
     pub use heapless::String as HeaplessString;
     #[cfg(feature = "derive")]
     pub use trouble_host_macros::*;
 
+    pub use super::att::AttErrorCode;
+    pub use super::{BleHostError, Controller, Error, HostResources, Stack};
+    #[cfg(feature = "peripheral")]
+    pub use crate::advertise::*;
     #[cfg(feature = "gatt")]
     pub use crate::attribute::*;
+    #[cfg(feature = "central")]
+    pub use crate::central::*;
+    pub use crate::connection::*;
     #[cfg(feature = "gatt")]
     pub use crate::gap::*;
     #[cfg(feature = "gatt")]
     pub use crate::gatt::*;
-    #[cfg(feature = "gatt")]
-    pub use crate::types::gatt_traits::{FixedGattValue, GattValue};
-
-    #[cfg(feature = "central")]
-    pub use crate::central::*;
-
-    #[cfg(feature = "peripheral")]
-    pub use crate::advertise::*;
+    pub use crate::host::{ControlRunner, HostMetrics, Runner, RxRunner, TxRunner};
+    pub use crate::l2cap::*;
+    pub use crate::packet_pool::{PacketPool, Qos as PacketQos};
     #[cfg(feature = "peripheral")]
     pub use crate::peripheral::*;
     #[cfg(feature = "peripheral")]
     pub use crate::scan::*;
+    #[cfg(feature = "gatt")]
+    pub use crate::types::gatt_traits::{FixedGattValue, GattValue};
+    pub use crate::Address;
 }
 
 #[cfg(feature = "gatt")]

--- a/host/src/types/gatt_traits.rs
+++ b/host/src/types/gatt_traits.rs
@@ -1,5 +1,6 @@
 use core::{mem, slice};
 
+use bt_hci::uuid::BluetoothUuid16;
 use heapless::{String, Vec};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -66,6 +67,7 @@ impl Primitive for i32 {}
 impl Primitive for i64 {}
 impl Primitive for f32 {}
 impl Primitive for f64 {}
+impl Primitive for BluetoothUuid16 {} // ok as this is just a NewType(u16)
 
 impl<T: Primitive> FixedGattValue for T {
     const SIZE: usize = mem::size_of::<Self>();

--- a/host/src/types/uuid.rs
+++ b/host/src/types/uuid.rs
@@ -1,4 +1,6 @@
 //! UUID types.
+use bt_hci::uuid::BluetoothUuid16;
+
 use crate::codec::{Decode, Encode, Error, Type};
 
 /// A 16-bit or 128-bit UUID.
@@ -9,6 +11,12 @@ pub enum Uuid {
     Uuid16([u8; 2]),
     /// 128-bit UUID
     Uuid128([u8; 16]),
+}
+
+impl From<BluetoothUuid16> for Uuid {
+    fn from(val: bt_hci::uuid::BluetoothUuid16) -> Self {
+        Uuid::Uuid16(val.into())
+    }
 }
 
 impl Uuid {

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -69,7 +69,7 @@ async fn gatt_client_server() {
             .build();
         let gap = GapConfig::Peripheral(PeripheralConfig {
             name: &name,
-            appearance: &appearance::GENERIC_POWER,
+            appearance: &appearance::power_device::GENERIC_POWER_DEVICE,
         });
         let server: Server<common::Controller> = Server::new_with_config(
             stack,


### PR DESCRIPTION
I've brought in the BluetoothUuid16 NewType from bt_hci and made the constant UUIDs available through trouble_host::prelude.  I guess there is an open question on whether to unify the trouble_host::Uuid with this further or not?