### PR TITLE
Enabling MTU work-around for ESP32-S3

### DIFF
--- a/examples/esp32/.cargo/config.toml
+++ b/examples/esp32/.cargo/config.toml
@@ -18,3 +18,8 @@ rustflags = [
 
 [env]
 ESP_LOG = "info"
+
+# Xtensa only:
+# Needed for nightly, until llvm upstream has support for Rust Xtensa.
+[unstable]
+build-std = ["alloc", "core"]

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -18,19 +18,6 @@ bt-hci = { version = "0.2" }
 [features]
 default = ["esp32c3"]
 
-# trouble-example-apps/esp:
-#
-# 'esp-hal' likely has a bug, causing _some_ ESP32 chips to give "Invalid HCI Command Parameters" BLE errors at launch,
-# if the L2CAP MTU is set low enough.
-#
-# The error producing ranges go:
-#   - ESP32-C6: x..<255             // examples with 128, 251 would fail
-#   - ESP32-C2: RANGE NOT KNOWN     // not having the hardware
-#   - ESP32-H2: RANGE NOT KNOWN     // not having the hardware
-#   - ESP32, -C3, -S2, -S3: claimed not to be affected [1], so the behaviour-altering feature is not enabled for them.
-#
-#       [1]: https://github.com/embassy-rs/trouble/pull/236#issuecomment-2586457641
-#
 esp32 = ["esp-hal/esp32", "esp-backtrace/esp32", "esp-hal-embassy/esp32", "esp-println/esp32", "esp-wifi/esp32"]
 esp32c2 = ["esp-hal/esp32c2", "esp-backtrace/esp32c2", "esp-hal-embassy/esp32c2", "esp-println/esp32c2", "esp-wifi/esp32c2"]
 esp32c3 = ["esp-hal/esp32c3", "esp-backtrace/esp32c3", "esp-hal-embassy/esp32c3", "esp-println/esp32c3", "esp-wifi/esp32c3"]

--- a/examples/esp32/src/consts.rs
+++ b/examples/esp32/src/consts.rs
@@ -1,6 +1,17 @@
 /// Size of L2CAP packets
-#[cfg(not(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2")))]
-pub const L2CAP_MTU: usize = 251;
-// Some esp chips only accept an MTU >= 255
-#[cfg(any(feature = "esp32c2", feature = "esp32c6", feature = "esp32h2"))]
+///
+/// 'esp-hal' likely has a bug, causing _some_ ESP32 chips to give "Invalid HCI Command Parameters" BLE errors at launch,
+/// if the L2CAP MTU is set low enough.
+///
+/// The error producing ranges go:
+///   - ESP32-C6: x..<255             // examples with 128, 251 would fail
+///   - ESP32-C2: RANGE NOT KNOWN     // not having the hardware
+///   - ESP32-H2: RANGE NOT KNOWN     // not having the hardware
+///   - ESP32, -C3, -S2: claimed not to be affected [1]
+///       [1]: https://github.com/embassy-rs/trouble/pull/236#issuecomment-2586457641
+///
+///   - ESP32-S3: 251 (presumably x..<255), see [2]:
+///       [2]: https://matrix.to/#/#esp-rs:matrix.org/$ZzC-QWHocidnEXtn5vAxcsGnUDLTnk4NGf9Cr7kVrjo
+///
+/// Playing safe by using '255' (that works for all)
 pub const L2CAP_MTU: usize = 255;


### PR DESCRIPTION
Doing two things:

- moving the comment about the MTU issue to where the choice currently happens
- changing ESP32-S3 to use the workaround

Three questions (before merge!!):

1. Should I introduce `if_cfg::if_cfg!` as a dependency, just for `examples/esp32`? Would make the work-around condition DRY (now repeated).
2. Is the switching from `///` (doc comments) to normal `//` ok?  Wanted to leave the details out from docs.
3. What to do with "ESP32, -S2"?    Should the work-around be enabled for them as well, just in case?     // I can vouch for C3 not needing the work-around