### PR TITLE
Fixed a bug when setting the size of the `send`'s `TX_MTU`

### DIFF
--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -26,7 +26,7 @@ where
     } = stack.build();
 
     // NOTE: Modify this to match the address of the peripheral you want to connect to.
-    // Currently it matches the address used by the peripheral examples
+    // Currently, it matches the address used by the peripheral examples
     let target: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
 
     let config = ConnectConfig {
@@ -49,7 +49,7 @@ where
             info!("New l2cap channel created, sending some data!");
             for i in 0..10 {
                 let tx = [i; PAYLOAD_LEN];
-                ch1.send::<_, PAYLOAD_LEN>(&stack, &tx).await.unwrap();
+                ch1.send::<_, L2CAP_MTU>(&stack, &tx).await.unwrap();
             }
             info!("Sent data, waiting for them to be sent back");
             let mut rx = [0; PAYLOAD_LEN];

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -70,7 +70,7 @@ where
             Timer::after(Duration::from_secs(1)).await;
             for i in 0..10 {
                 let tx = [i; PAYLOAD_LEN];
-                ch1.send::<_, PAYLOAD_LEN>(&stack, &tx).await.unwrap();
+                ch1.send::<_, L2CAP_MTU>(&stack, &tx).await.unwrap();
             }
             info!("L2CAP data echoed");
 


### PR DESCRIPTION
The `ch1.send`'s `TX_MTU` generic const was set to the `PAYLOAD_LEN` which is always going to be wrong as the `encode` method adds 4 to 6 bytes at the start of the payload. This has been updated to `L2CAP_MTU`; the maximum allowed size.