### PR TITLE
refactor: remove C from HostResources

### DIFF
--- a/examples/apps/src/ble_advertise_multiple.rs
+++ b/examples/apps/src/ble_advertise_multiple.rs
@@ -24,11 +24,9 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
-        HostResources::new(PacketQos::None);
-    let (_, mut peripheral, _, mut runner) = trouble_host::new(controller, &mut resources)
-        .set_random_address(address)
-        .build();
+    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let (mut peripheral, _, mut runner) = stack.build();
 
     let mut adv_data = [0; 31];
     let len = AdStructure::encode_slice(

--- a/examples/apps/src/ble_bas_central.rs
+++ b/examples/apps/src/ble_bas_central.rs
@@ -17,11 +17,9 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
-        HostResources::new(PacketQos::None);
-    let (stack, _, mut central, mut runner) = trouble_host::new(controller, &mut resources)
-        .set_random_address(address)
-        .build();
+    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let (_, mut central, mut runner) = stack.build();
 
     // NOTE: Modify this to match the address of the peripheral you want to connect to.
     // Currently it matches the address used by the peripheral examples
@@ -42,7 +40,7 @@ where
         let conn = central.connect(&config).await.unwrap();
         info!("Connected, creating gatt client");
 
-        let client = GattClient::<C, 10, 24>::new(stack, &conn).await.unwrap();
+        let client = GattClient::<C, 10, 24>::new(&stack, &conn).await.unwrap();
 
         let _ = join(client.task(), async {
             info!("Looking for battery service");

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -38,11 +38,9 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
-        HostResources::new(PacketQos::None);
-    let (stack, mut peripheral, _, runner) = trouble_host::new(controller, &mut resources)
-        .set_random_address(address)
-        .build();
+    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let (mut peripheral, _, runner) = stack.build();
 
     info!("Starting advertising and GATT service");
     let server = Server::new_with_config(GapConfig::Peripheral(PeripheralConfig {
@@ -57,7 +55,7 @@ where
                 Ok(conn) => {
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let a = gatt_events_task(&server, &conn);
-                    let b = custom_task(&server, &conn, stack);
+                    let b = custom_task(&server, &conn, &stack);
                     // run until any task ends (usually because the connection has been closed),
                     // then return to advertising state.
                     select(a, b).await;
@@ -176,7 +174,7 @@ async fn advertise<'a, C: Controller>(
 /// This task will notify the connected central of a counter value every 2 seconds.
 /// It will also read the RSSI value every 2 seconds.
 /// and will stop when the connection is closed by the central or an error occurs.
-async fn custom_task<C: Controller>(server: &Server<'_>, conn: &Connection<'_>, stack: Stack<'_, C>) {
+async fn custom_task<C: Controller>(server: &Server<'_>, conn: &Connection<'_>, stack: &Stack<'_, C>) {
     let mut tick: u8 = 0;
     let level = server.battery_service.level;
     loop {

--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -17,12 +17,9 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<C, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> =
-        HostResources::new(PacketQos::None);
-
-    let (stack, _, mut central, mut runner) = trouble_host::new(controller, &mut resources)
-        .set_random_address(address)
-        .build();
+    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let (_, mut central, mut runner) = stack.build();
 
     // NOTE: Modify this to match the address of the peripheral you want to connect to.
     // Currently it matches the address used by the peripheral examples
@@ -42,18 +39,18 @@ where
             let conn = central.connect(&config).await.unwrap();
             info!("Connected, creating l2cap channel");
             const PAYLOAD_LEN: usize = 27;
-            let mut ch1 = L2capChannel::create(stack, &conn, 0x2349, &Default::default())
+            let mut ch1 = L2capChannel::create(&stack, &conn, 0x2349, &Default::default())
                 .await
                 .unwrap();
             info!("New l2cap channel created, sending some data!");
             for i in 0..10 {
                 let tx = [i; PAYLOAD_LEN];
-                ch1.send::<_, PAYLOAD_LEN>(stack, &tx).await.unwrap();
+                ch1.send::<_, PAYLOAD_LEN>(&stack, &tx).await.unwrap();
             }
             info!("Sent data, waiting for them to be sent back");
             let mut rx = [0; PAYLOAD_LEN];
             for i in 0..10 {
-                let len = ch1.receive(stack, &mut rx).await.unwrap();
+                let len = ch1.receive(&stack, &mut rx).await.unwrap();
                 assert_eq!(len, rx.len());
                 assert_eq!(rx, [i; PAYLOAD_LEN]);
             }

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -12,13 +12,13 @@ use embassy_sync::waitqueue::WakerRegistration;
 use crate::cursor::WriteCursor;
 use crate::host::{AclSender, BleHost};
 use crate::l2cap::L2capChannel;
-use crate::packet_pool::{AllocId, DynamicPacketPool, Packet};
+use crate::packet_pool::{Packet, Pool};
 use crate::pdu::Pdu;
 use crate::types::l2cap::{
     CommandRejectRes, ConnParamUpdateReq, ConnParamUpdateRes, DisconnectionReq, DisconnectionRes, L2capHeader,
     L2capSignalCode, L2capSignalHeader, LeCreditConnReq, LeCreditConnRes, LeCreditConnResultCode, LeCreditFlowInd,
 };
-use crate::{BleHostError, Error};
+use crate::{config, BleHostError, Error};
 
 const BASE_ID: u16 = 0x40;
 
@@ -31,37 +31,37 @@ struct State<'d> {
 }
 
 /// Channel manager for L2CAP channels used directly by clients.
-pub struct ChannelManager<'d, const RXQ: usize> {
-    pool: &'d dyn DynamicPacketPool<'d>,
+pub struct ChannelManager<'d> {
+    pool: &'d dyn Pool,
     state: RefCell<State<'d>>,
-    inbound: &'d mut [PacketChannel<'d, RXQ>],
+    inbound: &'d mut [PacketChannel<{ config::L2CAP_RX_QUEUE_SIZE }>],
 }
 
-pub(crate) struct PacketChannel<'d, const QLEN: usize> {
-    chan: Channel<NoopRawMutex, Option<Pdu<'d>>, QLEN>,
+pub(crate) struct PacketChannel<const QLEN: usize> {
+    chan: Channel<NoopRawMutex, Option<Pdu>, QLEN>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ChannelIndex(u8);
 
-impl<'d, const QLEN: usize> PacketChannel<'d, QLEN> {
+impl<const QLEN: usize> PacketChannel<QLEN> {
     #[allow(clippy::declare_interior_mutable_const)]
-    pub(crate) const NEW: PacketChannel<'d, QLEN> = PacketChannel { chan: Channel::new() };
+    pub(crate) const NEW: PacketChannel<QLEN> = PacketChannel { chan: Channel::new() };
 
     pub fn close(&self) -> Result<(), ()> {
         self.chan.try_send(None).map_err(|_| ())
     }
 
-    pub async fn send(&self, pdu: Pdu<'d>) {
+    pub async fn send(&self, pdu: Pdu) {
         self.chan.send(Some(pdu)).await;
     }
 
-    pub fn try_send(&self, pdu: Pdu<'d>) -> Result<(), Error> {
+    pub fn try_send(&self, pdu: Pdu) -> Result<(), Error> {
         self.chan.try_send(Some(pdu)).map_err(|_| Error::OutOfMemory)
     }
 
-    pub async fn receive(&self) -> Option<Pdu<'d>> {
+    pub async fn receive(&self) -> Option<Pdu> {
         self.chan.receive().await
     }
 
@@ -94,11 +94,11 @@ impl State<'_> {
     }
 }
 
-impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
+impl<'d> ChannelManager<'d> {
     pub fn new(
-        pool: &'d dyn DynamicPacketPool<'d>,
+        pool: &'d dyn Pool,
         channels: &'d mut [ChannelStorage],
-        inbound: &'d mut [PacketChannel<'d, RXQ>],
+        inbound: &'d mut [PacketChannel<{ config::L2CAP_RX_QUEUE_SIZE }>],
     ) -> Self {
         Self {
             pool,
@@ -178,7 +178,7 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
                         chan.mtu = mtu;
                         chan.flow_control = CreditFlowControl::new(
                             credit_flow,
-                            initial_credits.unwrap_or(self.pool.min_available(AllocId::from_channel(chan.cid)) as u16),
+                            initial_credits.unwrap_or(self.pool.available() as u16),
                         );
                         chan.state = ChannelState::Connected;
                         let mps = chan.mps;
@@ -237,7 +237,7 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
         // Allocate space for our new channel.
         let idx = self.alloc(conn, |storage| {
             cid = storage.cid;
-            credits = initial_credits.unwrap_or(self.pool.min_available(AllocId::from_channel(storage.cid)) as u16);
+            credits = initial_credits.unwrap_or(self.pool.available() as u16);
             storage.psm = psm;
             storage.mps = mps;
             storage.mtu = mtu;
@@ -300,7 +300,7 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
     }
 
     /// Dispatch an incoming L2CAP packet to the appropriate channel.
-    pub(crate) fn dispatch(&self, header: L2capHeader, packet: Packet<'d>) -> Result<(), Error> {
+    pub(crate) fn dispatch(&self, header: L2capHeader, packet: Packet) -> Result<(), Error> {
         if header.channel < BASE_ID {
             return Err(Error::InvalidChannelId);
         }
@@ -522,7 +522,7 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
         Ok(pos)
     }
 
-    async fn receive_pdu(&self, chan: ChannelIndex) -> Result<Pdu<'d>, Error> {
+    async fn receive_pdu(&self, chan: ChannelIndex) -> Result<Pdu, Error> {
         match self.inbound[chan.0 as usize].receive().await {
             Some(pdu) => Ok(pdu),
             None => Err(Error::ChannelClosed),
@@ -625,7 +625,7 @@ impl<'d, const RXQ: usize> ChannelManager<'d, RXQ> {
         &self,
         index: ChannelIndex,
         ble: &BleHost<'d, T>,
-        mut packet: Packet<'d>,
+        mut packet: Packet,
     ) -> Result<(), BleHostError<T::Error>> {
         let (conn, cid, credits) = self.with_mut(|state| {
             let chan = &mut state.channels[index.0 as usize];
@@ -800,7 +800,7 @@ pub(crate) trait DynamicChannelManager {
     fn print(&self, index: ChannelIndex, f: defmt::Formatter);
 }
 
-impl<const RXQ: usize> DynamicChannelManager for ChannelManager<'_, RXQ> {
+impl DynamicChannelManager for ChannelManager<'_> {
     fn inc_ref(&self, index: ChannelIndex) {
         ChannelManager::inc_ref(self, index)
     }
@@ -1010,12 +1010,11 @@ mod tests {
 
     use super::*;
     use crate::mock_controller::MockController;
-    use crate::packet_pool::Qos;
     use crate::HostResources;
 
     #[test]
     fn channel_refcount() {
-        let mut resources: HostResources<MockController, 2, 2, 27> = HostResources::new(Qos::None);
+        let mut resources: HostResources<2, 2, 27> = HostResources::new();
         let ble = MockController::new();
 
         let builder = crate::new(ble, &mut resources);

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -73,14 +73,14 @@ impl<'d> L2capChannel<'d> {
     /// If there are no available credits to send, waits until more credits are available.
     pub async fn send<T: Controller, const TX_MTU: usize>(
         &mut self,
-        stack: Stack<'_, T>,
+        stack: &Stack<'_, T>,
         buf: &[u8],
     ) -> Result<(), BleHostError<T::Error>> {
         let mut p_buf = [0u8; TX_MTU];
         stack
             .host
             .channels
-            .send(self.index, buf, &mut p_buf[..], stack.host)
+            .send(self.index, buf, &mut p_buf[..], &stack.host)
             .await
     }
 
@@ -92,14 +92,14 @@ impl<'d> L2capChannel<'d> {
     /// If there are no available credits to send, returns Error::Busy.
     pub fn try_send<T: Controller + blocking::Controller, const TX_MTU: usize>(
         &mut self,
-        stack: Stack<'_, T>,
+        stack: &Stack<'_, T>,
         buf: &[u8],
     ) -> Result<(), BleHostError<T::Error>> {
         let mut p_buf = [0u8; TX_MTU];
         stack
             .host
             .channels
-            .try_send(self.index, buf, &mut p_buf[..], stack.host)
+            .try_send(self.index, buf, &mut p_buf[..], &stack.host)
     }
 
     /// Receive data on this channel and copy it into the buffer.
@@ -107,15 +107,15 @@ impl<'d> L2capChannel<'d> {
     /// The length provided buffer slice must be equal or greater to the agreed MTU.
     pub async fn receive<T: Controller>(
         &mut self,
-        stack: Stack<'_, T>,
+        stack: &Stack<'_, T>,
         buf: &mut [u8],
     ) -> Result<usize, BleHostError<T::Error>> {
-        stack.host.channels.receive(self.index, buf, stack.host).await
+        stack.host.channels.receive(self.index, buf, &stack.host).await
     }
 
     /// Await an incoming connection request matching the list of PSM.
     pub async fn accept<T: Controller>(
-        stack: Stack<'d, T>,
+        stack: &'d Stack<'d, T>,
         connection: &Connection<'_>,
         psm: &[u16],
         config: &L2capChannelConfig,
@@ -130,14 +130,14 @@ impl<'d> L2capChannel<'d> {
                 config.mtu,
                 config.flow_policy,
                 config.initial_credits,
-                stack.host,
+                &stack.host,
             )
             .await
     }
 
     /// Create a new connection request with the provided PSM.
     pub async fn create<T: Controller>(
-        stack: Stack<'d, T>,
+        stack: &'d Stack<'d, T>,
         connection: &Connection<'_>,
         psm: u16,
         config: &L2capChannelConfig,
@@ -152,7 +152,7 @@ where {
                 config.mtu,
                 config.flow_policy,
                 config.initial_credits,
-                stack.host,
+                &stack.host,
             )
             .await
     }

--- a/host/src/packet_pool.rs
+++ b/host/src/packet_pool.rs
@@ -1,34 +1,8 @@
 //! A packet pool for allocating and freeing packet buffers with quality of service policy.
 use core::cell::RefCell;
 
-use embassy_sync::blocking_mutex::raw::RawMutex;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::blocking_mutex::Mutex;
-
-use crate::types::l2cap::{L2CAP_CID_ATT, L2CAP_CID_DYN_START};
-
-// Generic client ID used by ATT PDU
-pub(crate) const GENERIC_ID: AllocId = AllocId(0);
-
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub(crate) struct AllocId(usize);
-
-impl AllocId {
-    pub(crate) fn dynamic(idx: usize) -> AllocId {
-        // Dynamic range starts at 2
-        AllocId(1 + idx)
-    }
-
-    pub(crate) fn from_channel(cid: u16) -> AllocId {
-        match cid {
-            L2CAP_CID_ATT => GENERIC_ID,
-            cid if cid >= L2CAP_CID_DYN_START => Self::dynamic((cid - L2CAP_CID_DYN_START) as usize),
-            cid => {
-                panic!("unexpected channel id {}", cid);
-            }
-        }
-    }
-}
 
 struct PacketBuf<const MTU: usize> {
     buf: [u8; MTU],
@@ -46,73 +20,23 @@ impl<const MTU: usize> PacketBuf<MTU> {
     }
 }
 
-/// Quality of service policy for packet allocation
-#[derive(Clone, Copy, Default)]
-pub enum Qos {
-    /// Distribute evenly among client
-    Fair,
-    /// Reserve at least N packets for each client
-    Guaranteed(usize),
-    /// No guarantees
-    #[default]
-    None,
-}
-
-struct State<const MTU: usize, const N: usize, const CLIENTS: usize> {
+struct State<const MTU: usize, const N: usize> {
     packets: [PacketBuf<MTU>; N],
-    usage: [usize; CLIENTS],
 }
 
-impl<const MTU: usize, const N: usize, const CLIENTS: usize> State<MTU, N, CLIENTS> {
+impl<const MTU: usize, const N: usize> State<MTU, N> {
     pub(crate) const fn new() -> Self {
         Self {
             packets: [PacketBuf::NEW; N],
-            usage: [0; CLIENTS],
         }
     }
 
-    // Guaranteed available
-    fn min_available(&self, qos: Qos, client: AllocId) -> usize {
-        let min = match qos {
-            Qos::None => N.saturating_sub(self.usage.iter().sum()),
-            Qos::Fair => (N / CLIENTS).saturating_sub(self.usage[client.0]),
-            Qos::Guaranteed(n) => {
-                let usage = self.usage[client.0];
-                n.saturating_sub(usage)
-            }
-        };
-        // info!("Min available for {}: {} (usage: {})", client.0, min, usage[client.0]);
-        min
-    }
-
-    fn available(&self, qos: Qos, client: AllocId) -> usize {
-        let available = match qos {
-            Qos::None => N.saturating_sub(self.usage.iter().sum()),
-            Qos::Fair => (N / CLIENTS).saturating_sub(self.usage[client.0]),
-            Qos::Guaranteed(n) => {
-                // Reserved for clients that should have minimum
-                let reserved = n * self.usage.iter().filter(|c| **c == 0).count();
-                let reserved = reserved
-                    - if self.usage[client.0] < n {
-                        n - self.usage[client.0]
-                    } else {
-                        0
-                    };
-                let usage = reserved + self.usage.iter().sum::<usize>();
-                N.saturating_sub(usage)
-            }
-        };
-        // info!("Available for {}: {} (usage {})", client.0, available, usage[client.0]);
-        available
-    }
-
-    fn alloc(&mut self, id: AllocId) -> Option<PacketRef> {
+    fn alloc(&mut self) -> Option<PacketRef> {
         for (idx, packet) in self.packets.iter_mut().enumerate() {
             if packet.free {
                 // info!("[{}] alloc {}", id.0, idx);
                 packet.free = false;
                 packet.buf.iter_mut().for_each(|b| *b = 0);
-                self.usage[id.0] += 1;
                 return Some(PacketRef {
                     idx,
                     buf: &mut packet.buf[..],
@@ -122,105 +46,86 @@ impl<const MTU: usize, const N: usize, const CLIENTS: usize> State<MTU, N, CLIEN
         None
     }
 
-    fn free(&mut self, id: AllocId, p_ref: PacketRef) {
+    fn free(&mut self, p_ref: PacketRef) {
         // info!("[{}] free {}", id.0, p_ref.idx);
         self.packets[p_ref.idx].free = true;
-        self.usage[id.0] -= 1;
+    }
+
+    fn available(&mut self) -> usize {
+        self.packets.iter().filter(|p| p.free).count()
     }
 }
 
 /// A packet pool holds a pool of packet buffers that can be dynamically allocated
 /// and free'd.
-///
-/// The pool has a concept QoS to control quota for multiple clients.
-pub struct PacketPool<M: RawMutex, const MTU: usize, const N: usize, const CLIENTS: usize> {
-    state: Mutex<M, RefCell<State<MTU, N, CLIENTS>>>,
-    qos: Qos,
+pub struct PacketPool<const MTU: usize, const N: usize> {
+    state: Mutex<NoopRawMutex, RefCell<State<MTU, N>>>,
 }
 
-impl<M: RawMutex, const MTU: usize, const N: usize, const CLIENTS: usize> PacketPool<M, MTU, N, CLIENTS> {
+impl<const MTU: usize, const N: usize> Default for PacketPool<MTU, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const MTU: usize, const N: usize> PacketPool<MTU, N> {
     /// Create a new packet pool with the given QoS policy
-    pub fn new(qos: Qos) -> Self {
-        // Need at least 1 for gatt
-        assert!(CLIENTS >= 1);
-        match qos {
-            Qos::None => {}
-            Qos::Fair => {
-                assert!(N >= CLIENTS);
-            }
-            Qos::Guaranteed(n) => {
-                assert!(N >= n);
-            }
-        }
+    pub fn new() -> Self {
         Self {
             state: Mutex::new(RefCell::new(State::new())),
-            qos,
         }
     }
 
-    fn alloc(&self, id: AllocId) -> Option<Packet> {
+    fn alloc(&self) -> Option<Packet> {
         self.state.lock(|state| {
             let mut state = state.borrow_mut();
-            let available = state.available(self.qos, id);
-            if available == 0 {
-                return None;
-            }
-
-            state.alloc(id).map(|p_ref| Packet {
-                client: id,
+            state.alloc().map(|p_ref| Packet {
                 p_ref: Some(p_ref),
                 pool: self,
             })
         })
     }
 
-    fn free(&self, id: AllocId, p_ref: PacketRef) {
+    fn free(&self, p_ref: PacketRef) {
         self.state.lock(|state| {
             let mut state = state.borrow_mut();
-            state.free(id, p_ref);
+            state.free(p_ref);
         });
     }
 
-    fn min_available(&self, id: AllocId) -> usize {
+    fn available(&self) -> usize {
         self.state.lock(|state| {
-            let state = state.borrow();
-            state.min_available(self.qos, id)
-        })
-    }
-
-    fn available(&self, id: AllocId) -> usize {
-        self.state.lock(|state| {
-            let state = state.borrow();
-            state.available(self.qos, id)
+            let mut state = state.borrow_mut();
+            state.available()
         })
     }
 }
 
-pub(crate) trait DynamicPacketPool<'d> {
-    fn alloc(&'d self, id: AllocId) -> Option<Packet<'d>>;
-    fn free(&self, id: AllocId, r: PacketRef);
-    fn available(&self, id: AllocId) -> usize;
-    fn min_available(&self, id: AllocId) -> usize;
+/// Type erased packet pool
+pub(crate) trait Pool {
+    /// Allocate a packet
+    ///
+    /// Returns None if out of memory.
+    fn alloc(&self) -> Option<Packet>;
+    /// Free a packet given it's reference.
+    fn free(&self, r: PacketRef);
+    /// Check for available packets.
+    fn available(&self) -> usize;
+    /// Check packet size.
     fn mtu(&self) -> usize;
 }
 
-impl<'d, M: RawMutex, const MTU: usize, const N: usize, const CLIENTS: usize> DynamicPacketPool<'d>
-    for PacketPool<M, MTU, N, CLIENTS>
-{
-    fn alloc(&'d self, id: AllocId) -> Option<Packet<'d>> {
-        PacketPool::alloc(self, id)
+impl<const MTU: usize, const N: usize> Pool for PacketPool<MTU, N> {
+    fn alloc(&self) -> Option<Packet> {
+        PacketPool::alloc(self)
     }
 
-    fn min_available(&self, id: AllocId) -> usize {
-        PacketPool::min_available(self, id)
+    fn free(&self, r: PacketRef) {
+        PacketPool::free(self, r)
     }
 
-    fn available(&self, id: AllocId) -> usize {
-        PacketPool::available(self, id)
-    }
-
-    fn free(&self, id: AllocId, r: PacketRef) {
-        PacketPool::free(self, id, r)
+    fn available(&self) -> usize {
+        PacketPool::available(self)
     }
 
     fn mtu(&self) -> usize {
@@ -228,18 +133,19 @@ impl<'d, M: RawMutex, const MTU: usize, const N: usize, const CLIENTS: usize> Dy
     }
 }
 
+#[repr(C)]
 pub(crate) struct PacketRef {
     idx: usize,
     buf: *mut [u8],
 }
 
-pub(crate) struct Packet<'d> {
-    client: AllocId,
+#[repr(C)]
+pub(crate) struct Packet {
     p_ref: Option<PacketRef>,
-    pool: &'d dyn DynamicPacketPool<'d>,
+    pool: *const dyn Pool,
 }
 
-impl Packet<'_> {
+impl Packet {
     pub(crate) fn len(&self) -> usize {
         self.as_ref().len()
     }
@@ -249,22 +155,23 @@ impl Packet<'_> {
     }
 }
 
-impl Drop for Packet<'_> {
+impl Drop for Packet {
     fn drop(&mut self) {
         if let Some(r) = self.p_ref.take() {
-            self.pool.free(self.client, r);
+            let pool = unsafe { &*self.pool };
+            pool.free(r);
         }
     }
 }
 
-impl AsRef<[u8]> for Packet<'_> {
+impl AsRef<[u8]> for Packet {
     fn as_ref(&self) -> &[u8] {
         let p = self.p_ref.as_ref().unwrap();
         unsafe { &(*p.buf)[..] }
     }
 }
 
-impl AsMut<[u8]> for Packet<'_> {
+impl AsMut<[u8]> for Packet {
     fn as_mut(&mut self) -> &mut [u8] {
         let p = self.p_ref.as_mut().unwrap();
         unsafe { &mut (*p.buf)[..] }
@@ -273,110 +180,34 @@ impl AsMut<[u8]> for Packet<'_> {
 
 #[cfg(test)]
 mod tests {
-    use embassy_sync::blocking_mutex::raw::NoopRawMutex;
     use static_cell::StaticCell;
 
     use super::*;
 
     #[test]
-    fn test_fair_qos() {
-        static POOL: StaticCell<PacketPool<NoopRawMutex, 1, 8, 4>> = StaticCell::new();
-        let pool = POOL.init(PacketPool::new(Qos::Fair));
-
-        let a1 = pool.alloc(AllocId(0));
-        assert!(a1.is_some());
-        let a2 = pool.alloc(AllocId(0));
-        assert!(a2.is_some());
-        assert!(pool.alloc(AllocId(0)).is_none());
-        drop(a2);
-        let a3 = pool.alloc(AllocId(0));
-        assert!(a3.is_some());
-
-        let b1 = pool.alloc(AllocId(1));
-        assert!(b1.is_some());
-
-        let c1 = pool.alloc(AllocId(2));
-        assert!(c1.is_some());
-    }
-
-    #[test]
     fn test_none_qos() {
-        static POOL: StaticCell<PacketPool<NoopRawMutex, 1, 8, 4>> = StaticCell::new();
-        let pool = POOL.init(PacketPool::new(Qos::None));
+        static POOL: StaticCell<PacketPool<1, 8>> = StaticCell::new();
+        let pool = POOL.init(PacketPool::new());
 
-        let a1 = pool.alloc(AllocId(0));
+        let a1 = pool.alloc();
         assert!(a1.is_some());
-        let a2 = pool.alloc(AllocId(0));
+        let a2 = pool.alloc();
         assert!(a2.is_some());
-        let a3 = pool.alloc(AllocId(0));
+        let a3 = pool.alloc();
         assert!(a3.is_some());
-        let a4 = pool.alloc(AllocId(0));
+        let a4 = pool.alloc();
         assert!(a4.is_some());
-        let a5 = pool.alloc(AllocId(0));
+        let a5 = pool.alloc();
         assert!(a5.is_some());
-        let a6 = pool.alloc(AllocId(0));
+        let a6 = pool.alloc();
         assert!(a6.is_some());
-        let a7 = pool.alloc(AllocId(0));
+        let a7 = pool.alloc();
         assert!(a7.is_some());
 
-        let b1 = pool.alloc(AllocId(1));
+        let b1 = pool.alloc();
         assert!(b1.is_some());
 
-        let b2 = pool.alloc(AllocId(1));
+        let b2 = pool.alloc();
         assert!(b2.is_none());
-    }
-
-    #[test]
-    fn test_guaranteed_qos() {
-        static POOL: StaticCell<PacketPool<NoopRawMutex, 1, 8, 4>> = StaticCell::new();
-        let pool = POOL.init(PacketPool::new(Qos::Guaranteed(1)));
-
-        let a1 = pool.alloc(AllocId(0));
-        assert!(a1.is_some());
-        let a2 = pool.alloc(AllocId(0));
-        assert!(a2.is_some());
-        let a3 = pool.alloc(AllocId(0));
-        assert!(a3.is_some());
-        let a4 = pool.alloc(AllocId(0));
-        assert!(a4.is_some());
-        let a5 = pool.alloc(AllocId(0));
-        assert!(a5.is_some());
-        // Needs at least 3 for the other clients
-        assert!(pool.alloc(AllocId(0)).is_none());
-
-        let b1 = pool.alloc(AllocId(1));
-        assert!(b1.is_some());
-        assert!(pool.alloc(AllocId(1)).is_none());
-
-        let c1 = pool.alloc(AllocId(2));
-        assert!(c1.is_some());
-        assert!(pool.alloc(AllocId(2)).is_none());
-
-        let d1 = pool.alloc(AllocId(3));
-        assert!(d1.is_some());
-        assert!(pool.alloc(AllocId(3)).is_none());
-    }
-
-    #[test]
-    fn test_guaranteed_qos_many() {
-        static POOL: StaticCell<PacketPool<NoopRawMutex, 1, 8, 8>> = StaticCell::new();
-        let pool = POOL.init(PacketPool::new(Qos::Guaranteed(1)));
-
-        let a1 = pool.alloc(AllocId(0));
-        assert!(a1.is_some());
-        // Needs at least 1 for the other clients
-        assert!(pool.alloc(AllocId(0)).is_none());
-
-        let b1 = pool.alloc(AllocId(1));
-        assert!(b1.is_some());
-        assert!(pool.alloc(AllocId(1)).is_none());
-
-        let c1 = pool.alloc(AllocId(2));
-        assert!(c1.is_some());
-        assert!(pool.alloc(AllocId(2)).is_none());
-
-        let d1 = pool.alloc(AllocId(3));
-        assert!(d1.is_some());
-        assert!(pool.alloc(AllocId(3)).is_none());
     }
 }

--- a/host/src/pdu.rs
+++ b/host/src/pdu.rs
@@ -1,23 +1,23 @@
 use crate::packet_pool::Packet;
 
-pub(crate) struct Pdu<'d> {
-    pub packet: Packet<'d>,
+pub(crate) struct Pdu {
+    pub packet: Packet,
     pub len: usize,
 }
 
-impl<'d> Pdu<'d> {
-    pub(crate) fn new(packet: Packet<'d>, len: usize) -> Self {
+impl Pdu {
+    pub(crate) fn new(packet: Packet, len: usize) -> Self {
         Self { packet, len }
     }
 }
 
-impl AsRef<[u8]> for Pdu<'_> {
+impl AsRef<[u8]> for Pdu {
     fn as_ref(&self) -> &[u8] {
         &self.packet.as_ref()[..self.len]
     }
 }
 
-impl AsMut<[u8]> for Pdu<'_> {
+impl AsMut<[u8]> for Pdu {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.packet.as_mut()[..self.len]
     }

--- a/host/src/peripheral.rs
+++ b/host/src/peripheral.rs
@@ -14,11 +14,11 @@ use crate::{Address, BleHostError, Error, Stack};
 
 /// Type which implements the BLE peripheral role.
 pub struct Peripheral<'d, C: Controller> {
-    stack: Stack<'d, C>,
+    stack: &'d Stack<'d, C>,
 }
 
 impl<'d, C: Controller> Peripheral<'d, C> {
-    pub(crate) fn new(stack: Stack<'d, C>) -> Self {
+    pub(crate) fn new(stack: &'d Stack<'d, C>) -> Self {
         Self { stack }
     }
 
@@ -34,7 +34,7 @@ impl<'d, C: Controller> Peripheral<'d, C> {
             + for<'t> ControllerCmdSync<LeSetAdvEnable>
             + for<'t> ControllerCmdSync<LeSetScanResponseData>,
     {
-        let host = self.stack.host;
+        let host = &self.stack.host;
 
         // Ensure no other advertise ongoing.
         let drop = crate::host::OnDrop::new(|| {
@@ -128,7 +128,7 @@ impl<'d, C: Controller> Peripheral<'d, C> {
             + for<'t> ControllerCmdSync<LeSetExtScanResponseData<'t>>,
     {
         assert_eq!(sets.len(), handles.len());
-        let host = self.stack.host;
+        let host = &self.stack.host;
         // Check host supports the required advertisement sets
         {
             let result = host.command(LeReadNumberOfSupportedAdvSets::new()).await?;
@@ -219,7 +219,7 @@ impl<'d, C: Controller> Peripheral<'d, C> {
 
 /// Handle to an active advertiser which can accept connections.
 pub struct Advertiser<'d, C: Controller> {
-    stack: Stack<'d, C>,
+    stack: &'d Stack<'d, C>,
     extended: bool,
     done: bool,
 }

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -1,6 +1,6 @@
 //! Scan config.
-use crate::central::ScanConfig;
 use crate::command::CommandState;
+use crate::connection::ScanConfig;
 use crate::host::ScanState;
 use crate::BleHostError;
 use crate::Error;
@@ -54,7 +54,7 @@ impl<'d, C: Controller, const BUFFER_SIZE: usize> Scanner<'d, C, BUFFER_SIZE> {
             + ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>,
     {
-        let host = self.central.stack.host;
+        let host = &self.central.stack.host;
         let drop = crate::host::OnDrop::new(|| {
             host.scan_command_state.cancel(false);
             host.scan_state.stop();
@@ -68,7 +68,7 @@ impl<'d, C: Controller, const BUFFER_SIZE: usize> Scanner<'d, C, BUFFER_SIZE> {
             scan_window: config.window.into(),
         };
         let phy_params = crate::central::create_phy_params(scanning, config.phys);
-        let host = self.central.stack.host;
+        let host = &self.central.stack.host;
         host.command(LeSetExtScanParams::new(
             host.address.map(|s| s.kind).unwrap_or(AddrKind::PUBLIC),
             if config.filter_accept_list.is_empty() {
@@ -118,7 +118,7 @@ impl<'d, C: Controller, const BUFFER_SIZE: usize> Scanner<'d, C, BUFFER_SIZE> {
             + ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>,
     {
-        let host = self.central.stack.host;
+        let host = &self.central.stack.host;
         let drop = crate::host::OnDrop::new(|| {
             host.scan_command_state.cancel(false);
             host.scan_state.stop();

--- a/host/tests/common.rs
+++ b/host/tests/common.rs
@@ -7,6 +7,7 @@ use tokio::io::{ReadHalf, WriteHalf};
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 
+#[allow(dead_code)]
 pub type Controller = ExternalController<
     SerialTransport<NoopRawMutex, FromTokio<ReadHalf<SerialStream>>, FromTokio<WriteHalf<SerialStream>>>,
     10,


### PR DESCRIPTION
* Refactor API to remove C: Controller from HostResources
* Remove Clone + Copy on Stack and use it to hold the BleHost
* Remove all 'internal' lifetime of elements within channels. Guarantee their lifetime in types that is handed ownership of elements from channels.
* Simplify packet pool, removing the QoS flag.

Issue #252