### PR TITLE
Perform l2cap fragmentation at lower layer

### DIFF
--- a/host/src/pdu.rs
+++ b/host/src/pdu.rs
@@ -3,20 +3,11 @@ use crate::packet_pool::Packet;
 pub(crate) struct Pdu<'d> {
     pub packet: Packet<'d>,
     pub len: usize,
-    pub first: bool,
 }
 
 impl<'d> Pdu<'d> {
     pub(crate) fn new(packet: Packet<'d>, len: usize) -> Self {
-        Self {
-            packet,
-            len,
-            first: true,
-        }
-    }
-
-    pub(crate) fn segment(self) -> Self {
-        Self { first: false, ..self }
+        Self { packet, len }
     }
 }
 

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -57,7 +57,7 @@ async fn gatt_client_server() {
                 &mut value
             ).build();
 
-        let server = GattServer::<NoopRawMutex, 10, 27>::new(stack, table);
+        let server = GattServer::<NoopRawMutex, 10>::new(stack, table);
         select! {
             r = runner.run() => {
                 r

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -18,7 +18,7 @@ const VALUE_UUID: Uuid = Uuid::new_long([
     0x00, 0x00, 0x10, 0x01, 0xb0, 0xcd, 0x11, 0xec, 0x87, 0x1f, 0xd4, 0x5d, 0xdf, 0x13, 0x88, 0x40,
 ]);
 
-#[gatt_server(mutex_type = NoopRawMutex, attribute_table_size = 10, mtu = 27)]
+#[gatt_server(mutex_type = NoopRawMutex, attribute_table_size = 10)]
 struct Server {
     service: CustomService,
 }


### PR DESCRIPTION
* Att mtu is anyway bounded by l2cap mtu, use the pool mtu - 3 (att overhead) as guidance.
* Remove mtu parameter from macros and const generics now that it is no longer needed.