### PR TITLE
Refactor AttErrorCode as wrapper type around u8

### DIFF
--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -54,14 +54,14 @@ impl<'a> Attribute<'a> {
 
     pub(crate) fn read(&self, offset: usize, data: &mut [u8]) -> Result<usize, AttErrorCode> {
         if !self.data.readable() {
-            return Err(AttErrorCode::ReadNotPermitted);
+            return Err(AttErrorCode::READ_NOT_PERMITTED);
         }
         self.data.read(offset, data)
     }
 
     pub(crate) fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), AttErrorCode> {
         if !self.data.writable() {
-            return Err(AttErrorCode::WriteNotPermitted);
+            return Err(AttErrorCode::WRITE_NOT_PERMITTED);
         }
 
         self.data.write(offset, data)
@@ -120,7 +120,7 @@ impl AttributeData<'_> {
 
     fn read(&self, offset: usize, data: &mut [u8]) -> Result<usize, AttErrorCode> {
         if !self.readable() {
-            return Err(AttErrorCode::ReadNotPermitted);
+            return Err(AttErrorCode::READ_NOT_PERMITTED);
         }
         match self {
             Self::ReadOnlyData { props, value } => {
@@ -165,10 +165,10 @@ impl AttributeData<'_> {
                 indications,
             } => {
                 if offset > 0 {
-                    return Err(AttErrorCode::InvalidOffset);
+                    return Err(AttErrorCode::INVALID_OFFSET);
                 }
                 if data.len() < 2 {
-                    return Err(AttErrorCode::UnlikelyError);
+                    return Err(AttErrorCode::UNLIKELY_ERROR);
                 }
                 let mut v = 0;
                 if *notifications {
@@ -217,7 +217,7 @@ impl AttributeData<'_> {
                 len,
             } => {
                 if !writable {
-                    return Err(AttErrorCode::WriteNotPermitted);
+                    return Err(AttErrorCode::WRITE_NOT_PERMITTED);
                 }
 
                 if offset + data.len() <= value.len() {
@@ -225,7 +225,7 @@ impl AttributeData<'_> {
                     *len = (offset + data.len()) as u16;
                     Ok(())
                 } else {
-                    Err(AttErrorCode::InvalidOffset)
+                    Err(AttErrorCode::INVALID_OFFSET)
                 }
             }
             Self::Cccd {
@@ -233,18 +233,18 @@ impl AttributeData<'_> {
                 indications,
             } => {
                 if offset > 0 {
-                    return Err(AttErrorCode::InvalidOffset);
+                    return Err(AttErrorCode::INVALID_OFFSET);
                 }
 
                 if data.is_empty() {
-                    return Err(AttErrorCode::UnlikelyError);
+                    return Err(AttErrorCode::UNLIKELY_ERROR);
                 }
 
                 *notifications = data[0] & 0x01 != 0;
                 *indications = data[0] & 0x02 != 0;
                 Ok(())
             }
-            _ => Err(AttErrorCode::WriteNotPermitted),
+            _ => Err(AttErrorCode::WRITE_NOT_PERMITTED),
         }
     }
 

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -110,7 +110,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
 
         let (mut header, mut body) = data.split(2)?;
         let err = self.table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::AttributeNotFound);
+            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
                 //trace!("Check attribute {:?} {}", att.uuid, att.handle);
                 if &att.uuid == attribute_type && att.handle >= start && att.handle <= end {
@@ -153,7 +153,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
 
         let (mut header, mut body) = data.split(2)?;
         let err = self.table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::AttributeNotFound);
+            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
                 //            trace!("Check attribute {:x} {}", att.uuid, att.handle);
                 if &att.uuid == group_type && att.handle >= start && att.handle <= end {
@@ -189,7 +189,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
         data.write(att::ATT_READ_RSP)?;
 
         let err = self.table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::AttributeNotFound);
+            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
                 if att.handle == handle {
                     err = att.read(0, data.write_buf());
@@ -235,7 +235,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
         data: &[u8],
     ) -> Result<usize, codec::Error> {
         let err = self.table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::AttributeNotFound);
+            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
                 if att.handle == handle {
                     err = att.write(0, data);
@@ -300,7 +300,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
                 w,
                 att::ATT_FIND_BY_TYPE_VALUE_REQ,
                 start,
-                AttErrorCode::AttributeNotFound,
+                AttErrorCode::ATTRIBUTE_NOT_FOUND,
             )?)
         }
     }
