### PR TITLE
Avoid sending advertise cancel if not necessary

### DIFF
--- a/examples/apps/src/ble_advertise_multiple.rs
+++ b/examples/apps/src/ble_advertise_multiple.rs
@@ -86,7 +86,7 @@ where
     let _ = join(runner.run(), async {
         loop {
             let start = Instant::now();
-            let mut advertiser = peripheral.advertise_ext(&sets, &mut handles).await.unwrap();
+            let advertiser = peripheral.advertise_ext(&sets, &mut handles).await.unwrap();
             match advertiser.accept().await {
                 Ok(_) => {}
                 Err(trouble_host::Error::Timeout) => {

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -100,13 +100,25 @@ where
 ///
 /// spawner.must_spawn(ble_task(runner));
 /// ```
-async fn ble_task<C: Controller>(mut runner: Runner<'_, C>) -> Result<(), BleHostError<C::Error>> {
-    runner.run().await
+async fn ble_task<C: Controller>(mut runner: Runner<'_, C>) {
+    loop {
+        if let Err(e) = runner.run().await {
+            #[cfg(feature = "defmt")]
+            let e = defmt::Debug2Format(&e);
+            panic!("[ble_task] error: {:?}", e);
+        }
+    }
 }
 
 /// Run the Gatt Server.
-async fn gatt_task<C: Controller>(server: &Server<'_, '_, C>) -> Result<(), BleHostError<C::Error>> {
-    server.run().await
+async fn gatt_task<C: Controller>(server: &Server<'_, '_, C>) {
+    loop {
+        if let Err(e) = server.run().await {
+            #[cfg(feature = "defmt")]
+            let e = defmt::Debug2Format(&e);
+            panic!("[gatt_task] error: {:?}", e);
+        }
+    }
 }
 
 /// Stream Events until the connection closes.

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -155,7 +155,7 @@ async fn advertise<'a, C: Controller>(
         ],
         &mut advertiser_data[..],
     )?;
-    let mut advertiser = peripheral
+    let advertiser = peripheral
         .advertise(
             &Default::default(),
             Advertisement::ConnectableScannableUndirected {

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -45,7 +45,7 @@ where
     let _ = join(runner.run(), async {
         loop {
             info!("Advertising, waiting for connection...");
-            let mut advertiser = peripheral
+            let advertiser = peripheral
                 .advertise(
                     &Default::default(),
                     Advertisement::ConnectableScannableUndirected {


### PR DESCRIPTION
Sending advertise cancel command if a connection was accepted should not be necessary, but nrf silently accepts, whereas rpi pico w will fail.

Fixes #188 