### PR TITLE
Consolidate UUID from slice functionality into TryFrom implementation

### DIFF
--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -253,7 +253,7 @@ impl AttributeData<'_> {
         Ok(Self::Declaration {
             props: CharacteristicProps(r.read()?),
             handle: r.read()?,
-            uuid: Uuid::from_slice(r.remaining()),
+            uuid: Uuid::try_from(r.remaining())?,
         })
     }
 }


### PR DESCRIPTION
While working on making get and set generic for all attributes (#155) I noticed there were multiple "from slice" implementations for the Uuid type, which would panic if the slice length didn't match what was expected.

I've consolidated these with a single TryFrom implementation instead.