### PR TITLE
Remove invalid field from FindTypeValue response

### DIFF
--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -286,7 +286,6 @@ impl<'values, M: RawMutex, const MAX: usize> AttributeServer<'values, M, MAX> {
                             }
                             w.write(att.handle)?;
                             w.write(att.last_handle_in_group)?;
-                            w.write_ref(uuid)?;
                         }
                     }
                 }


### PR DESCRIPTION
This incorrect field prevented the WinRT Bluetooth API to work with TrouBLE devices. Fixes #107.