### PR TITLE
refactor: rework controller-host flow control support

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -24,6 +24,7 @@ cargo batch \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,central \
     --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral,central,scan \
+    --- build --release --manifest-path host/Cargo.toml --no-default-features --features gatt,peripheral,central,scan,controller-host-flow-control \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52840 \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52833 --artifact-dir tests/nrf-sdc \
     --- build --release --manifest-path examples/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52832 \

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -2,8 +2,6 @@
 use bt_hci::cmd::le::{LeAddDeviceToFilterAcceptList, LeClearFilterAcceptList, LeCreateConn, LeExtCreateConn};
 use bt_hci::controller::{Controller, ControllerCmdAsync, ControllerCmdSync};
 use bt_hci::param::{AddrKind, BdAddr, InitiatingPhy, LeConnRole, PhyParams};
-#[cfg(feature = "controller-host-flow-control")]
-use bt_hci::param::{ConnHandleCompletedPackets, ControllerToHostFlowControl};
 use embassy_futures::select::{Either, select};
 
 use crate::connection::{ConnectConfig, Connection, PhySet};

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -9,6 +9,7 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::waitqueue::WakerRegistration;
 
+use crate::connection_manager::ConnectionManager;
 use crate::cursor::WriteCursor;
 use crate::host::BleHost;
 use crate::l2cap::L2capChannel;
