### PR TITLE
'embedded-io-async' dependency seems to be unneeded

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -10,7 +10,6 @@ resolver = "2"
 
 [dependencies]
 bt-hci = { version = "0.1.2", features = ["embassy-time", "uuid"] }
-#embedded-io-async = { version = "0.6" }
 embedded-io = { version = "0.6" }
 embassy-sync = "0.6"
 embassy-time = "0.3"
@@ -33,7 +32,6 @@ tokio = { version = "1", default-features = false, features = [
   "macros",
 ] }
 embedded-io-adapters = { version = "0.6.1", features = ["tokio-1"] }
-#embedded-io-async = { version = "0.6.1" }
 embedded-io = { version = "0.6.1" }
 tokio-serial = "5.4"
 env_logger = "0.11"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [dependencies]
 bt-hci = { version = "0.1.2", features = ["embassy-time", "uuid"] }
-embedded-io-async = { version = "0.6" }
+#embedded-io-async = { version = "0.6" }
 embedded-io = { version = "0.6" }
 embassy-sync = "0.6"
 embassy-time = "0.3"
@@ -33,7 +33,7 @@ tokio = { version = "1", default-features = false, features = [
   "macros",
 ] }
 embedded-io-adapters = { version = "0.6.1", features = ["tokio-1"] }
-embedded-io-async = { version = "0.6.1" }
+#embedded-io-async = { version = "0.6.1" }
 embedded-io = { version = "0.6.1" }
 tokio-serial = "5.4"
 env_logger = "0.11"


### PR DESCRIPTION
I noticed that the `embedded-io-async` dependency doesn't seem to be needed. As far as I can tell, I can build the examples without it.

Is this correct?

If approved, the lines should of course be removed (my bad); just commented them out here. Also, should I remove them from Lock files, e.g. [here](https://github.com/embassy-rs/trouble/blob/main/examples/esp32/Cargo.lock#L334-L341) ?