### PR TITLE
Add more esp32 examples

### DIFF
--- a/examples/apps/Cargo.toml
+++ b/examples/apps/Cargo.toml
@@ -28,6 +28,7 @@ defmt = [
     "embedded-io/defmt-03",
     "embedded-hal/defmt-03"
 ]
+esp = []
 log = [
     "dep:log",
     "trouble-host/log",

--- a/examples/apps/src/ble_bas_central.rs
+++ b/examples/apps/src/ble_bas_central.rs
@@ -3,7 +3,11 @@ use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
 /// Size of L2CAP packets
+#[cfg(not(feature = "esp"))]
 const L2CAP_MTU: usize = 128;
+#[cfg(feature = "esp")]
+// Some esp chips only accept an MTU >= 1017
+const L2CAP_MTU: usize = 1017;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;

--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -9,7 +9,11 @@ const L2CAP_TXQ: u8 = 20;
 const L2CAP_RXQ: u8 = 20;
 
 /// Size of L2CAP packets
-const L2CAP_MTU: usize = 27;
+#[cfg(not(feature = "esp"))]
+const L2CAP_MTU: usize = 128;
+#[cfg(feature = "esp")]
+// Some esp chips only accept an MTU >= 1017
+const L2CAP_MTU: usize = 1017;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -9,7 +9,11 @@ const L2CAP_TXQ: u8 = 20;
 const L2CAP_RXQ: u8 = 20;
 
 /// Size of L2CAP packets
-const L2CAP_MTU: usize = 27;
+#[cfg(not(feature = "esp"))]
+const L2CAP_MTU: usize = 128;
+#[cfg(feature = "esp")]
+// Some esp chips only accept an MTU >= 1017
+const L2CAP_MTU: usize = 1017;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;

--- a/examples/esp32/.cargo/config.toml
+++ b/examples/esp32/.cargo/config.toml
@@ -6,7 +6,7 @@ esp32c6 = "run --release --no-default-features --features=esp32c6 --target=riscv
 esp32h2 = "run --release --no-default-features --features=esp32h2 --target=riscv32imac-unknown-none-elf"
 esp32s3 = "run --release --no-default-features --features=esp32s3 --target=xtensa-esp32s3-none-elf"
 
-[target.'cfg(all(any(target_arch = "riscv32imc", target_arch = "riscv32imac", target_arch = "xtensa"), target_os = "none"))']
+[target.'cfg(all(any(target_arch = "riscv32", target_arch = "xtensa"), target_os = "none"))']
 runner = "espflash flash --monitor"
 
 [build]

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -21,7 +21,7 @@ esp-wifi = { version = "0.10.1", features = [
     "ble",
 ] }
 heapless = { version = "0.8.0", default-features = false }
-trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["log"] }
+trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["esp", "log"] }
 bt-hci = { version = "0.1.1" }
 embassy-futures = "0.1.1"
 embassy-time = { version = "0.3", features = ["generic-queue-8"] }

--- a/examples/esp32/src/bin/ble_bas_central.rs
+++ b/examples/esp32/src/bin/ble_bas_central.rs
@@ -1,0 +1,46 @@
+#![no_std]
+#![no_main]
+
+use bt_hci::controller::ExternalController;
+use embassy_executor::Spawner;
+use esp_hal::prelude::*;
+use esp_hal::timer::timg::TimerGroup;
+use esp_wifi::ble::controller::BleConnector;
+use trouble_example_apps::ble_bas_central;
+use {esp_alloc as _, esp_backtrace as _};
+
+#[esp_hal_embassy::main]
+async fn main(_s: Spawner) {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
+    esp_alloc::heap_allocator!(72 * 1024);
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    let init = esp_wifi::init(
+        timg0.timer0,
+        esp_hal::rng::Rng::new(peripherals.RNG),
+        peripherals.RADIO_CLK,
+    )
+    .unwrap();
+
+    #[cfg(not(feature = "esp32"))]
+    {
+        let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
+            .split::<esp_hal::timer::systimer::Target>();
+        esp_hal_embassy::init(systimer.alarm0);
+    }
+    #[cfg(feature = "esp32")]
+    {
+        esp_hal_embassy::init(timg0.timer1);
+    }
+
+    let bluetooth = peripherals.BT;
+    let connector = BleConnector::new(&init, bluetooth);
+    let controller: ExternalController<_, 20> = ExternalController::new(connector);
+
+    ble_bas_central::run(controller).await;
+}

