### PR TITLE
small changes proposed to 'esp32' build and 'ble_bas_peripheral' example

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -1,4 +1,4 @@
-use embassy_futures::select::select;
+use embassy_futures::{join::join, select::select};
 use embassy_time::Timer;
 use trouble_host::prelude::*;
 
@@ -38,9 +38,8 @@ pub async fn run<C>(controller: C)
 where
     C: Controller,
 {
-    // Using a fixed seed means the "random" address will be the same every time the program runs,
-    // which can be useful for testing. If truly random addresses are required, a different,
-    // dynamically generated seed should be used.
+    // Using a fixed "random" address can be useful for testing. In real scenarios, one would
+    // use e.g. the MAC 6 byte array as the address (how to get that varies by the platform).
     let address = Address::random([0x41, 0x5A, 0xE3, 0x1E, 0x83, 0xE7]);
     info!("Our address = {:?}", address);
 
@@ -55,16 +54,17 @@ where
         appearance: &appearance::power_device::GENERIC_POWER_DEVICE,
     }))
     .unwrap();
-    let app_task = async {
+
+    let _ = join(ble_task(runner), async {
         loop {
             match advertise("Trouble Example", &mut peripheral).await {
                 Ok(conn) => {
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let connection_task = conn_task(&server, &conn);
-                    let counter_task = counter_task(&server, &conn, stack);
+                    let custom_task = custom_task(&server, &conn, stack);
                     // run until any task ends (usually because the connection has been closed),
                     // then return to advertising state.
-                    select(connection_task, counter_task).await;
+                    select(connection_task, custom_task).await;
                 }
                 Err(e) => {
                     #[cfg(feature = "defmt")]
@@ -73,8 +73,8 @@ where
                 }
             }
         }
-    };
-    select(ble_task(runner), app_task).await;
+    })
+    .await;
 }
 
 /// This is a background task that is required to run forever alongside any other BLE tasks.
@@ -111,7 +111,7 @@ async fn conn_task(server: &Server<'_>, conn: &Connection<'_>) -> Result<(), Err
     loop {
         match conn.next().await {
             ConnectionEvent::Disconnected { reason } => {
-                info!("[gatt] disconnected: {:?}", reason);
+                info!("[conn_task] disconnected: {:?}", reason);
                 break;
             }
             ConnectionEvent::Gatt { data } => {
@@ -127,23 +127,23 @@ async fn conn_task(server: &Server<'_>, conn: &Connection<'_>) -> Result<(), Err
                     Ok(Some(GattEvent::Read(event))) => {
                         if event.handle() == level.handle {
                             let value = server.get(&level);
-                            info!("[gatt] Read Event to Level Characteristic: {:?}", value);
+                            info!("[conn_task] Read Event to Level Characteristic: {:?}", value);
                         }
                     }
                     Ok(Some(GattEvent::Write(event))) => {
                         if event.handle() == level.handle {
-                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
+                            info!("[conn_task] Write Event to Level Characteristic: {:?}", event.data());
                         }
                     }
                     Ok(_) => {}
                     Err(e) => {
-                        warn!("[gatt] error processing event: {:?}", e);
+                        warn!("[conn_task] error processing event: {:?}", e);
                     }
                 }
             }
         }
     }
-    info!("[gatt] task finished");
+    info!("[conn_task] finished");
     Ok(())
 }
 
@@ -180,21 +180,21 @@ async fn advertise<'a, C: Controller>(
 /// This task will notify the connected central of a counter value every 2 seconds.
 /// It will also read the RSSI value every 2 seconds.
 /// and will stop when the connection is closed by the central or an error occurs.
-async fn counter_task<C: Controller>(server: &Server<'_>, conn: &Connection<'_>, stack: Stack<'_, C>) {
+async fn custom_task<C: Controller>(server: &Server<'_>, conn: &Connection<'_>, stack: Stack<'_, C>) {
     let mut tick: u8 = 0;
     let level = server.battery_service.level;
     loop {
         tick = tick.wrapping_add(1);
-        info!("[adv] notifying connection of tick {}", tick);
+        info!("[custom_task] notifying connection of tick {}", tick);
         if level.notify(server, conn, &tick).await.is_err() {
-            info!("[adv] error notifying connection");
+            info!("[custom_task] error notifying connection");
             break;
         };
         // read RSSI (Received Signal Strength Indicator) of the connection.
         if let Ok(rssi) = conn.rssi(stack).await {
-            info!("[gatt] RSSI: {:?}", rssi);
+            info!("[custom_task] RSSI: {:?}", rssi);
         } else {
-            info!("[gatt] error getting RSSI");
+            info!("[custom_task] error getting RSSI");
             break;
         };
         Timer::after_secs(2).await;

--- a/examples/esp32/.cargo/config.toml
+++ b/examples/esp32/.cargo/config.toml
@@ -10,20 +10,11 @@ esp32s3 = "run --release --no-default-features --features=esp32s3 --target=xtens
 runner = "espflash flash --monitor"
 
 [build]
-# Pick ONE of these compilation targets
-# target = "xtensa-esp32-none-elf"        # ESP32
-# target = "xtensa-esp32s3-none-elf"      # ESP32-S3
-target = "riscv32imc-unknown-none-elf"  # ESP32-C2 and ESP32-C3
-# target = "riscv32imac-unknown-none-elf" # ESP32-C6 and ESP32-H2
-
 rustflags = [
   # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
   # NOTE: May negatively impact performance of produced code
   "-C", "force-frame-pointers",
 ]
-
-[unstable]
-build-std = ["alloc", "core"]
 
 [env]
 ESP_LOG = "info"


### PR DESCRIPTION
Some things discussed in #226 collected as a mergeable PR.

- use of `join` in `apps/ble_bas_peripheral` example
- change to `Address` comment; "seed" gone
- more consistency to logging tags
- `[build]: target` removed from `.cargo/config.toml`
- `[unstable]` -""-