### PR TITLE
add 128 and 16 bit conversions to Uuid

### DIFF
--- a/host/src/types/uuid.rs
+++ b/host/src/types/uuid.rs
@@ -20,6 +20,24 @@ impl From<BluetoothUuid16> for Uuid {
     }
 }
 
+impl From<u128> for Uuid {
+    fn from(val: u128) -> Self {
+        Uuid::Uuid128(val.to_be_bytes())
+    }
+}
+
+impl From<[u8; 16]> for Uuid {
+    fn from(val: [u8; 16]) -> Self {
+        Uuid::Uuid128(val)
+    }
+}
+
+impl From<[u8; 2]> for Uuid {
+    fn from(val: [u8; 2]) -> Self {
+        Uuid::Uuid16(val)
+    }
+}
+
 impl Uuid {
     /// Create a new 16-bit UUID.
     pub const fn new_short(val: u16) -> Self {

--- a/host/src/types/uuid.rs
+++ b/host/src/types/uuid.rs
@@ -22,7 +22,7 @@ impl From<BluetoothUuid16> for Uuid {
 
 impl From<u128> for Uuid {
     fn from(val: u128) -> Self {
-        Uuid::Uuid128(val.to_be_bytes())
+        Uuid::Uuid128(val.to_le_bytes())
     }
 }
 

--- a/host/src/types/uuid.rs
+++ b/host/src/types/uuid.rs
@@ -15,26 +15,32 @@ pub enum Uuid {
 }
 
 impl From<BluetoothUuid16> for Uuid {
-    fn from(val: bt_hci::uuid::BluetoothUuid16) -> Self {
-        Uuid::Uuid16(val.into())
+    fn from(data: bt_hci::uuid::BluetoothUuid16) -> Self {
+        Uuid::Uuid16(data.into())
     }
 }
 
 impl From<u128> for Uuid {
-    fn from(val: u128) -> Self {
-        Uuid::Uuid128(val.to_le_bytes())
+    fn from(data: u128) -> Self {
+        Uuid::Uuid128(data.to_le_bytes())
     }
 }
 
 impl From<[u8; 16]> for Uuid {
-    fn from(val: [u8; 16]) -> Self {
-        Uuid::Uuid128(val)
+    fn from(data: [u8; 16]) -> Self {
+        Uuid::Uuid128(data)
     }
 }
 
 impl From<[u8; 2]> for Uuid {
-    fn from(val: [u8; 2]) -> Self {
-        Uuid::Uuid16(val)
+    fn from(data: [u8; 2]) -> Self {
+        Uuid::Uuid16(data)
+    }
+}
+
+impl From<u16> for Uuid {
+    fn from(data: u16) -> Self {
+        Uuid::Uuid16(data.to_le_bytes())
     }
 }
 
@@ -86,12 +92,6 @@ impl Uuid {
             Uuid::Uuid16(uuid) => uuid,
             Uuid::Uuid128(uuid) => uuid,
         }
-    }
-}
-
-impl From<u16> for Uuid {
-    fn from(data: u16) -> Self {
-        Uuid::Uuid16(data.to_le_bytes())
     }
 }
 

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -48,13 +48,13 @@ async fn gatt_client_server() {
         let mut expected = value.wrapping_add(1);
 
         let mut table: AttributeTable<'_, NoopRawMutex, 10> = AttributeTable::new();
-        let mut svc = table.add_service(Service::new(0x1800));
-        let _ = svc.add_characteristic_ro(0x2a00, id);
-        let _ = svc.add_characteristic_ro(0x2a01, &appearance);
+        let mut svc = table.add_service(Service::new(0x1800u16));
+        let _ = svc.add_characteristic_ro(0x2a00u16, id);
+        let _ = svc.add_characteristic_ro(0x2a01u16, &appearance);
         svc.build();
 
         // Generic attribute service (mandatory)
-        table.add_service(Service::new(0x1801));
+        table.add_service(Service::new(0x1801u16));
 
         // Custom service
         let _handle: Characteristic<u8> = table.add_service(Service::new(SERVICE_UUID.clone()))

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -23,13 +23,15 @@ struct Server {
     bas: BatteryService,
 }
 
+const UUID_U128: u128 = 0x408813df_5dd4_1f87_ec11_cdb000100000;
+
 #[gatt_service(uuid = "408813df-5dd4-1f87-ec11-cdb000100000")]
 struct CustomService {
     #[descriptor(uuid = "2b20", value = "Read Only Descriptor", read)]
     #[characteristic(uuid = "408813df-5dd4-1f87-ec11-cdb001100000", value = 42, read, write, notify)]
     #[descriptor(uuid = "2b21", value = [0x01,0x02,0x03], read)]
     pub value: u8,
-    #[characteristic(uuid = "408814df-5dd4-1f87-ec11-cdb001100000", value = 123.321, read, write, notify)]
+    #[characteristic(uuid = UUID_U128, value = 123.321, read, write, notify)]
     /// Order doesn't matter
     #[descriptor(uuid = "2b20", read, value = 42u16.to_le_bytes())] // empty descriptor
     pub second: f32,


### PR DESCRIPTION
allow more ways to express Uuids in Gatt Service creation

```rust

pub const MATTER_BLE_SERVICE_UUID16: u16 = 0xFFF6;
pub const C1_CHARACTERISTIC_UUID: [u8; 16] = [0x18, 0xEE, 0x2E, 0xF5, 0x26, 0x3D, 0x45, 0x59, 0x95, 0x9F, 0x4F, 0x9C, 0x42, 0x9F, 0x9D, 0x11];
pub const C2_CHARACTERISTIC_UUID: u128 = 0x18EE2EF5263D4559959F4F9C429F9D12;

/// Matter service
#[gatt_service(uuid = MATTER_BLE_SERVICE_UUID16)]
struct MatterService {
    #[characteristic(uuid = C1_CHARACTERISTIC_UUID, write)]
    c1: u8,
    #[characteristic(uuid = C2_CHARACTERISTIC_UUID, write, indicate)]
    c2: u8,
    #[characteristic(uuid = "408813df-5dd4-1f87-ec11-cdb001100000")]
    status: bool,
}
```