@@ -491,9 +492,9 @@ impl<'d> ChannelManager<'d> {
         buf: &mut [u8],
         ble: &BleHost<'d, T>,
     ) -> Result<usize, BleHostError<T::Error>> {
-        let packet = self.receive_pdu(chan).await?;
+        let mut packet = self.receive_pdu(&ble.connections, chan).await?;
 
-        let (first, data) = packet.as_ref().split_at(2);
+        let (first, data) = packet.pdu.as_ref().split_at(2);
         let remaining: u16 = u16::from_le_bytes([first[0], first[1]]);
 
         let to_copy = data.len().min(buf.len());
@@ -502,26 +503,32 @@ impl<'d> ChannelManager<'d> {
 
         let mut remaining = remaining as usize - data.len();
 
-        self.flow_control(chan, ble, packet.packet).await?;
+        self.flow_control(chan, ble, packet.pdu.packet.as_mut()).await?;
+        drop(packet);
 
         // We have some k-frames to reassemble
         while remaining > 0 {
-            let packet = self.receive_pdu(chan).await?;
-            let to_copy = packet.len.min(buf.len() - pos);
+            let mut packet = self.receive_pdu(&ble.connections, chan).await?;
+            let to_copy = packet.pdu.len.min(buf.len() - pos);
             if to_copy > 0 {
-                buf[pos..pos + to_copy].copy_from_slice(&packet.as_ref()[..to_copy]);
+                buf[pos..pos + to_copy].copy_from_slice(&packet.pdu.as_ref()[..to_copy]);
                 pos += to_copy;
             }
-            remaining -= packet.len;
-            self.flow_control(chan, ble, packet.packet).await?;
+            remaining -= packet.pdu.len;
+            self.flow_control(chan, ble, packet.pdu.packet.as_mut()).await?;
         }
 
         Ok(pos)
     }
 
-    async fn receive_pdu(&self, chan: ChannelIndex) -> Result<Pdu, Error> {
+    async fn receive_pdu<'m>(
+        &self,
+        ble: &'m ConnectionManager<'d>,
+        chan: ChannelIndex,
+    ) -> Result<L2capPdu<'m, 'd>, Error> {
+        let (conn, _, _) = self.connected_channel_params(chan)?;
         match self.inbound[chan.0 as usize].receive().await {
-            Some(pdu) => Ok(pdu),
+            Some(pdu) => Ok(L2capPdu { ble, conn, pdu }),
             None => Err(Error::ChannelClosed),
         }
     }
@@ -626,7 +633,7 @@ impl<'d> ChannelManager<'d> {
         &self,
         index: ChannelIndex,
         ble: &BleHost<'d, T>,
-        mut packet: Packet,
+        p_buf: &mut [u8],
     ) -> Result<(), BleHostError<T::Error>> {
         let (conn, cid, credits) = self.with_mut(|state| {
             let chan = &mut state.channels[index.0 as usize];
@@ -642,7 +649,7 @@ impl<'d> ChannelManager<'d> {
             let signal = LeCreditFlowInd { cid, credits };
 
             // Reuse packet buffer for signalling data to save the extra TX buffer
-            ble.l2cap_signal(conn, identifier, &signal, packet.as_mut()).await?;
+            ble.l2cap_signal(conn, identifier, &signal, p_buf).await?;
             self.with_mut(|state| {
                 let chan = &mut state.channels[index.0 as usize];
                 if chan.state == ChannelState::Connected {
@@ -999,6 +1006,18 @@ impl Drop for CreditGrant<'_, '_> {
             // make it an assert?
             //        warn!("[l2cap][credit grant drop] channel {} not found", self.index);
         }
+    }
+}
+
+struct L2capPdu<'a, 'd> {
+    ble: &'a ConnectionManager<'d>,
+    conn: ConnHandle,
+    pdu: Pdu,
+}
+
+impl<'a, 'd> Drop for L2capPdu<'a, 'd> {
+    fn drop(&mut self) {
+        self.ble.completed_packets(self.conn, 1);
     }
 }
 

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -684,7 +684,7 @@ impl<'d> ChannelManager<'d> {
                 chan.peer_credits -= credits;
                 return Poll::Ready(Ok(CreditGrant::new(&self.state, index, credits)));
             } else {
-                warn!(
+                debug!(
                     "[l2cap][poll_request_to_send][cid = {}]: not enough credits, requested {} available {}",
                     chan.cid, credits, chan.peer_credits
                 );

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -158,6 +158,14 @@ impl<'stack> Connection<'stack> {
         Self { index, manager }
     }
 
+    pub(crate) fn completed_packets(&self, amount: u16) {
+        #[cfg(feature = "controller-host-flow-control")]
+        {
+            let handle = self.manager.handle(self.index);
+            self.manager.completed_packets(handle, amount);
+        }
+    }
+
     pub(crate) fn set_att_mtu(&self, mtu: u16) {
         self.manager.set_att_mtu(self.index, mtu);
     }

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -225,7 +225,7 @@ impl<'d> ConnectionManager<'d> {
             let mut pos = cursor;
             let end = if pos > 0 { pos - 1 } else { state.connections.len() - 1 };
 
-            while pos != end {
+            loop {
                 let next = (pos + 1) % state.connections.len();
                 let storage = &state.connections[pos];
                 if let ConnectionState::Connected = storage.state {
@@ -237,6 +237,9 @@ impl<'d> ConnectionManager<'d> {
                             state: &self.state,
                         });
                     }
+                }
+                if pos == end {
+                    break;
                 }
                 pos = next;
             }
@@ -320,6 +323,7 @@ impl<'d> ConnectionManager<'d> {
                 self.events[idx].clear();
                 storage.state = ConnectionState::Connecting;
                 storage.link_credits = default_credits;
+                storage.completed_packets = 0;
                 storage.att_mtu = default_att_mtu;
                 storage.handle.replace(handle);
                 storage.peer_addr_kind.replace(peer_addr_kind);

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -324,7 +324,9 @@ impl<'d> ConnectionManager<'d> {
                 storage.state = ConnectionState::Connecting;
                 storage.link_credits = default_credits;
                 #[cfg(feature = "controller-host-flow-control")]
-                storage.completed_packets = 0;
+                {
+                    storage.completed_packets = 0;
+                }
                 storage.att_mtu = default_att_mtu;
                 storage.handle.replace(handle);
                 storage.peer_addr_kind.replace(peer_addr_kind);

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -323,6 +323,7 @@ impl<'d> ConnectionManager<'d> {
                 self.events[idx].clear();
                 storage.state = ConnectionState::Connecting;
                 storage.link_credits = default_credits;
+                #[cfg(feature = "controller-host-flow-control")]
                 storage.completed_packets = 0;
                 storage.att_mtu = default_att_mtu;
                 storage.handle.replace(handle);

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -18,6 +18,8 @@ struct State<'d> {
     central_waker: WakerRegistration,
     peripheral_waker: WakerRegistration,
     disconnect_waker: WakerRegistration,
+    #[cfg(feature = "controller-host-flow-control")]
+    completed_packets_waker: WakerRegistration,
     default_link_credits: usize,
     default_att_mtu: u16,
 }
@@ -86,6 +88,8 @@ impl<'d> ConnectionManager<'d> {
                 central_waker: WakerRegistration::new(),
                 peripheral_waker: WakerRegistration::new(),
                 disconnect_waker: WakerRegistration::new(),
+                #[cfg(feature = "controller-host-flow-control")]
+                completed_packets_waker: WakerRegistration::new(),
                 default_link_credits: 0,
                 default_att_mtu,
             }),
@@ -160,6 +164,21 @@ impl<'d> ConnectionManager<'d> {
         })
     }
 
+    pub(crate) fn completed_packets(&self, _handle: ConnHandle, _amount: u16) {
+        #[cfg(feature = "controller-host-flow-control")]
+        self.with_mut(|state| {
+            let handle = _handle;
+            let amount = _amount;
+            for entry in state.connections.iter_mut() {
+                if entry.state == ConnectionState::Connected && Some(handle) == entry.handle {
+                    entry.completed_packets += amount;
+                    state.completed_packets_waker.wake();
+                    break;
+                }
+            }
+        })
+    }
+
     pub(crate) fn request_handle_disconnect(&self, handle: ConnHandle, reason: DisconnectReason) {
         self.with_mut(|state| {
             for entry in state.connections.iter_mut() {
@@ -185,6 +204,41 @@ impl<'d> ConnectionManager<'d> {
                     reason,
                     state: &self.state,
                 });
+            }
+        }
+        Poll::Pending
+    }
+
+    pub(crate) fn poll_completed_packets<'m>(
+        &'m self,
+        _cursor: usize,
+        _cx: Option<&mut Context<'_>>,
+    ) -> Poll<CompletedPackets<'m, 'd>> {
+        #[cfg(feature = "controller-host-flow-control")]
+        {
+            let cursor = _cursor;
+            let cx = _cx;
+            let mut state = self.state.borrow_mut();
+            if let Some(cx) = cx {
+                state.completed_packets_waker.register(cx.waker());
+            }
+            let mut pos = cursor;
+            let end = if pos > 0 { pos - 1 } else { state.connections.len() - 1 };
+
+            while pos != end {
+                let next = (pos + 1) % state.connections.len();
+                let storage = &state.connections[pos];
+                if let ConnectionState::Connected = storage.state {
+                    if storage.completed_packets > 0 {
+                        return Poll::Ready(CompletedPackets {
+                            index: pos,
+                            handle: storage.handle.unwrap(),
+                            amount: storage.completed_packets,
+                            state: &self.state,
+                        });
+                    }
+                }
+                pos = next;
             }
         }
         Poll::Pending
@@ -511,6 +565,34 @@ impl DisconnectRequest<'_, '_> {
     }
 }
 
+pub(crate) struct CompletedPackets<'a, 'd> {
+    state: &'a RefCell<State<'d>>,
+    handle: ConnHandle,
+    amount: u16,
+    index: usize,
+}
+
+#[cfg(feature = "controller-host-flow-control")]
+impl CompletedPackets<'_, '_> {
+    pub(crate) fn amount(&self) -> u16 {
+        self.amount
+    }
+
+    pub(crate) fn handle(&self) -> ConnHandle {
+        self.handle
+    }
+
+    pub(crate) fn confirm(self) -> usize {
+        let mut state = self.state.borrow_mut();
+        let connection = &mut state.connections[self.index];
+        if connection.state == ConnectionState::Connected && connection.handle == Some(self.handle) {
+            connection.completed_packets = connection.completed_packets.saturating_sub(self.amount);
+        }
+
+        (self.index + 1) % state.connections.len()
+    }
+}
+
 #[derive(Debug)]
 pub struct ConnectionStorage {
     pub state: ConnectionState,
@@ -521,6 +603,8 @@ pub struct ConnectionStorage {
     pub att_mtu: u16,
     pub link_credits: usize,
     pub link_credit_waker: WakerRegistration,
+    #[cfg(feature = "controller-host-flow-control")]
+    pub completed_packets: u16,
     pub refcount: u8,
     #[cfg(feature = "connection-metrics")]
     pub metrics: Metrics,
@@ -584,6 +668,8 @@ impl ConnectionStorage {
         peer_addr: None,
         att_mtu: 23,
         link_credits: 0,
+        #[cfg(feature = "controller-host-flow-control")]
+        completed_packets: 0,
         link_credit_waker: WakerRegistration::new(),
         refcount: 0,
         #[cfg(feature = "connection-metrics")]
@@ -594,30 +680,26 @@ impl ConnectionStorage {
 #[cfg(feature = "defmt")]
 impl defmt::Format for ConnectionStorage {
     fn format(&self, f: defmt::Formatter<'_>) {
-        #[cfg(feature = "connection-metrics")]
         defmt::write!(
             f,
-            "state = {}, conn = {}, flow = {}, role = {}, peer = {:02x}, ref = {}, {}",
+            "state = {}, conn = {}, flow = {}",
             self.state,
             self.handle,
             self.link_credits,
-            self.role,
-            self.peer_addr,
-            self.refcount,
-            self.metrics
         );
 
-        #[cfg(not(feature = "connection-metrics"))]
+        #[cfg(feature = "controller-host-flow-control")]
+        defmt::write!(f, ", completed = {}", self.completed_packets);
         defmt::write!(
             f,
-            "state = {}, conn = {}, flow = {}, role = {}, peer = {:02x}, ref = {}",
-            self.state,
-            self.handle,
-            self.link_credits,
+            ", role = {}, peer = {:02x}, ref = {}",
             self.role,
             self.peer_addr,
-            self.refcount,
+            self.refcount
         );
+
+        #[cfg(feature = "connection-metrics")]
+        defmt::write!(", {}", self.metrics);
     }
 }
 


### PR DESCRIPTION
* Keep track of per connection completed packets in connection manager.
* Add control task of polling connection manager for completed packets and issuing the command to the controller.
* Upon receiving ACL data from the controller, delay the increment of completed packets when dispatched to an l2cap channel, gatt server or gatt client.
* Modify all paths that receive l2cap messages to also increment completed packets when drop'ing the PDU. This could've been made simpler if the Pdu type knew it's connection handle and had a reference to the connection manager, but that brings another bunch of problems to the table, as well as a significant memory usage increase.