### PR TITLE
Add support for using server and client concurrently

### DIFF
--- a/host/src/cursor.rs
+++ b/host/src/cursor.rs
@@ -109,6 +109,8 @@ impl<'d> WriteCursor<'d> {
 }
 
 #[derive(Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug)]
 pub struct ReadCursor<'d> {
     pos: usize,
     data: &'d [u8],


### PR DESCRIPTION
Enable support for using GATT server and client at the same time by using separate data paths for inbound attribute data.