### PR TITLE
Update the GATT client to allow use of `Write Without Response` characteristics

### DIFF
--- a/host/src/att.rs
+++ b/host/src/att.rs
@@ -768,7 +768,7 @@ impl<'d> AttCmd<'d> {
         let mut w = WriteCursor::new(dest);
         match self {
             Self::Write { handle, data } => {
-                w.write(ATT_WRITE_REQ)?;
+                w.write(ATT_WRITE_CMD)?;
                 w.write(*handle)?;
                 w.append(data)?;
             }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -422,6 +422,7 @@ impl<'reference> Drop for Response<'reference> {
 pub(crate) trait Client<'d, E> {
     /// Perform a gatt request and return the response.
     fn request(&self, req: AttReq<'_>) -> impl Future<Output = Result<Response<'d>, BleHostError<E>>>;
+    fn command(&self, cmd: AttCmd<'_>) -> impl Future<Output = Result<(), BleHostError<E>>>;
 }
 
 impl<'reference, T: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usize> Client<'reference, T::Error>
@@ -429,6 +430,33 @@ impl<'reference, T: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
 {
     async fn request(&self, req: AttReq<'_>) -> Result<Response<'reference>, BleHostError<T::Error>> {
         let data = Att::Client(AttClient::Request(req));
+
+        self.send_att_data(data).await?;
+
+        let (h, pdu) = self.response_channel.receive().await;
+
+        assert_eq!(h, self.connection.handle());
+        Ok(Response {
+            handle: h,
+            pdu,
+            connections: &self.stack.host.connections,
+        })
+    }
+
+    async fn command(&self, cmd: AttCmd<'_>) -> Result<(), BleHostError<T::Error>> {
+        let data = Att::Client(AttClient::Command(cmd));
+
+        self.send_att_data(data).await?;
+
+        Ok(())
+    }
+}
+
+impl<'reference, T: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usize>
+    GattClient<'reference, T, MAX_SERVICES, L2CAP_MTU>
+{
+    async fn send_att_data(&self, data: Att<'_>) -> Result<(), BleHostError<T::Error>> {
+        // Check the data type without consuming it
 
         let header = L2capHeader {
             channel: crate::types::l2cap::L2CAP_CID_ATT,
@@ -447,14 +475,7 @@ impl<'reference, T: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
             .await?;
         grant.send(w.finish()).await?;
 
-        let (h, pdu) = self.response_channel.receive().await;
-
-        assert_eq!(h, self.connection.handle());
-        Ok(Response {
-            handle: h,
-            pdu,
-            connections: &self.stack.host.connections,
-        })
+        Ok(())
     }
 }
 
@@ -704,6 +725,22 @@ impl<'reference, C: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
             AttRsp::Error { request, handle, code } => Err(Error::Att(code).into()),
             _ => Err(Error::InvalidValue.into()),
         }
+    }
+
+    /// Write without waiting for a response to a characteristic described by a handle.
+    pub async fn write_characteristic_without_response<T: FromGatt>(
+        &self,
+        handle: &Characteristic<T>,
+        buf: &[u8],
+    ) -> Result<(), BleHostError<C::Error>> {
+        let data = att::AttCmd::Write {
+            handle: handle.handle,
+            data: buf,
+        };
+
+        self.command(data).await?;
+
+        Ok(())
     }
 
     /// Subscribe to indication/notification of a given Characteristic

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -456,8 +456,6 @@ impl<'reference, T: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
     GattClient<'reference, T, MAX_SERVICES, L2CAP_MTU>
 {
     async fn send_att_data(&self, data: Att<'_>) -> Result<(), BleHostError<T::Error>> {
-        // Check the data type without consuming it
-
         let header = L2capHeader {
             channel: crate::types::l2cap::L2CAP_CID_ATT,
             length: data.size() as u16,


### PR DESCRIPTION
# Summary
Some BLE devices expose the attribute "Write Without Response" on characteristics. Currently, `trouble` only supports writing *with* responses. This PR extends the GATT client to support Write Without Response.

## Implementation
[According to the BLE Spec regarding Write Without Response](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/attribute-protocol--att-.html), the end of section `3.4.5.3` reads:


> No ATT_ERROR_RSP or ATT_WRITE_RSP PDUs shall be sent in response to this command. If the server cannot write this attribute for any reason the command shall be ignored

Therefore, we should be able to re-use existing logic in the `request` method for the GATT client to send the message, and not wait on a response from the `response_channel`.

I've added a new method, `write_characteristic_without_response` which invokes this new `Write` command process

## Testing

I've tested this on an Acaia Lunar 2021 which exposes a Write Without Response characteristic, writing to this before would cause an `WRITE_NOT_PERMITTED = 0x03` error code from the host layer. Utilizing the new method allows me keep a long-lived connection open with the scale. This was tested on an ESP32C3 dev board.