### PR TITLE
~~Rename and~~ split of `esp` feature based on ESP32 chip types

### DIFF
--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -12,18 +12,32 @@ esp-hal-embassy = { version = "0.5.0" }
 esp-alloc = { version = "0.5.0" }
 esp-println = { version = "0.12.0", features = ["log"] }
 esp-wifi = { version = "0.11.0", features = [ "ble" ] }
-trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["esp", "log"] }
+trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["log"] }
 bt-hci = { version = "0.2" }
 embassy-futures = "0.1.1"
 embassy-time = { version = "0.4", features = ["generic-queue-8"] }
 
 [features]
 default = ["esp32c3"]
+
+# trouble-example-apps/esp:
+#
+# 'esp-hal' likely has a bug, causing _some_ ESP32 chips to give "Invalid HCI Command Parameters" BLE errors at launch,
+# if the L2CAP MTU is set low enough.
+#
+# The error producing ranges go:
+#   - ESP32-C6: x..<255             // examples with 128, 251 would fail
+#   - ESP32-C2: RANGE NOT KNOWN     // not having the hardware
+#   - ESP32-H2: RANGE NOT KNOWN     // not having the hardware
+#   - ESP32, -C3, -S2, -S3: claimed not to be affected [1], so the behaviour-altering feature is not enabled for them.
+#
+#       [1]: https://github.com/embassy-rs/trouble/pull/236#issuecomment-2586457641
+#
 esp32 = ["esp-hal/esp32", "esp-backtrace/esp32", "esp-hal-embassy/esp32", "esp-println/esp32", "esp-wifi/esp32"]
-esp32c2 = ["esp-hal/esp32c2", "esp-backtrace/esp32c2", "esp-hal-embassy/esp32c2", "esp-println/esp32c2", "esp-wifi/esp32c2"]
+esp32c2 = ["esp-hal/esp32c2", "esp-backtrace/esp32c2", "esp-hal-embassy/esp32c2", "esp-println/esp32c2", "esp-wifi/esp32c2", "trouble-example-apps/esp"]
 esp32c3 = ["esp-hal/esp32c3", "esp-backtrace/esp32c3", "esp-hal-embassy/esp32c3", "esp-println/esp32c3", "esp-wifi/esp32c3"]
-esp32c6 = ["esp-hal/esp32c6", "esp-backtrace/esp32c6", "esp-hal-embassy/esp32c6", "esp-println/esp32c6", "esp-wifi/esp32c6"]
-esp32h2 = ["esp-hal/esp32h2", "esp-backtrace/esp32h2", "esp-hal-embassy/esp32h2", "esp-println/esp32h2", "esp-wifi/esp32h2"]
+esp32c6 = ["esp-hal/esp32c6", "esp-backtrace/esp32c6", "esp-hal-embassy/esp32c6", "esp-println/esp32c6", "esp-wifi/esp32c6", "trouble-example-apps/esp"]
+esp32h2 = ["esp-hal/esp32h2", "esp-backtrace/esp32h2", "esp-hal-embassy/esp32h2", "esp-println/esp32h2", "esp-wifi/esp32h2", "trouble-example-apps/esp"]
 esp32s3 = ["esp-hal/esp32s3", "esp-backtrace/esp32s3", "esp-hal-embassy/esp32s3", "esp-println/esp32s3", "esp-wifi/esp32s3"]
 
 [profile.dev]


### PR DESCRIPTION
I was somewhat bothered by the "magical" 1017 MTU limit for "Some ESP[32] chips". Which chips? Where are the details?

So I tested on the two chips I have access to: ESP32-C3 and ESP32-C6. Results:

```
C6	
	500 ok
	251 PANIC
	300 ok
	260 ok
	255 ok
	254 PANIC

C3
	300 ok
	251 ok
	128 ok
```

Seems that a) ESP32-C3 doesn't need any special handling in the TrouBLE examples.

b) The limit for ESP32-C6 is >= 255, not 1017.

I don't claim this to be the whole truth. I haven't found any mention of such MTU limits. What I do suggest is renaming the feature and splitting it so that for each chip we run as closed to the (by trial and error) found limit as possible. 

Is this okay?

What to do with the other ESP32 chips?  In the initial version of the PR I left their behaviour unchanged (safe bet). Actually I'd like to not use MTU limits with each, until someone reports seeing a panic in the examples.

If this approach looks okay-ish, I'd also like to experiment with a better way to define the repeating blocks. Have two ideas about it, but having `build.rs` create a constant would mean generating a code snippet. Don't know if you are okay with such added complexity (it would clean the example code, though).