### PR TITLE
Update esp-hal to released versions.

### DIFF
--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -50,9 +50,9 @@ checksum = "f798d2d157e547aa99aab0967df39edd0b70307312b6f8bd2848e6abe40896e0"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bt-hci"
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "delegate"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2323e10c92e1cf4d86e11538512e6dc03ceb586842970b6332af3d4046a046"
+checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -386,8 +386,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "esp-alloc"
-version = "0.5.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408c0d4c7f51efb256af18641047b0d83b58a485be9edf5a559da796abef0b63"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -398,8 +399,9 @@ dependencies = [
 
 [[package]]
 name = "esp-backtrace"
-version = "0.14.2"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c83ca63fd02ca40644ae91ae63362e3a6e7f53458f6c1356decf892343d2418"
 dependencies = [
  "esp-build",
  "esp-println",
@@ -408,8 +410,9 @@ dependencies = [
 
 [[package]]
 name = "esp-build"
-version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa1c8f9954c9506699cf1ca10a2adcc226ff10b6ae3cb9e875cf2c6a0b9a372"
 dependencies = [
  "quote",
  "syn",
@@ -418,16 +421,18 @@ dependencies = [
 
 [[package]]
 name = "esp-config"
-version = "0.2.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd428a3b4b2975772f24eabea123d45cf6a5e28020396ed5dcb331ee3a904046"
 dependencies = [
  "document-features",
 ]
 
 [[package]]
 name = "esp-hal"
-version = "0.22.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0219639e5154b0513d8a67f5431dd442f31479c5c1f0b21b377fd61f14e415c3"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -480,8 +485,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-embassy"
-version = "0.5.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cea15ef146c7689fede0c3a7d765e07b1eb22ef462f1203a137dacc615b031a"
 dependencies = [
  "critical-section",
  "document-features",
@@ -501,8 +507,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.15.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a3297005c2b31cd00e2ba50037edc9bddf99da3afe1c97a2d1b0165a312eab"
 dependencies = [
  "darling",
  "document-features",
@@ -517,8 +524,9 @@ dependencies = [
 
 [[package]]
 name = "esp-metadata"
-version = "0.4.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb15c17e50f4cccb0d88305c19eae2d5533d750f0a05b6a05f1c99864974758e"
 dependencies = [
  "anyhow",
  "basic-toml",
@@ -528,8 +536,9 @@ dependencies = [
 
 [[package]]
 name = "esp-println"
-version = "0.12.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645e54eb592ca0a3d60213b1695e2a5fc0b51ca6d693c08d6983857224a629ed"
 dependencies = [
  "critical-section",
  "esp-build",
@@ -540,7 +549,8 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.9.1"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94aca65db6157aa5f42d9df6595b21462f28207ca4230b799aa3620352ef6a72"
 dependencies = [
  "document-features",
  "riscv",
@@ -562,8 +572,9 @@ dependencies = [
 
 [[package]]
 name = "esp-wifi"
-version = "0.11.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321b112db6629693fae49644b1ba28e8b917b58829533e9cdd0400183af1877d"
 dependencies = [
  "bt-hci",
  "cfg-if",
@@ -591,17 +602,18 @@ dependencies = [
 
 [[package]]
 name = "esp-wifi-sys"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7730d6093853119088bbb793e3383801965ebe8fcf91e0817781d94628aaf718"
+checksum = "c6b5438361891c431970194a733415006fb3d00b6eb70b3dcb66fd58f04d9b39"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "esp32"
-version = "0.34.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=ffbee35069d137ef611097d39fa7734c299ce124#ffbee35069d137ef611097d39fa7734c299ce124"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d3bff1d268a4b8d34b494c0e88466cd59a827bb330189773db299ff525ea13"
 dependencies = [
  "critical-section",
  "vcell",
@@ -609,8 +621,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c2"
-version = "0.23.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=ffbee35069d137ef611097d39fa7734c299ce124#ffbee35069d137ef611097d39fa7734c299ce124"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0285be5b9dc4018d7f31fefe4c3d17f56461ef3ab46300ea1bf9d760968957f0"
 dependencies = [
  "critical-section",
  "vcell",
@@ -618,8 +631,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c3"
-version = "0.26.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=ffbee35069d137ef611097d39fa7734c299ce124#ffbee35069d137ef611097d39fa7734c299ce124"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61655d48e45039dfac5ae769581fb50ea7f61dea3227b4b744a1a900d03fbbd4"
 dependencies = [
  "critical-section",
  "vcell",
@@ -627,8 +641,9 @@ dependencies = [
 
 [[package]]
 name = "esp32c6"
-version = "0.17.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=ffbee35069d137ef611097d39fa7734c299ce124#ffbee35069d137ef611097d39fa7734c299ce124"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd38a7771b65cb640cc4a79324a6301ba4ac3bf2987caca5d3aa34492238fdb9"
 dependencies = [
  "critical-section",
  "vcell",
@@ -636,8 +651,9 @@ dependencies = [
 
 [[package]]
 name = "esp32h2"
-version = "0.13.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=ffbee35069d137ef611097d39fa7734c299ce124#ffbee35069d137ef611097d39fa7734c299ce124"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05aafc25d8c68ce504d8025750fc37915a2fc7d2605be3d3b51f8886a43411a"
 dependencies = [
  "critical-section",
  "vcell",
@@ -645,8 +661,9 @@ dependencies = [
 
 [[package]]
 name = "esp32s3"
-version = "0.29.0"
-source = "git+https://github.com/esp-rs/esp-pacs?rev=ffbee35069d137ef611097d39fa7734c299ce124#ffbee35069d137ef611097d39fa7734c299ce124"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0ab39d5ae3b61b3a83f5616a03220a7dc9c4d6e4ed16d2da73d50bf8d798d7"
 dependencies = [
  "critical-section",
  "vcell",
@@ -800,9 +817,9 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "instability"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "894813a444908c0c8c0e221b041771d107c4a21de1d317dc49bcc66e3c9e5b3f"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
  "darling",
  "indoc",
@@ -850,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -862,9 +879,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minijinja"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c37e1b517d1dcd0e51dc36c4567b9d5a29262b3ec8da6cb5d35e27a8fb529b5"
+checksum = "212b4cab3aad057bc6e611814472905546c533295723b9e26a31c7feb19a8e65"
 dependencies = [
  "serde",
 ]
@@ -941,9 +958,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1011,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1129,9 +1146,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semihosting"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004ff204633065b824d4b952bf5ac84c185d3bd4d43f6b3ae2f049ee318944e"
+checksum = "5d00d0037a88d97379cc27d815a471350923a1dc5880d5325c49695edcdc0d37"
 
 [[package]]
 name = "serde"
@@ -1207,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1227,18 +1244,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1367,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 
 [[package]]
 name = "vcell"
@@ -1467,17 +1484,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "xtensa-lx"
-version = "0.9.0"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51cbb46c78cfd284c9378070ab90bae9d14d38b3766cb853a97c0a137f736d5b"
 dependencies = [
  "critical-section",
  "document-features",
@@ -1485,8 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.17.2"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689c2ef159d9cd4fc9503603e9999968a84a30db9bde0f0f880d0cceea0190a9"
 dependencies = [
  "anyhow",
  "document-features",
@@ -1503,7 +1522,8 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.2.2"
-source = "git+https://github.com/esp-rs/esp-hal.git?rev=7288d0367e0a820db4ca25a22496a35beff1bb61#7288d0367e0a820db4ca25a22496a35beff1bb61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11277b1e4cbb7ffe44678c668518b249c843c81df249b8f096701757bc50d7ee"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -6,12 +6,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embassy-executor    = { version = "0.7.0", features = ["task-arena-size-32768"] }
-esp-backtrace = { version = "0.14.2", features = [ "exception-handler", "panic-handler", "println" ] }
-esp-hal = { version = "0.22.0", features = [ "unstable" ] }
-esp-hal-embassy = { version = "0.5.0" }
-esp-alloc = { version = "0.5.0" }
-esp-println = { version = "0.12.0", features = ["log"] }
-esp-wifi = { version = "0.11.0", features = [ "ble" ] }
+esp-backtrace = { version = "0.15", features = [ "exception-handler", "panic-handler", "println" ] }
+esp-hal = { version = "0.23.0", features = [ "unstable" ] }
+esp-hal-embassy = { version = "0.6.0" }
+esp-alloc = { version = "0.6.0" }
+esp-println = { version = "0.13.0", features = ["log"] }
+esp-wifi = { version = "0.12.0", features = [ "ble" ] }
 trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["esp", "log"] }
 bt-hci = { version = "0.2" }
 embassy-futures = "0.1.1"
@@ -39,11 +39,3 @@ incremental = false
 lto = 'thin'
 opt-level = 3
 overflow-checks = false
-
-[patch.crates-io]
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7288d0367e0a820db4ca25a22496a35beff1bb61" }
-esp-hal-embassy = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7288d0367e0a820db4ca25a22496a35beff1bb61" }
-esp-wifi = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7288d0367e0a820db4ca25a22496a35beff1bb61" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7288d0367e0a820db4ca25a22496a35beff1bb61" }
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7288d0367e0a820db4ca25a22496a35beff1bb61" }
-esp-alloc = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7288d0367e0a820db4ca25a22496a35beff1bb61" }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![allow(clippy::needless_lifetimes)]
 #![warn(missing_docs)]
 
 use core::mem::MaybeUninit;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "1.83"
+channel = "1.84"
 components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
 targets = [
     "thumbv8m.main-none-eabihf",


### PR DESCRIPTION
The esp-hal embassy update is released, no need to use git anymore.
