### PR TITLE
fix: add missing import for scan feature

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -18,6 +18,7 @@ fi
 cargo batch \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features peripheral \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features central \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features central,scan \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features central,peripheral \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features central,peripheral,defmt \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral \

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -28,7 +28,7 @@ use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
 use embassy_futures::select::{select3, select4, Either3, Either4};
 use embassy_sync::once_lock::OnceLock;
 use embassy_sync::waitqueue::WakerRegistration;
-#[cfg(feature = "gatt")]
+#[cfg(any(feature = "gatt", feature = "scan"))]
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use futures::pin_mut;
 


### PR DESCRIPTION
Fix an issue where the scan feature did not import the required dependency, and add combination to CI.