### PR TITLE
Fix cyw43 firmware download base url

### DIFF
--- a/examples/rp-pico-w/build.rs
+++ b/examples/rp-pico-w/build.rs
@@ -41,7 +41,7 @@ fn main() {
 #[cfg(not(feature = "skip-cyw43-firmware"))]
 fn download_cyw43_firmware() {
     let download_folder = "cyw43-firmware";
-    let url_base = "https://github.com/embassy-rs/embassy/tree/main/cyw43-firmware";
+    let url_base = "https://github.com/embassy-rs/embassy/raw/refs/heads/main/cyw43-firmware";
     let file_names = [
         "43439A0.bin",
         "43439A0_btfw.bin",


### PR DESCRIPTION
Use the `raw/refs/heads` url so that the actual firmware binaries are downloaded and not the GitHub HTML pages.  

Fixes #182