### PR TITLE
fix: do not exit runner on non-critical errors

### DIFF
--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -980,6 +980,12 @@ impl<'d, C: Controller> TxRunner<'d, C> {
                         return Err(e);
                     }
                 }
+                Err(BleHostError::BleHost(Error::NotFound)) => {
+                    warn!("[host] unable to send data to disconnected host (ignored)");
+                }
+                Err(BleHostError::BleHost(Error::Disconnected)) => {
+                    warn!("[host] unable to send data to disconnected host (ignored)");
+                }
                 Err(e) => {
                     warn!("[host] error requesting sending outbound pdu");
                     return Err(e);


### PR DESCRIPTION
Connection handles may be marked as disconnected before the runner has a chance to send responses to it. In that case, log and ignore error.

Fixes #277