### PR TITLE
fix: fix interaction between central and peripheral in nrf

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -25,9 +25,9 @@ cargo batch \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,central \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral,central,scan \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52840 \
-    --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52833 --out-dir tests/nrf-sdc \
+    --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52833 --artifact-dir tests/nrf-sdc \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52832 \
-    --- build --release --manifest-path examples/esp32/Cargo.toml --target riscv32imc-unknown-none-elf --out-dir tests/esp32 \
+    --- build --release --manifest-path examples/esp32/Cargo.toml --target riscv32imc-unknown-none-elf --artifact-dir tests/esp32 \
     --- build --release --manifest-path examples/serial-hci/Cargo.toml \
     --- build --release --manifest-path examples/rp-pico-w/Cargo.toml --target thumbv6m-none-eabi --features skip-cyw43-firmware \
     --- build --release --manifest-path examples/rp-pico-2-w/Cargo.toml --target thumbv8m.main-none-eabihf --features skip-cyw43-firmware

--- a/ci.sh
+++ b/ci.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 if ! command -v cargo-batch &> /dev/null; then
     mkdir -p $HOME/.cargo/bin
-    curl -L https://github.com/embassy-rs/cargo-batch/releases/download/batch-0.5.0/cargo-batch > $HOME/.cargo/bin/cargo-batch
+    curl -L https://github.com/embassy-rs/cargo-batch/releases/download/batch-0.6.0/cargo-batch > $HOME/.cargo/bin/cargo-batch
     chmod +x $HOME/.cargo/bin/cargo-batch
 fi
 

--- a/examples/apache-nimble/src/bin/ble_bas_peripheral.rs
+++ b/examples/apache-nimble/src/bin/ble_bas_peripheral.rs
@@ -31,7 +31,7 @@ async fn main(spawner: embassy_executor::Spawner) {
     // wait for RNG to calm down
     Timer::after(Duration::from_secs(1)).await;
 
-    ble_bas_peripheral::run(controller).await;
+    ble_bas_peripheral::run::<_, 128>(controller).await;
 }
 
 #[embassy_executor::task]

--- a/examples/apps/Cargo.toml
+++ b/examples/apps/Cargo.toml
@@ -27,7 +27,6 @@ defmt = [
     "embedded-io/defmt-03",
     "embedded-hal/defmt-03"
 ]
-esp = []
 log = [
     "dep:log",
     "trouble-host/log",

--- a/examples/apps/src/ble_advertise_multiple.rs
+++ b/examples/apps/src/ble_advertise_multiple.rs
@@ -4,18 +4,13 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, Timer};
 use trouble_host::prelude::*;
 
-/// Size of L2CAP packets (ATT MTU is this - 4)
-const L2CAP_MTU: usize = 27;
-
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
 
 /// Max number of L2CAP channels.
 const L2CAP_CHANNELS_MAX: usize = 2; // Signal + att
 
-type Resources<C> = HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
-
-pub async fn run<C>(controller: C)
+pub async fn run<C, const L2CAP_MTU: usize>(controller: C)
 where
     C: Controller
         + for<'t> ControllerCmdSync<LeSetExtAdvData<'t>>
@@ -29,7 +24,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources = Resources::new(PacketQos::None);
+    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
+        HostResources::new(PacketQos::None);
     let (_, mut peripheral, _, mut runner) = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -2,13 +2,6 @@ use embassy_futures::{join::join, select::select};
 use embassy_time::Timer;
 use trouble_host::prelude::*;
 
-/// Size of L2CAP packets
-#[cfg(not(feature = "esp"))]
-pub const L2CAP_MTU: usize = 251;
-#[cfg(feature = "esp")]
-// Some esp chips only accept an MTU >= 1017
-pub const L2CAP_MTU: usize = 1017;
-
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
 
@@ -16,8 +9,6 @@ const CONNECTIONS_MAX: usize = 1;
 const L2CAP_CHANNELS_MAX: usize = 2; // Signal + att
 
 const MAX_ATTRIBUTES: usize = 10;
-
-type Resources<C> = HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
 
 // GATT Server definition
 #[gatt_server]
@@ -38,16 +29,17 @@ struct BatteryService {
 }
 
 /// Run the BLE stack.
