### PR TITLE
Hil tests for examples

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           gh api --method POST -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" /repos/embassy-rs/trouble/statuses/${COMMIT} \
-            -f "state=pending" -f "description=Running tests" -f "context=tests"
+            -f "state=pending" -f "description=Running integration tests" -f "context=integration-tests"
       - name: Test
         env:
           TEST_ADAPTER_ONE: /dev/ttyACM0
@@ -43,7 +43,7 @@ jobs:
         run: |
           gh api --method POST -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" /repos/embassy-rs/trouble/statuses/${COMMIT} \
-            -f "state=failure" -f "description=The build failed" -f "context=tests"
+            -f "state=failure" -f "description=The integration tests failed" -f "context=integration-tests"
       - name: Update success status
         if: success()
         env:
@@ -52,4 +52,54 @@ jobs:
         run: |
           gh api --method POST -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" /repos/embassy-rs/trouble/statuses/${COMMIT} \
-            -f "state=success" -f "description=The build succeeded!" -f "context=tests"
+            -f "state=success" -f "description=The integration tests succeeded!" -f "context=integration-tests"
+
+  example-tests:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout
+        id: checkout
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr checkout "${{ github.event.inputs.prNr }}"
+          echo "commit=$(git rev-parse --verify HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Set pending
+        env:
+          COMMIT: ${{ steps.checkout.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method POST -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" /repos/embassy-rs/trouble/statuses/${COMMIT} \
+            -f "state=pending" -f "description=Running example tests" -f "context=example-tests"
+      - name: Build
+        run: |
+          cd examples/nrf-sdc
+          CARGO_TARGET_DIR=../tests cargo build --release --bins
+      - name: Test
+        env:
+          TEST_ADAPTER_ONE: /dev/ttyACM0
+          PROBE_CONFIG: ${{ secrets.PROBE_CONFIG }}
+          RUST_LOG: info
+        run: |
+          cd examples/tests
+          cargo test -- --nocapture
+      - name: Update failed status
+        if: failure()
+        env:
+          COMMIT: ${{ steps.checkout.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method POST -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" /repos/embassy-rs/trouble/statuses/${COMMIT} \
+            -f "state=failure" -f "description=The example tests failed" -f "context=example-tests"
+      - name: Update success status
+        if: success()
+        env:
+          COMMIT: ${{ steps.checkout.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method POST -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" /repos/embassy-rs/trouble/statuses/${COMMIT} \
+            -f "state=success" -f "description=The example tests succeeded!" -f "context=example-tests"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,8 +29,6 @@ jobs:
             -f "state=pending" -f "description=Running integration tests" -f "context=integration-tests"
       - name: Test
         env:
-          TEST_ADAPTER_ONE: /dev/ttyACM0
-          TEST_ADAPTER_TWO: /dev/ttyACM1
           RUST_LOG: trace
         run: |
           cd host
@@ -79,7 +77,6 @@ jobs:
           CARGO_TARGET_DIR=../tests cargo build --release --bins
       - name: Test
         env:
-          TEST_ADAPTER_ONE: /dev/ttyACM0
           PROBE_CONFIG: ${{ secrets.PROBE_CONFIG }}
           RUST_LOG: info
         run: |

--- a/ci.sh
+++ b/ci.sh
@@ -24,6 +24,7 @@ cargo batch \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,central \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral,central,scan \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52840 \
+    --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52833 \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52832 \
     --- build --release --manifest-path examples/esp32/Cargo.toml --target riscv32imc-unknown-none-elf \
     --- build --release --manifest-path examples/serial-hci/Cargo.toml \

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -2,24 +2,18 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
-/// How many outgoing L2CAP buffers per link
-const L2CAP_TXQ: u8 = 20;
-
-/// How many incoming L2CAP buffers per link
-const L2CAP_RXQ: u8 = 20;
-
 /// Size of L2CAP packets
 #[cfg(not(feature = "esp"))]
-const L2CAP_MTU: usize = 128;
+pub const L2CAP_MTU: usize = 128;
 #[cfg(feature = "esp")]
 // Some esp chips only accept an MTU >= 1017
-const L2CAP_MTU: usize = 1017;
+pub const L2CAP_MTU: usize = 1017;
 
 /// Max number of connections
-const CONNECTIONS_MAX: usize = 1;
+pub const CONNECTIONS_MAX: usize = 1;
 
 /// Max number of L2CAP channels.
-const L2CAP_CHANNELS_MAX: usize = 3; // Signal + att + CoC
+pub const L2CAP_CHANNELS_MAX: usize = 3; // Signal + att + CoC
 
 type Resources<C> = HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
 
@@ -29,6 +23,7 @@ where
 {
     let mut resources = Resources::new(PacketQos::None);
 
+    // Hardcoded peripheral address
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 

--- a/examples/nrf-sdc/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/nrf-sdc/src/bin/ble_l2cap_peripheral.rs
@@ -32,7 +32,7 @@ const L2CAP_TXQ: u8 = 20;
 const L2CAP_RXQ: u8 = 20;
 
 /// Size of L2CAP packets
-const L2CAP_MTU: usize = 27;
+const L2CAP_MTU: usize = ble_l2cap_peripheral::L2CAP_MTU;
 
 fn build_sdc<'d, const N: usize>(
     p: nrf_sdc::Peripherals<'d>,
@@ -70,7 +70,7 @@ async fn main(spawner: Spawner) {
 
     let mut rng = rng::Rng::new(p.RNG, Irqs);
 
-    let mut sdc_mem = sdc::Mem::<6224>::new();
+    let mut sdc_mem = sdc::Mem::<12848>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
 
     ble_l2cap_peripheral::run(sdc).await;

--- a/examples/tests/Cargo.toml
+++ b/examples/tests/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "trouble-example-tests"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+trouble-host = { path = "../../host", features = ["derive", "log"] }
+bt-hci = { version = "0.1.1" }
+serde = { version = "1", features = ["derive"] }
+futures = "0.3"
+serde_json = "1"
+log = "0.4"
+tokio = { version = "1", default-features = false, features = [
+  "time",
+  "rt-multi-thread",
+  "macros",
+] }
+reqwest = "0.12"
+embedded-io-adapters = { version = "0.6.1", features = ["tokio-1"] }
+embedded-io-async = { version = "0.6.1" }
+embedded-io = { version = "0.6.1" }
+embassy-sync = { version = "0.6" }
+tokio-serial = "5.4"
+critical-section = { version = "1", features = ["std"] }
+probe-rs = "0.25.0"
+rand = "0.8.5"
+heapless = "0.8.0"
+anyhow = "1"
+object = "0.32.2"
+defmt-decoder = { version = "0.3.9", features = ["unstable"] }
+bytes = "1.5.0"
+backtrace = "0.3.69"
+pretty_env_logger = "0.5.0"
+pin-project-lite = "0.2.13"
+chrono = { version = "0.4.31", features = ["serde"] }

--- a/examples/tests/src/lib.rs
+++ b/examples/tests/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod probe;
+pub mod serial;

--- a/examples/tests/src/probe/mod.rs
+++ b/examples/tests/src/probe/mod.rs
@@ -1,0 +1,123 @@
+use probe_rs::probe::list::Lister;
+use probe_rs::probe::DebugProbeSelector;
+use probe_rs::{Permissions, Session};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use tokio::sync::oneshot;
+use tokio::task::spawn_blocking;
+
+mod run;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProbeConfig {
+    pub targets: Vec<TargetConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TargetConfig {
+    pub chip: String,
+    pub probe: String,
+    pub labels: HashMap<String, String>,
+}
+
+static SELECTOR: OnceLock<ProbeSelector> = OnceLock::new();
+
+pub fn init(config: ProbeConfig) -> &'static ProbeSelector {
+    SELECTOR.get_or_init(|| ProbeSelector::new(config))
+}
+
+pub struct ProbeSelector {
+    targets: Vec<(AtomicBool, TargetConfig)>,
+}
+
+pub struct Target<'d> {
+    config: TargetConfig,
+    taken: &'d AtomicBool,
+}
+
+impl ProbeSelector {
+    fn new(config: ProbeConfig) -> Self {
+        let mut targets = Vec::new();
+        for t in config.targets {
+            targets.push((AtomicBool::new(false), t));
+        }
+        Self { targets }
+    }
+
+    /// Select a target with the provided labels
+    pub fn select<'m>(&'m self, labels: &[(&str, &str)]) -> Option<Target<'m>> {
+        for (taken, config) in &self.targets {
+            let mut matched = true;
+            for (key, value) in labels {
+                let v = config.labels.get(*key);
+                if let Some(v) = v {
+                    if v != value {
+                        matched = false;
+                        break;
+                    }
+                }
+            }
+            if matched && taken.swap(true, Ordering::Acquire) == false {
+                return Some(Target {
+                    config: config.clone(),
+                    taken,
+                });
+            }
+        }
+        None
+    }
+}
+
+impl<'d> Target<'d> {
+    pub fn flash(self, elf: Vec<u8>) -> Result<TargetRunner<'d>, anyhow::Error> {
+        let probe = self.config.probe.clone();
+        let p: DebugProbeSelector = probe.try_into()?;
+        let t = probe_rs::config::get_target_by_name(&self.config.chip)?;
+
+        let lister = Lister::new();
+        let probe = lister.open(p)?;
+
+        let perms = Permissions::new().allow_erase_all();
+        let mut session = probe.attach(t, perms)?;
+        let opts = run::Options { do_flash: true };
+        let mut flasher = run::Flasher::new(elf, opts);
+        flasher.flash(&mut session)?;
+        Ok(TargetRunner {
+            _target: self,
+            flasher,
+            session,
+        })
+    }
+}
+
+impl<'d> Drop for Target<'d> {
+    fn drop(&mut self) {
+        self.taken.store(false, Ordering::Release);
+    }
+}
+
+pub struct TargetRunner<'d> {
+    _target: Target<'d>,
+    flasher: run::Flasher,
+    session: Session,
+}
+
+impl<'d> TargetRunner<'d> {
+    pub async fn run(mut self, cancel: oneshot::Receiver<()>) -> Result<(), anyhow::Error> {
+        let result = spawn_blocking(move || {
+            let mut runner = self.flasher.start(&mut self.session).unwrap();
+            runner.run(&mut self.session, cancel)
+        })
+        .await
+        .unwrap();
+        result
+
+        //let mut res = String::new();
+        //for entry in entries {
+        //    writeln!(&mut res, "{} - {}", entry.level, entry.message).unwrap();
+        //}
+        //(ok, res.into_bytes())
+    }
+}

--- a/examples/tests/src/probe/run.rs
+++ b/examples/tests/src/probe/run.rs
@@ -1,0 +1,575 @@
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::fmt::Write;
+use std::io::Cursor;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail};
+use defmt_decoder::{DecodeError, Location, StreamDecoder, Table};
+use log::{info, warn};
+use object::read::{File as ElfFile, Object as _, ObjectSection as _};
+use object::ObjectSymbol;
+use probe_rs::config::MemoryRegion;
+use probe_rs::debug::{DebugInfo, DebugRegisters};
+use probe_rs::flashing::{DownloadOptions, Format};
+use probe_rs::rtt::{Rtt, ScanRegion};
+use probe_rs::{Core, MemoryInterface, RegisterId, Session};
+use tokio::sync::oneshot;
+
+// pub const LR: RegisterId = RegisterId(14);
+pub const PC: RegisterId = RegisterId(15);
+pub const SP: RegisterId = RegisterId(13);
+pub const XPSR: RegisterId = RegisterId(16);
+
+const THUMB_BIT: u32 = 1;
+const TIMEOUT: Duration = Duration::from_secs(1);
+
+const POLL_SLEEP_MILLIS: u64 = 100;
+
+pub struct Options {
+    pub do_flash: bool,
+}
+
+pub(crate) struct Flasher {
+    elf_bytes: Vec<u8>,
+    opts: Options,
+}
+
+pub(crate) struct Runner {
+    rtt: Rtt,
+    defmt_table: Box<Table>,
+    defmt_locs: BTreeMap<u64, Location>,
+    defmt_stream: Box<dyn StreamDecoder>,
+
+    di: DebugInfo,
+}
+
+unsafe fn fuck_it<'a, 'b, T>(wtf: &'a T) -> &'b T {
+    std::mem::transmute(wtf)
+}
+
+impl Flasher {
+    pub fn new(elf_bytes: Vec<u8>, opts: Options) -> Self {
+        Self { elf_bytes, opts }
+    }
+
+    pub fn flash(&mut self, sess: &mut Session) -> anyhow::Result<()> {
+        // reset ALL cores other than the main one.
+        // This is needed for rp2040 core1.
+        for (i, _) in sess.list_cores() {
+            if i != 0 {
+                sess.core(i)?.reset()?;
+            }
+        }
+
+        if !self.opts.do_flash {
+            log::info!("skipped flashing");
+        } else {
+            sess.core(0)?.reset_and_halt(TIMEOUT)?;
+
+            log::info!("flashing program...");
+            let mut dopts = DownloadOptions::new();
+            dopts.keep_unwritten_bytes = true;
+            dopts.verify = true;
+
+            let mut loader = sess.target().flash_loader();
+            let instruction_set = sess.core(0)?.instruction_set().ok();
+            loader.load_image(sess, &mut Cursor::new(&self.elf_bytes), Format::Elf, instruction_set)?;
+            loader.commit(sess, dopts)?;
+
+            //flashing::download_file_with_options(sess, &opts.elf, Format::Elf, dopts)?;
+            log::info!("flashing done!");
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn start(&mut self, sess: &mut Session) -> anyhow::Result<Runner> {
+        let mut run_from_ram = None;
+
+        let elf = ElfFile::parse(&self.elf_bytes[..])?;
+        let di = DebugInfo::from_raw(&self.elf_bytes[..])?;
+
+        let table = Box::new(defmt_decoder::Table::parse(&self.elf_bytes[..])?.unwrap());
+        let locs = table.get_locations(&self.elf_bytes[..])?;
+        if !table.is_empty() && locs.is_empty() {
+            log::warn!("insufficient DWARF info; compile your program with `debug = 2` to enable location info");
+        }
+
+        // sections used in cortex-m-rt
+        // NOTE we won't load `.uninit` so it is not included here
+        // NOTE we don't load `.bss` because the app (cortex-m-rt) will zero it
+        let candidates = [".vector_table", ".text", ".rodata", ".data"];
+
+        let mut vector_table = None;
+        for sect in elf.sections() {
+            if let Ok(name) = sect.name() {
+                let size = sect.size();
+                // skip empty sections
+                if candidates.contains(&name) && size != 0 {
+                    let start = sect.address();
+                    if size % 4 != 0 || start % 4 != 0 {
+                        // we could support unaligned sections but let's not do that now
+                        bail!("section `{}` is not 4-byte aligned", name);
+                    }
+
+                    let start = start.try_into()?;
+                    let data = sect
+                        .data()?
+                        .chunks_exact(4)
+                        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                        .collect::<Vec<_>>();
+
+                    if name == ".vector_table" {
+                        vector_table = Some(VectorTable {
+                            location: start,
+                            // Initial stack pointer
+                            initial_sp: data[0],
+                            reset: data[1],
+                            hard_fault: data[3],
+                        });
+                    }
+                }
+            }
+        }
+
+        let vector_table = vector_table.ok_or_else(|| anyhow!("`.vector_table` section is missing"))?;
+        log::debug!("vector table: {:x?}", vector_table);
+
+        for r in &sess.target().memory_map {
+            match r {
+                MemoryRegion::Ram(r) => {
+                    if r.range.contains(&(vector_table.location as u64)) {
+                        run_from_ram = Some(true);
+                    }
+                }
+                MemoryRegion::Generic(r) => {
+                    if r.range.contains(&(vector_table.location as u64)) {
+                        run_from_ram = Some(true);
+                    }
+                }
+                MemoryRegion::Nvm(r) => {
+                    if r.range.contains(&(vector_table.location as u64)) {
+                        run_from_ram = Some(false);
+                    }
+                }
+            }
+        }
+
+        let run_from_ram = run_from_ram.unwrap();
+        info!("run_from_ram: {:?}", run_from_ram);
+
+        let (rtt_addr, main_addr) = get_rtt_main_from(&elf)?;
+        let rtt_addr = rtt_addr.ok_or_else(|| anyhow!("RTT is missing"))?;
+
+        {
+            let mut core = sess.core(0)?;
+
+            if run_from_ram {
+                // On STM32H7 due to RAM ECC (I think?) it's possible that the
+                // last written word doesn't "stick" on reset because it's "half written"
+                // https://www.st.com/resource/en/application_note/dm00623136-error-correction-code-ecc-management-for-internal-memories-protection-on-stm32h7-series-stmicroelectronics.pdf
+                //
+                // Do one dummy write to ensure the last word sticks.
+                let data = core.read_word_32(vector_table.location as _)?;
+                core.write_word_32(vector_table.location as _, data)?;
+            }
+
+            core.reset_and_halt(TIMEOUT)?;
+
+            log::debug!("starting device");
+            if core.available_breakpoint_units()? == 0 {
+                bail!("RTT not supported on device without HW breakpoints");
+            }
+
+            if run_from_ram {
+                core.write_core_reg(PC, vector_table.reset)?;
+                core.write_core_reg(SP, vector_table.initial_sp)?;
+
+                // Write VTOR
+                // NOTE this DOES NOT play nice with the softdevice.
+                core.write_word_32(0xE000ED08, vector_table.location)?;
+                let got_vtor = core.read_word_32(0xE000ED08)?;
+                if got_vtor != vector_table.location {
+                    panic!(
+                        "failed to set VTOR! got {:08x} want {:08x}",
+                        got_vtor, vector_table.location
+                    )
+                }
+
+                // Hacks to get the softdevice to think we're doing a cold boot here.
+                //core.write_32(0x2000_005c, &[0]).unwrap();
+                //core.write_32(0x2000_0000, &[0x1000, vector_table.location]).unwrap();
+            }
+
+            if !run_from_ram {
+                // Corrupt the rtt control block so that it's setup fresh again
+                // Only do this when running from flash, because when running from RAM the
+                // "fake-flashing to RAM" is what initializes it.
+                core.write_word_32(rtt_addr as _, 0xdeadc0de)?;
+
+                // RTT control block is initialized pre-main. Run until main before
+                // changing to BlockIfFull.
+                core.set_hw_breakpoint(main_addr as _)?;
+                core.run()?;
+                core.wait_for_core_halted(Duration::from_secs(5))?;
+                core.clear_hw_breakpoint(main_addr as _)?;
+            }
+
+            const OFFSET: u32 = 44;
+            const FLAG: u32 = 2; // BLOCK_IF_FULL
+            core.write_word_32((rtt_addr + OFFSET) as _, FLAG)?;
+
+            if run_from_ram {
+                core.write_8((vector_table.hard_fault & !THUMB_BIT) as _, &[0x00, 0xbe])?;
+            } else {
+                core.set_hw_breakpoint((vector_table.hard_fault & !THUMB_BIT) as _)?;
+            }
+
+            core.run()?;
+        }
+
+        let rtt = setup_logging_channel(rtt_addr as u64, sess)?;
+
+        let defmt_stream = unsafe { fuck_it(&table) }.new_stream_decoder();
+
+        Ok(Runner {
+            defmt_table: table,
+            defmt_locs: locs,
+            rtt,
+            defmt_stream,
+            di,
+        })
+    }
+}
+
+impl Runner {
+    fn poll(&mut self, sess: &mut Session) -> anyhow::Result<()> {
+        let current_dir = std::env::current_dir()?;
+
+        let mut read_buf = [0; 1024];
+        let defmt = self
+            .rtt
+            .up_channel(0)
+            .ok_or_else(|| anyhow!("RTT up channel 0 not found"))?;
+        match defmt.read(&mut sess.core(0).unwrap(), &mut read_buf)? {
+            0 => {
+                // Sleep to reduce CPU usage when defmt didn't return any data.
+                std::thread::sleep(Duration::from_millis(POLL_SLEEP_MILLIS));
+                return Ok(());
+            }
+            n => self.defmt_stream.received(&read_buf[..n]),
+        }
+
+        loop {
+            match self.defmt_stream.decode() {
+                Ok(frame) => {
+                    let loc = self.defmt_locs.get(&frame.index());
+
+                    let (mut file, mut line) = (None, None);
+                    if let Some(loc) = loc {
+                        let relpath = if let Ok(relpath) = loc.file.strip_prefix(&current_dir) {
+                            relpath
+                        } else {
+                            // not relative; use full path
+                            &loc.file
+                        };
+                        file = Some(relpath.display().to_string());
+                        line = Some(loc.line as u32);
+                    };
+
+                    let mut timestamp = String::new();
+                    if let Some(ts) = frame.display_timestamp() {
+                        timestamp = format!("{} ", ts);
+                    }
+
+                    log::logger().log(
+                        &log::Record::builder()
+                            .level(match frame.level() {
+                                Some(level) => match level.as_str() {
+                                    "trace" => log::Level::Trace,
+                                    "debug" => log::Level::Debug,
+                                    "info" => log::Level::Info,
+                                    "warn" => log::Level::Warn,
+                                    "error" => log::Level::Error,
+                                    _ => log::Level::Error,
+                                },
+                                None => log::Level::Info,
+                            })
+                            .file(file.as_deref())
+                            .line(line)
+                            .target("device")
+                            //.args(format_args!("{} {:?} {:?}", frame.display_message(), file, line))
+                            .args(format_args!("{}{}", timestamp, frame.display_message()))
+                            .build(),
+                    );
+                }
+                Err(DecodeError::UnexpectedEof) => break,
+                Err(DecodeError::Malformed) => match self.defmt_table.encoding().can_recover() {
+                    // if recovery is impossible, abort
+                    false => bail!("failed to decode defmt data"),
+                    // if recovery is possible, skip the current frame and continue with new data
+                    true => log::warn!("failed to decode defmt data"),
+                },
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn run(&mut self, sess: &mut Session, mut cancel: oneshot::Receiver<()>) -> anyhow::Result<()> {
+        let mut was_halted = false;
+
+        loop {
+            match cancel.try_recv() {
+                Ok(_) | Err(oneshot::error::TryRecvError::Closed) => {
+                    warn!("Cancelled");
+                    return Ok(());
+                }
+                _ => {}
+            }
+
+            self.poll(sess)?;
+
+            let mut core = sess.core(0)?;
+            let is_halted = core.core_halted()?;
+
+            if is_halted && was_halted {
+                break;
+            }
+            was_halted = is_halted;
+        }
+
+        let mut core = sess.core(0)?;
+
+        let is_hardfault = self.dump_state(&mut core, false)?;
+        if is_hardfault {
+            bail!("Firmware crashed");
+        }
+
+        Ok(())
+    }
+
+    fn traceback(&mut self, core: &mut Core) -> anyhow::Result<()> {
+        let mut r = [0; 17];
+        for (i, val) in r.iter_mut().enumerate() {
+            *val = core.read_core_reg::<u32>(i as u16)?;
+        }
+        info!(
+            "  R0: {:08x}   R1: {:08x}   R2: {:08x}   R3: {:08x}",
+            r[0], r[1], r[2], r[3],
+        );
+        info!(
+            "  R4: {:08x}   R5: {:08x}   R6: {:08x}   R7: {:08x}",
+            r[4], r[5], r[6], r[7],
+        );
+        info!(
+            "  R8: {:08x}   R9: {:08x}  R10: {:08x}  R11: {:08x}",
+            r[8], r[9], r[10], r[11],
+        );
+        info!(
+            " R12: {:08x}   SP: {:08x}   LR: {:08x}   PC: {:08x}",
+            r[12], r[13], r[14], r[15],
+        );
+        info!("XPSR: {:08x}", r[16]);
+
+        info!("");
+        info!("Stack:");
+        let mut stack = [0u32; 32];
+        core.read_32(r[13] as _, &mut stack)?;
+        for i in 0..(stack.len() / 4) {
+            info!(
+                "{:08x}: {:08x} {:08x} {:08x} {:08x}",
+                r[13] + i as u32 * 16,
+                stack[i * 4 + 0],
+                stack[i * 4 + 1],
+                stack[i * 4 + 2],
+                stack[i * 4 + 3],
+            );
+        }
+
+        info!("");
+        info!("Backtrace:");
+        let di = &self.di;
+        let initial_registers = DebugRegisters::from_core(core);
+        let exception_handler = probe_rs::exception_handler_for_core(core.core_type());
+        let instruction_set = core.instruction_set().ok();
+        let stack_frames = di.unwind(core, initial_registers, exception_handler.as_ref(), instruction_set)?;
+
+        for (i, frame) in stack_frames.iter().enumerate() {
+            let mut s = String::new();
+            write!(&mut s, "Frame {}: {} @ {}", i, frame.function_name, frame.pc).unwrap();
+
+            if frame.is_inlined {
+                write!(&mut s, " inline").unwrap();
+            }
+            info!("{}", s);
+
+            if let Some(location) = &frame.source_location {
+                let mut s = String::new();
+                let file = location.path.to_string_lossy();
+                write!(&mut s, "  {file}").unwrap();
+
+                if let Some(line) = location.line {
+                    write!(&mut s, ":{line}").unwrap();
+                    if let Some(col) = location.column {
+                        match col {
+                            probe_rs::debug::ColumnType::LeftEdge => {
+                                write!(&mut s, ":1").unwrap();
+                            }
+                            probe_rs::debug::ColumnType::Column(c) => {
+                                write!(&mut s, ":{c}").unwrap();
+                            }
+                        }
+                    }
+                }
+                info!("{}", s);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn dump_state(&mut self, core: &mut Core, force: bool) -> anyhow::Result<bool> {
+        core.halt(TIMEOUT)?;
+
+        // determine if the target is handling an interupt
+        let xpsr: u32 = core.read_core_reg(XPSR)?;
+        let exception_number = xpsr & 0xff;
+        match exception_number {
+            0 => {
+                //info!("No exception!");
+                if force {
+                    self.traceback(core)?;
+                }
+                Ok(false)
+            }
+            3 => {
+                self.traceback(core)?;
+                info!("Hard Fault!");
+
+                // Get reason for hard fault
+                let hfsr = core.read_word_32(0xE000_ED2C)?;
+
+                if hfsr & (1 << 30) != 0 {
+                    info!("-> configurable priority exception has been escalated to hard fault!");
+
+                    // read cfsr
+                    let cfsr = core.read_word_32(0xE000_ED28)?;
+
+                    let ufsr = (cfsr >> 16) & 0xffff;
+                    let bfsr = (cfsr >> 8) & 0xff;
+                    let mmfsr = (cfsr) & 0xff;
+
+                    if ufsr != 0 {
+                        info!("\tUsage Fault     - UFSR: {:#06x}", ufsr);
+                    }
+
+                    if bfsr != 0 {
+                        info!("\tBus Fault       - BFSR: {:#04x}", bfsr);
+
+                        if bfsr & (1 << 7) != 0 {
+                            // Read address from BFAR
+                            let bfar = core.read_word_32(0xE000_ED38)?;
+                            info!("\t Location       - BFAR: {:#010x}", bfar);
+                        }
+                    }
+
+                    if mmfsr != 0 {
+                        info!("\tMemManage Fault - BFSR: {:04x}", bfsr);
+                    }
+                }
+                Ok(true)
+            }
+            // Ignore other exceptions for now
+            _ => {
+                self.traceback(core)?;
+                info!("Exception {}", exception_number);
+                Ok(false)
+            }
+        }
+    }
+}
+
+fn setup_logging_channel(rtt_addr: u64, sess: &mut Session) -> anyhow::Result<Rtt> {
+    const NUM_RETRIES: usize = 10; // picked at random, increase if necessary
+    let mut rtt_res: Result<Rtt, probe_rs::rtt::Error> = Err(probe_rs::rtt::Error::ControlBlockNotFound);
+
+    let mut core = sess.core(0).unwrap();
+
+    for try_index in 0..=NUM_RETRIES {
+        rtt_res = Rtt::attach_region(&mut core, &ScanRegion::Exact(rtt_addr));
+        match rtt_res {
+            Ok(_) => {
+                log::debug!("Successfully attached RTT");
+                break;
+            }
+            Err(probe_rs::rtt::Error::ControlBlockNotFound) => {
+                if try_index < NUM_RETRIES {
+                    log::trace!(
+                        "Could not attach because the target's RTT control block isn't initialized (yet). retrying"
+                    );
+                } else {
+                    log::error!("Max number of RTT attach retries exceeded.");
+                    return Err(anyhow!(probe_rs::rtt::Error::ControlBlockNotFound));
+                }
+            }
+            Err(e) => {
+                return Err(anyhow!(e));
+            }
+        }
+    }
+
+    // this block is only executed when rtt was successfully attached before
+    let mut rtt = rtt_res.expect("unreachable");
+    for ch in rtt.up_channels().iter() {
+        log::debug!(
+            "up channel {}: {:?}, buffer size {} bytes",
+            ch.number(),
+            ch.name(),
+            ch.buffer_size()
+        );
+    }
+    for ch in rtt.down_channels().iter() {
+        log::debug!(
+            "down channel {}: {:?}, buffer size {} bytes",
+            ch.number(),
+            ch.name(),
+            ch.buffer_size()
+        );
+    }
+
+    Ok(rtt)
+}
+
+fn get_rtt_main_from(elf: &ElfFile) -> anyhow::Result<(Option<u32>, u32)> {
+    let mut rtt = None;
+    let mut main = None;
+
+    for symbol in elf.symbols() {
+        let name = match symbol.name() {
+            Ok(name) => name,
+            Err(_) => continue,
+        };
+
+        match name {
+            "main" => main = Some(symbol.address() as u32 & !THUMB_BIT),
+            "_SEGGER_RTT" => rtt = Some(symbol.address() as u32),
+            _ => {}
+        }
+    }
+
+    Ok((rtt, main.ok_or_else(|| anyhow!("`main` symbol not found"))?))
+}
+
+/// The contents of the vector table
+#[derive(Debug)]
+struct VectorTable {
+    location: u32,
+    // entry 0
+    initial_sp: u32,
+    // entry 1: Reset handler
+    reset: u32,
+    // entry 3: HardFault handler
+    hard_fault: u32,
+}

--- a/examples/tests/src/serial.rs
+++ b/examples/tests/src/serial.rs
@@ -11,6 +11,21 @@ pub type Controller = ExternalController<
     10,
 >;
 
+pub fn find_controllers() -> Vec<String> {
+    let folder = "/dev/serial/by-id";
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(folder).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        if file_name.starts_with("usb-ZEPHYR_Zephyr_HCI_UART_sample") {
+            paths.push(path.to_string_lossy().to_string());
+        }
+    }
+    paths
+}
+
 pub async fn create_controller(
     port: &str,
 ) -> ExternalController<

--- a/examples/tests/src/serial.rs
+++ b/examples/tests/src/serial.rs
@@ -1,0 +1,47 @@
+use bt_hci::controller::ExternalController;
+use bt_hci::transport::SerialTransport;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embedded_io_adapters::tokio_1::FromTokio;
+use tokio::io::{ReadHalf, WriteHalf};
+use tokio::time::Duration;
+use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
+
+pub type Controller = ExternalController<
+    SerialTransport<NoopRawMutex, FromTokio<ReadHalf<SerialStream>>, FromTokio<WriteHalf<SerialStream>>>,
+    10,
+>;
+
+pub async fn create_controller(
+    port: &str,
+) -> ExternalController<
+    SerialTransport<NoopRawMutex, FromTokio<ReadHalf<SerialStream>>, FromTokio<WriteHalf<SerialStream>>>,
+    10,
+> {
+    let baudrate = 1000000;
+    let mut port = SerialStream::open(
+        &tokio_serial::new(port, baudrate)
+            .baud_rate(baudrate)
+            .data_bits(DataBits::Eight)
+            .parity(Parity::None)
+            .stop_bits(StopBits::One),
+    )
+    .unwrap();
+
+    // Drain input
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    loop {
+        let mut buf = [0; 1];
+        match port.try_read(&mut buf[..]) {
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            _ => {}
+        }
+    }
+
+    let (reader, writer) = tokio::io::split(port);
+
+    let reader = embedded_io_adapters::tokio_1::FromTokio::new(reader);
+    let writer = embedded_io_adapters::tokio_1::FromTokio::new(writer);
+
+    let driver: SerialTransport<NoopRawMutex, _, _> = SerialTransport::new(reader, writer);
+    ExternalController::new(driver)
+}

--- a/examples/tests/tests/l2cap.rs
+++ b/examples/tests/tests/l2cap.rs
@@ -7,7 +7,8 @@ use trouble_host::prelude::*;
 #[tokio::test(flavor = "multi_thread")]
 async fn l2cap_peripheral_nrf52() {
     let _ = pretty_env_logger::try_init();
-    let central = std::env::var("TEST_ADAPTER_ONE").unwrap();
+    let adapters = serial::find_controllers();
+    let central = adapters[0].clone();
     let config = std::env::var("PROBE_CONFIG").unwrap();
     let config = serde_json::from_str(&config).unwrap();
     let elf = std::fs::read("./thumbv7em-none-eabihf/release/ble_l2cap_peripheral").unwrap();

--- a/examples/tests/tests/l2cap.rs
+++ b/examples/tests/tests/l2cap.rs
@@ -1,0 +1,102 @@
+use std::time::Duration;
+use tokio::select;
+use tokio::sync::oneshot;
+use trouble_example_tests::{probe, serial};
+use trouble_host::prelude::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn l2cap_peripheral_nrf52() {
+    let _ = pretty_env_logger::try_init();
+    let central = std::env::var("TEST_ADAPTER_ONE").unwrap();
+    let config = std::env::var("PROBE_CONFIG").unwrap();
+    let config = serde_json::from_str(&config).unwrap();
+    let elf = std::fs::read("./thumbv7em-none-eabihf/release/ble_l2cap_peripheral").unwrap();
+
+    let selector = probe::init(config);
+    let target = selector
+        .select(&[("target", "nrf52"), ("board", "microbit")])
+        .expect("no suitable probe found");
+
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+
+    // Flash the binary to the target
+    let runner = target.flash(elf).unwrap();
+
+    // Spawn a runner for the target
+    let peripheral = tokio::task::spawn(async move { runner.run(cancel_rx).await });
+
+    // Run the central in the test using the serial adapter to verify
+    let peripheral_address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    let central_fut = async {
+        let controller_central = serial::create_controller(&central).await;
+        let mut resources: HostResources<serial::Controller, 2, 4, 27> = HostResources::new(PacketQos::None);
+        let (stack, _peripheral, mut central, mut runner) =
+            trouble_host::new(controller_central, &mut resources).build();
+        select! {
+            r = runner.run() => {
+                r
+            }
+            r = async {
+                let config = ConnectConfig {
+                    connect_params: Default::default(),
+                    scan_config: ScanConfig {
+                        active: true,
+                        filter_accept_list: &[(peripheral_address.kind, &peripheral_address.addr)],
+                        ..Default::default()
+                    },
+                };
+
+                log::info!("[central] connecting");
+                loop {
+                    let conn = central.connect(&config).await.unwrap();
+                    log::info!("[central] connected");
+                    const PAYLOAD_LEN: usize = 27;
+                    let mut ch1 = L2capChannel::create(stack, &conn, 0x2349, &Default::default()).await?;
+                    log::info!("[central] channel created");
+                    for i in 0..10 {
+                        let tx = [i; PAYLOAD_LEN];
+                        ch1.send::<_, PAYLOAD_LEN>(stack, &tx).await?;
+                    }
+                    log::info!("[central] data sent");
+                    let mut rx = [0; PAYLOAD_LEN];
+                    for i in 0..10 {
+                        let len = ch1.receive(stack, &mut rx).await?;
+                        assert_eq!(len, rx.len());
+                        assert_eq!(rx, [i; PAYLOAD_LEN]);
+                    }
+                    log::info!("[central] data received");
+                    cancel_tx.send(()).unwrap();
+                    break;
+                }
+                Ok(())
+            } => {
+                r
+            }
+        }
+    };
+
+    match tokio::time::timeout(Duration::from_secs(30), async { tokio::join!(central_fut, peripheral) }).await {
+        Ok(result) => match result {
+            (Err(e1), Err(e2)) => {
+                println!("Central error: {:?}", e1);
+                println!("Peripheral error: {:?}", e2);
+                panic!();
+            }
+            (Err(e), _) => {
+                println!("Central error: {:?}", e);
+                panic!();
+            }
+            (_, Err(e)) => {
+                println!("Peripheral error: {:?}", e);
+                panic!();
+            }
+            _ => {
+                println!("Test completed successfully");
+            }
+        },
+        Err(e) => {
+            println!("Test timed out: {:?}", e);
+            panic!();
+        }
+    }
+}

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -34,6 +34,7 @@ impl<'d, C: Controller> Central<'d, C> {
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>
             + ControllerCmdAsync<LeCreateConn>,
     {
+        info!("CENTRAL CONNECT START");
         if config.scan_config.filter_accept_list.is_empty() {
             return Err(Error::InvalidValue.into());
         }
@@ -42,10 +43,13 @@ impl<'d, C: Controller> Central<'d, C> {
         let _drop = crate::host::OnDrop::new(|| {
             host.connect_command_state.cancel(true);
         });
+        info!("CENTRAL STATE REQUEST WAIT");
         host.connect_command_state.request().await;
 
+        info!("SET ACCEPT FILTER");
         self.set_accept_filter(config.scan_config.filter_accept_list).await?;
 
+        info!("Instructing to CREATE CONNECTION");
         host.async_command(LeCreateConn::new(
             config.scan_config.interval.into(),
             config.scan_config.window.into(),

--- a/host/tests/common.rs
+++ b/host/tests/common.rs
@@ -2,6 +2,7 @@ use bt_hci::controller::ExternalController;
 use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embedded_io_adapters::tokio_1::FromTokio;
+use std::path::PathBuf;
 use tokio::io::{ReadHalf, WriteHalf};
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
@@ -11,13 +12,29 @@ pub type Controller = ExternalController<
     10,
 >;
 
+pub fn find_controllers() -> Vec<PathBuf> {
+    let folder = "/dev/serial/by-id";
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(folder).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        if file_name.starts_with("usb-ZEPHYR_Zephyr_HCI_UART_sample") {
+            paths.push(path.to_path_buf());
+        }
+    }
+    paths
+}
+
 #[allow(unused)]
 pub(crate) async fn create_controller(
-    port: &str,
+    port: &PathBuf,
 ) -> ExternalController<
     SerialTransport<NoopRawMutex, FromTokio<ReadHalf<SerialStream>>, FromTokio<WriteHalf<SerialStream>>>,
     10,
 > {
+    let port = port.to_string_lossy();
     let baudrate = 1000000;
     let mut port = SerialStream::open(
         &tokio_serial::new(port, baudrate)

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -19,8 +19,9 @@ const VALUE_UUID: Uuid = Uuid::new_long([
 #[tokio::test]
 async fn gatt_client_server() {
     let _ = env_logger::try_init();
-    let peripheral = std::env::var("TEST_ADAPTER_ONE").unwrap();
-    let central = std::env::var("TEST_ADAPTER_TWO").unwrap();
+    let adapters = common::find_controllers();
+    let peripheral = adapters[0].clone();
+    let central = adapters[1].clone();
 
     let peripheral_address: Address = Address::random([0xff, 0x9f, 0x1a, 0x05, 0xe4, 0xff]);
 

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -56,8 +56,10 @@ struct BatteryService {
 #[tokio::test]
 async fn gatt_client_server() {
     let _ = env_logger::try_init();
-    let peripheral = std::env::var("TEST_ADAPTER_ONE").unwrap();
-    let central = std::env::var("TEST_ADAPTER_TWO").unwrap();
+    let adapters = common::find_controllers();
+    let peripheral = adapters[0].clone();
+    let central = adapters[1].clone();
+
     let name = std::env::var("DEVICE_NAME").unwrap_or("TrouBLE".into());
 
     let peripheral_address: Address = Address::random([0xff, 0x9f, 0x1a, 0x05, 0xe4, 0xff]);

--- a/host/tests/l2cap.rs
+++ b/host/tests/l2cap.rs
@@ -12,8 +12,9 @@ const MTU: usize = 23;
 #[tokio::test]
 async fn l2cap_connection_oriented_channels() {
     let _ = env_logger::try_init();
-    let peripheral = std::env::var("TEST_ADAPTER_ONE").unwrap();
-    let central = std::env::var("TEST_ADAPTER_TWO").unwrap();
+    let adapters = common::find_controllers();
+    let peripheral = adapters[0].clone();
+    let central = adapters[1].clone();
 
     let peripheral_address: Address = Address::random([0xff, 0x9f, 0x1a, 0x05, 0xe4, 0xff]);
 


### PR DESCRIPTION
Works by adding a workflow to the test bot that runs tests for examples/tests which uses probe-rs to flash a peripheral example to a board (like microbit), and run the central in the test framework with a serial HCI adapter.

Lots of the probe setup, running and log handling is taken from embassy-rs/teleprobe.