@@ -336,7 +336,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
                 w,
                 att::ATT_FIND_INFORMATION_REQ,
                 start,
-                AttErrorCode::AttributeNotFound,
+                AttErrorCode::ATTRIBUTE_NOT_FOUND,
             )?)
         }
     }
@@ -351,7 +351,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
         w.write(att::ATT_ERROR_RSP)?;
         w.write(opcode)?;
         w.write(handle)?;
-        w.write(code as u8)?;
+        w.write(code)?;
         Ok(w.len())
     }
 
@@ -369,7 +369,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
         w.write(offset)?;
 
         let err = self.table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::AttributeNotFound);
+            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
                 if att.handle == handle {
                     err = att.write(offset as usize, value);
@@ -403,7 +403,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
         w.write(att::ATT_READ_BLOB_RSP)?;
 
         let err = self.table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::AttributeNotFound);
+            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
                 if att.handle == handle {
                     err = att.read(offset as usize, w.write_buf());
@@ -433,7 +433,7 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
             w,
             att::ATT_READ_MULTIPLE_REQ,
             u16::from_le_bytes([handles[0], handles[1]]),
-            AttErrorCode::AttributeNotFound,
+            AttErrorCode::ATTRIBUTE_NOT_FOUND,
         )
     }
 

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -496,7 +496,7 @@ impl<'reference, C: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
             let res = AttRsp::decode(pdu.as_ref())?;
             match res {
                 AttRsp::Error { request, handle, code } => {
-                    if code == att::AttErrorCode::AttributeNotFound {
+                    if code == att::AttErrorCode::ATTRIBUTE_NOT_FOUND {
                         break;
                     }
                     return Err(Error::Att(code).into());

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -123,7 +123,7 @@ async fn gatt_client_server() {
                             }
                             ConnectionEvent::Gatt { data } => if let Ok(Some(GattEvent::Write(event))) = data.process(&server).await {
                                 if writes == 0 {
-                                    event.reject(AttErrorCode::ValueNotAllowed).unwrap().send().await;
+                                    event.reject(AttErrorCode::VALUE_NOT_ALLOWED).unwrap().send().await;
                                     writes += 1;
                                 } else {
                                     let characteristic = server.table().find_characteristic_by_value_handle(event.handle()).unwrap();
@@ -201,7 +201,7 @@ async fn gatt_client_server() {
                         println!("[central] read value: {}", data[0]);
                         data[0] = data[0].wrapping_add(1);
                         println!("[central] write value: {}", data[0]);
-                        if let Err(BleHostError::BleHost(Error::Att(AttErrorCode::ValueNotAllowed))) = client.write_characteristic(&c, &data[..]).await {
+                        if let Err(BleHostError::BleHost(Error::Att(AttErrorCode::VALUE_NOT_ALLOWED))) = client.write_characteristic(&c, &data[..]).await {
                             println!("[central] Frist write was rejected by write callback as expected.");
                         } else {
                             println!("[central] First write was expected to be rejected by server write callback!");


### PR DESCRIPTION
This change allows the entire range of u8 as error codes. According to the Bluetooth spec the entire range 0 - 255 is valid, however only a subset of these are defined in the Bluetooth spec.
Some are reserved for application error codes, some are reserved for common profile and service error codes, and some are reserved for future use.

Still to do:
- [ ] Match arm for application error codes
- [ ] Match arm for common error codes
- [ ] Update "other" match arm