-pub async fn run<C>(controller: C)
+pub async fn run<C, const L2CAP_MTU: usize>(controller: C)
 where
     C: Controller,
 {
     // Using a fixed "random" address can be useful for testing. In real scenarios, one would
     // use e.g. the MAC 6 byte array as the address (how to get that varies by the platform).
-    let address = Address::random([0x41, 0x5A, 0xE3, 0x1E, 0x83, 0xE7]);
+    let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources = Resources::new(PacketQos::None);
+    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
+        HostResources::new(PacketQos::None);
     let (stack, mut peripheral, _, runner) = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -2,34 +2,27 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
-/// How many outgoing L2CAP buffers per link
-const L2CAP_TXQ: u8 = 20;
-
-/// How many incoming L2CAP buffers per link
-const L2CAP_RXQ: u8 = 20;
-
-/// Size of L2CAP packets
-#[cfg(not(feature = "esp"))]
-const L2CAP_MTU: usize = 128;
-#[cfg(feature = "esp")]
-// Some esp chips only accept an MTU >= 1017
-const L2CAP_MTU: usize = 1017;
-
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
 
 /// Max number of L2CAP channels.
 const L2CAP_CHANNELS_MAX: usize = 3; // Signal + att + CoC
 
-type Resources<C> = HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
-
-pub async fn run<C>(controller: C)
+pub async fn run<C, const L2CAP_MTU: usize>(controller: C)
 where
     C: Controller,
 {
-    let mut resources = Resources::new(PacketQos::None);
+    // Using a fixed "random" address can be useful for testing. In real scenarios, one would
+    // use e.g. the MAC 6 byte array as the address (how to get that varies by the platform).
+    let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
+    info!("Our address = {:?}", address);
 
-    let (stack, _, mut central, mut runner) = trouble_host::new(controller, &mut resources).build();
+    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
+        HostResources::new(PacketQos::None);
+
+    let (stack, _, mut central, mut runner) = trouble_host::new(controller, &mut resources)
+        .set_random_address(address)
+        .build();
 
     // NOTE: Modify this to match the address of the peripheral you want to connect to.
     // Currently it matches the address used by the peripheral examples

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -2,26 +2,18 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
-/// Size of L2CAP packets
-#[cfg(not(feature = "esp"))]
-pub const L2CAP_MTU: usize = 128;
-#[cfg(feature = "esp")]
-// Some esp chips only accept an MTU >= 1017
-pub const L2CAP_MTU: usize = 1017;
-
 /// Max number of connections
-pub const CONNECTIONS_MAX: usize = 1;
+const CONNECTIONS_MAX: usize = 1;
 
 /// Max number of L2CAP channels.
-pub const L2CAP_CHANNELS_MAX: usize = 3; // Signal + att + CoC
+const L2CAP_CHANNELS_MAX: usize = 3; // Signal + att + CoC
 
-type Resources<C> = HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU>;
-
-pub async fn run<C>(controller: C)
+pub async fn run<C, const L2CAP_MTU: usize>(controller: C)
 where
     C: Controller,
 {
-    let mut resources = Resources::new(PacketQos::None);
+    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
+        HostResources::new(PacketQos::None);
 
     // Hardcoded peripheral address
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -32,10 +32,10 @@ default = ["esp32c3"]
 #       [1]: https://github.com/embassy-rs/trouble/pull/236#issuecomment-2586457641
 #
 esp32 = ["esp-hal/esp32", "esp-backtrace/esp32", "esp-hal-embassy/esp32", "esp-println/esp32", "esp-wifi/esp32"]
-esp32c2 = ["esp-hal/esp32c2", "esp-backtrace/esp32c2", "esp-hal-embassy/esp32c2", "esp-println/esp32c2", "esp-wifi/esp32c2", "trouble-example-apps/esp"]
+esp32c2 = ["esp-hal/esp32c2", "esp-backtrace/esp32c2", "esp-hal-embassy/esp32c2", "esp-println/esp32c2", "esp-wifi/esp32c2"]
 esp32c3 = ["esp-hal/esp32c3", "esp-backtrace/esp32c3", "esp-hal-embassy/esp32c3", "esp-println/esp32c3", "esp-wifi/esp32c3"]
-esp32c6 = ["esp-hal/esp32c6", "esp-backtrace/esp32c6", "esp-hal-embassy/esp32c6", "esp-println/esp32c6", "esp-wifi/esp32c6", "trouble-example-apps/esp"]
-esp32h2 = ["esp-hal/esp32h2", "esp-backtrace/esp32h2", "esp-hal-embassy/esp32h2", "esp-println/esp32h2", "esp-wifi/esp32h2", "trouble-example-apps/esp"]
+esp32c6 = ["esp-hal/esp32c6", "esp-backtrace/esp32c6", "esp-hal-embassy/esp32c6", "esp-println/esp32c6", "esp-wifi/esp32c6"]
+esp32h2 = ["esp-hal/esp32h2", "esp-backtrace/esp32h2", "esp-hal-embassy/esp32h2", "esp-println/esp32h2", "esp-wifi/esp32h2"]
 esp32s3 = ["esp-hal/esp32s3", "esp-backtrace/esp32s3", "esp-hal-embassy/esp32s3", "esp-println/esp32s3", "esp-wifi/esp32s3"]
 
 [profile.dev]

--- a/examples/esp32/src/bin/ble_bas_central.rs
+++ b/examples/esp32/src/bin/ble_bas_central.rs
@@ -8,6 +8,9 @@ use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_bas_central;
 use {esp_alloc as _, esp_backtrace as _};
 
+#[path = "../consts.rs"]
+mod consts;
+
 #[esp_hal_embassy::main]
 async fn main(_s: Spawner) {
     esp_println::logger::init_logger_from_env();
@@ -40,5 +43,5 @@ async fn main(_s: Spawner) {
     let connector = BleConnector::new(&init, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
-    ble_bas_central::run(controller).await;
+    ble_bas_central::run::<_, { consts::L2CAP_MTU }>(controller).await;
 }

--- a/examples/esp32/src/bin/ble_bas_peripheral.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral.rs
@@ -8,6 +8,9 @@ use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_bas_peripheral;
 use {esp_alloc as _, esp_backtrace as _};
 
+#[path = "../consts.rs"]
+mod consts;
+
 #[esp_hal_embassy::main]
 async fn main(_s: Spawner) {
     esp_println::logger::init_logger_from_env();
@@ -40,5 +43,5 @@ async fn main(_s: Spawner) {
     let connector = BleConnector::new(&init, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
-    ble_bas_peripheral::run(controller).await;
+    ble_bas_peripheral::run::<_, { consts::L2CAP_MTU }>(controller).await;
 }

--- a/examples/esp32/src/bin/ble_l2cap_central.rs
+++ b/examples/esp32/src/bin/ble_l2cap_central.rs
@@ -8,6 +8,9 @@ use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_l2cap_central;
 use {esp_alloc as _, esp_backtrace as _};
 
+#[path = "../consts.rs"]
+mod consts;
+
 #[esp_hal_embassy::main]
 async fn main(_s: Spawner) {
     esp_println::logger::init_logger_from_env();
@@ -40,5 +43,5 @@ async fn main(_s: Spawner) {
     let connector = BleConnector::new(&init, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
-    ble_l2cap_central::run(controller).await;
+    ble_l2cap_central::run::<_, { consts::L2CAP_MTU }>(controller).await;
 }

--- a/examples/esp32/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/esp32/src/bin/ble_l2cap_peripheral.rs
@@ -8,6 +8,9 @@ use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_l2cap_peripheral;
 use {esp_alloc as _, esp_backtrace as _};
 
+#[path = "../consts.rs"]
+mod consts;
+
 #[esp_hal_embassy::main]
 async fn main(_s: Spawner) {
     esp_println::logger::init_logger_from_env();
@@ -40,5 +43,5 @@ async fn main(_s: Spawner) {
     let connector = BleConnector::new(&init, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
-    ble_l2cap_peripheral::run(controller).await;
+    ble_l2cap_peripheral::run::<_, { consts::L2CAP_MTU }>(controller).await;
 }

--- a/examples/esp32/src/consts.rs
+++ b/examples/esp32/src/consts.rs
@@ -1,0 +1,6 @@
+/// Size of L2CAP packets
+#[cfg(not(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2")))]
+pub const L2CAP_MTU: usize = 128;
+// Some esp chips only accept an MTU >= 1017
+#[cfg(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2"))]
+pub const L2CAP_MTU: usize = 1017;

--- a/examples/esp32/src/consts.rs
+++ b/examples/esp32/src/consts.rs
@@ -1,6 +1,6 @@
 /// Size of L2CAP packets
 #[cfg(not(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2")))]
 pub const L2CAP_MTU: usize = 128;
-// Some esp chips only accept an MTU >= 1017
+// Some esp chips only accept an MTU >= 255
 #[cfg(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2"))]
-pub const L2CAP_MTU: usize = 1017;
+pub const L2CAP_MTU: usize = 255;

--- a/examples/nrf-sdc/Cargo.lock
+++ b/examples/nrf-sdc/Cargo.lock
@@ -1093,7 +1093,6 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-hal 1.0.0",
- "embedded-hal-async",
  "embedded-io",
  "static_cell",
  "trouble-host",

--- a/examples/nrf-sdc/src/bin/ble_bas_central.rs
+++ b/examples/nrf-sdc/src/bin/ble_bas_central.rs
@@ -73,5 +73,5 @@ async fn main(spawner: Spawner) {
     let mut sdc_mem = sdc::Mem::<6544>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
 
-    ble_bas_central::run(sdc).await;
+    ble_bas_central::run::<_, L2CAP_MTU>(sdc).await;
 }

--- a/examples/nrf-sdc/src/bin/ble_bas_peripheral.rs
+++ b/examples/nrf-sdc/src/bin/ble_bas_peripheral.rs
@@ -25,6 +25,15 @@ async fn mpsl_task(mpsl: &'static MultiprotocolServiceLayer<'static>) -> ! {
     mpsl.run().await
 }
 
+/// How many outgoing L2CAP buffers per link
+const L2CAP_TXQ: u8 = 3;
+
+/// How many incoming L2CAP buffers per link
+const L2CAP_RXQ: u8 = 3;
+
+/// Size of L2CAP packets
+const L2CAP_MTU: usize = 27;
+
 fn build_sdc<'d, const N: usize>(
     p: nrf_sdc::Peripherals<'d>,
     rng: &'d mut rng::Rng<RNG>,
@@ -35,6 +44,7 @@ fn build_sdc<'d, const N: usize>(
         .support_adv()?
         .support_peripheral()?
         .peripheral_count(1)?
+        .buffer_cfg(L2CAP_MTU as u8, L2CAP_MTU as u8, L2CAP_TXQ, L2CAP_RXQ)?
         .build(p, rng, mpsl, mem)
 }
 
@@ -63,5 +73,5 @@ async fn main(spawner: Spawner) {
     let mut sdc_mem = sdc::Mem::<3312>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
 
-    ble_bas_peripheral::run(sdc).await;
+    ble_bas_peripheral::run::<_, L2CAP_MTU>(sdc).await;
 }

--- a/examples/nrf-sdc/src/bin/ble_l2cap_central.rs
+++ b/examples/nrf-sdc/src/bin/ble_l2cap_central.rs
@@ -76,5 +76,5 @@ async fn main(spawner: Spawner) {
 
     Timer::after(Duration::from_millis(200)).await;
 
-    ble_l2cap_central::run(sdc).await;
+    ble_l2cap_central::run::<_, L2CAP_MTU>(sdc).await;
 }

--- a/examples/nrf-sdc/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/nrf-sdc/src/bin/ble_l2cap_peripheral.rs
@@ -31,8 +31,7 @@ const L2CAP_TXQ: u8 = 20;
 /// How many incoming L2CAP buffers per link
 const L2CAP_RXQ: u8 = 20;
 
-/// Size of L2CAP packets
-const L2CAP_MTU: usize = ble_l2cap_peripheral::L2CAP_MTU;
+const L2CAP_MTU: usize = 27;
 
 fn build_sdc<'d, const N: usize>(
     p: nrf_sdc::Peripherals<'d>,
@@ -73,5 +72,5 @@ async fn main(spawner: Spawner) {
     let mut sdc_mem = sdc::Mem::<12848>::new();
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
 
-    ble_l2cap_peripheral::run(sdc).await;
+    ble_l2cap_peripheral::run::<_, L2CAP_MTU>(sdc).await;
 }

--- a/examples/rp-pico-2-w/src/bin/ble_bas_central.rs
+++ b/examples/rp-pico-2-w/src/bin/ble_bas_central.rs
@@ -65,5 +65,5 @@ async fn main(spawner: Spawner) {
 
     let controller: ExternalController<_, 10> = ExternalController::new(bt_device);
 
-    ble_bas_central::run(controller).await;
+    ble_bas_central::run::<_, 128>(controller).await;
 }

--- a/examples/rp-pico-2-w/src/bin/ble_bas_peripheral.rs
+++ b/examples/rp-pico-2-w/src/bin/ble_bas_peripheral.rs
@@ -65,5 +65,5 @@ async fn main(spawner: Spawner) {
 
     let controller: ExternalController<_, 10> = ExternalController::new(bt_device);
 
-    ble_bas_peripheral::run(controller).await;
+    ble_bas_peripheral::run::<_, 128>(controller).await;
 }

--- a/examples/rp-pico-w/Cargo.lock
+++ b/examples/rp-pico-w/Cargo.lock
@@ -2414,7 +2414,6 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-hal 1.0.0",
- "embedded-hal-async",
  "embedded-io",
  "static_cell",
  "trouble-host",

--- a/examples/rp-pico-w/src/bin/ble_bas_central.rs
+++ b/examples/rp-pico-w/src/bin/ble_bas_central.rs
@@ -65,5 +65,5 @@ async fn main(spawner: Spawner) {
 
     let controller: ExternalController<_, 10> = ExternalController::new(bt_device);
 
-    ble_bas_central::run(controller).await;
+    ble_bas_central::run::<_, 128>(controller).await;
 }

--- a/examples/rp-pico-w/src/bin/ble_bas_peripheral.rs
+++ b/examples/rp-pico-w/src/bin/ble_bas_peripheral.rs
@@ -65,5 +65,5 @@ async fn main(spawner: Spawner) {
 
     let controller: ExternalController<_, 10> = ExternalController::new(bt_device);
 
-    ble_bas_peripheral::run(controller).await;
+    ble_bas_peripheral::run::<_, 128>(controller).await;
 }

--- a/examples/serial-hci/src/bin/ble_bas_peripheral.rs
+++ b/examples/serial-hci/src/bin/ble_bas_peripheral.rs
@@ -51,5 +51,5 @@ async fn main() {
     let driver: SerialTransport<NoopRawMutex, _, _> = SerialTransport::new(reader, writer);
     let controller: ExternalController<_, 10> = ExternalController::new(driver);
 
-    ble_bas_peripheral::run(controller).await;
+    ble_bas_peripheral::run::<_, 128>(controller).await;
 }

--- a/examples/tests/src/probe/mod.rs
+++ b/examples/tests/src/probe/mod.rs
@@ -54,6 +54,9 @@ impl<'d> DeviceUnderTest<'d> {
         select! {
             r = flasher.wait() => {
                 log::warn!("flasher exited unexpectedly: {:?}", r);
+                for line in lines {
+                    log::warn!("{}", line);
+                }
             }
             _ = self.token.cancelled() => {
                 flasher.kill().await.unwrap();

--- a/examples/tests/tests/ble_l2cap_peripheral.rs
+++ b/examples/tests/tests/ble_l2cap_peripheral.rs
@@ -1,14 +1,13 @@
 use futures::future::select;
 use std::time::Duration;
 use tokio::select;
-use trouble_example_tests::{probe, serial, TestContext};
+use trouble_example_tests::{serial, TestContext};
 use trouble_host::prelude::*;
 
 #[tokio::test]
 async fn ble_l2cap_peripheral_nrf52() {
     let _ = pretty_env_logger::try_init();
-    let fw = std::fs::read("bins/nrf-sdc/ble_l2cap_peripheral").unwrap();
-    let firmware = probe::Firmware { data: fw };
+    let firmware = "bins/nrf-sdc/ble_l2cap_peripheral";
     let local = tokio::task::LocalSet::new();
     local
         .run_until(run_l2cap_peripheral_test(
@@ -21,8 +20,7 @@ async fn ble_l2cap_peripheral_nrf52() {
 #[tokio::test]
 async fn ble_l2cap_peripheral_esp32c3() {
     let _ = pretty_env_logger::try_init();
-    let fw = std::fs::read("bins/esp32/ble_l2cap_peripheral").unwrap();
-    let firmware = probe::Firmware { data: fw };
+    let firmware = "bins/esp32/ble_l2cap_peripheral";
     let local = tokio::task::LocalSet::new();
     local
         .run_until(run_l2cap_peripheral_test(
@@ -32,7 +30,7 @@ async fn ble_l2cap_peripheral_esp32c3() {
         .await;
 }
 
-async fn run_l2cap_peripheral_test(labels: &[(&str, &str)], firmware: probe::Firmware) {
+async fn run_l2cap_peripheral_test(labels: &[(&str, &str)], firmware: &str) {
     let ctx = TestContext::new();
     let central = ctx.serial_adapters[0].clone();
 
@@ -42,7 +40,7 @@ async fn run_l2cap_peripheral_test(labels: &[(&str, &str)], firmware: probe::Fir
     let token = dut.token();
 
     // Spawn a runner for the target
-    let peripheral = tokio::task::spawn_local(dut.run(firmware));
+    let peripheral = tokio::task::spawn_local(dut.run(firmware.to_string()));
 
     // Run the central in the test using the serial adapter to verify
     let peripheral_address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);


### PR DESCRIPTION
* Make l2cap_mtu a const generic pass in from application
* Move esp32-specific logic into esp32 examples