--- a/examples/esp32/src/bin/ble_l2cap_central.rs
+++ b/examples/esp32/src/bin/ble_l2cap_central.rs
@@ -1,0 +1,46 @@
+#![no_std]
+#![no_main]
+
+use bt_hci::controller::ExternalController;
+use embassy_executor::Spawner;
+use esp_hal::prelude::*;
+use esp_hal::timer::timg::TimerGroup;
+use esp_wifi::ble::controller::BleConnector;
+use trouble_example_apps::ble_l2cap_central;
+use {esp_alloc as _, esp_backtrace as _};
+
+#[esp_hal_embassy::main]
+async fn main(_s: Spawner) {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
+    esp_alloc::heap_allocator!(72 * 1024);
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    let init = esp_wifi::init(
+        timg0.timer0,
+        esp_hal::rng::Rng::new(peripherals.RNG),
+        peripherals.RADIO_CLK,
+    )
+    .unwrap();
+
+    #[cfg(not(feature = "esp32"))]
+    {
+        let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
+            .split::<esp_hal::timer::systimer::Target>();
+        esp_hal_embassy::init(systimer.alarm0);
+    }
+    #[cfg(feature = "esp32")]
+    {
+        esp_hal_embassy::init(timg0.timer1);
+    }
+
+    let bluetooth = peripherals.BT;
+    let connector = BleConnector::new(&init, bluetooth);
+    let controller: ExternalController<_, 20> = ExternalController::new(connector);
+
+    ble_l2cap_central::run(controller).await;
+}

--- a/examples/esp32/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/esp32/src/bin/ble_l2cap_peripheral.rs
@@ -1,0 +1,46 @@
+#![no_std]
+#![no_main]
+
+use bt_hci::controller::ExternalController;
+use embassy_executor::Spawner;
+use esp_hal::prelude::*;
+use esp_hal::timer::timg::TimerGroup;
+use esp_wifi::ble::controller::BleConnector;
+use trouble_example_apps::ble_l2cap_peripheral;
+use {esp_alloc as _, esp_backtrace as _};
+
+#[esp_hal_embassy::main]
+async fn main(_s: Spawner) {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init({
+        let mut config = esp_hal::Config::default();
+        config.cpu_clock = CpuClock::max();
+        config
+    });
+    esp_alloc::heap_allocator!(72 * 1024);
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    let init = esp_wifi::init(
+        timg0.timer0,
+        esp_hal::rng::Rng::new(peripherals.RNG),
+        peripherals.RADIO_CLK,
+    )
+    .unwrap();
+
+    #[cfg(not(feature = "esp32"))]
+    {
+        let systimer = esp_hal::timer::systimer::SystemTimer::new(peripherals.SYSTIMER)
+            .split::<esp_hal::timer::systimer::Target>();
+        esp_hal_embassy::init(systimer.alarm0);
+    }
+    #[cfg(feature = "esp32")]
+    {
+        esp_hal_embassy::init(timg0.timer1);
+    }
+
+    let bluetooth = peripherals.BT;
+    let connector = BleConnector::new(&init, bluetooth);
+    let controller: ExternalController<_, 20> = ExternalController::new(connector);
+
+    ble_l2cap_peripheral::run(controller).await;
+}


### PR DESCRIPTION
This PR adds more examples for the esp32 platform.

It introduces an optional `esp32` feature to the `examples/apps` crate that influences the hardcoded L2CAP MTU and is intended to be set by the esp32 examples only. The current MTU of `128` causes a `BleHost(Hci(Unsupported Feature or Parameter Value))` error here when using an esp: https://github.com/embassy-rs/trouble/blob/aaf2d02b09bc4ecdc4cd3a820cf9e268500b5082/host/src/host.rs#L813-L820
This is a known limitation, as seen in an issue comment over at the esp-idf repo https://github.com/espressif/esp-idf/issues/942#issuecomment-336809446. They wrote that any total host buffer size <= 1021 bytes aren't safe to use (1017 bytes ACL MTU + 4 bytes ACL Data Packet header) as long as ACL packet segmentation isn't implemented, so I've set the MTU to 1017 if the `esp` feature is activated.
I tested my changes with an ESP32C3 and ESP32S3 and in both cases I was able to use a lower MTU than 1017 but it still failed at 128 (200 failed too, 512 not)