### PR TITLE
Split event into event and reply

### DIFF
--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -97,7 +97,7 @@ async fn gatt_client_server() {
                                 if let Ok(Some(GattEvent::Write(event))) = data.process(&server).await {
                                     let characteristic = server.table().find_characteristic_by_value_handle(event.handle()).unwrap();
                                     assert_eq!(characteristic.handle, event.handle());
-                                    event.reply(Ok(())).await.unwrap();
+                                    event.accept().unwrap().send().await;
 
                                     let value: u8 = server.table().get(&characteristic).unwrap();
                                     println!("[peripheral] write value: {}", value);

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -110,7 +110,7 @@ async fn gatt_client_server() {
                             }
                             ConnectionEvent::Gatt { data } => if let Ok(Some(GattEvent::Write(event))) = data.process(&server).await {
                                 if writes == 0 {
-                                    event.reply(Err(AttErrorCode::ValueNotAllowed)).await.unwrap();
+                                    event.reject(AttErrorCode::ValueNotAllowed).unwrap().send().await;
                                     writes += 1;
                                 } else {
                                     let characteristic = server.table().find_characteristic_by_value_handle(event.handle()).unwrap();


### PR DESCRIPTION
Splitting allows a cleaner API for accepting or rejecting an event,
and for sending the reply at a later point.
