### PR TITLE
Add support for advertised 16 and 128 bit service uuid

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -166,7 +166,7 @@ async fn advertise<'a, C: Controller>(
     AdStructure::encode_slice(
         &[
             AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
-            AdStructure::ServiceUuids16(&[Uuid::Uuid16([0x0f, 0x18])]),
+            AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
             AdStructure::CompleteLocalName(name.as_bytes()),
         ],
         &mut advertiser_data[..],

--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "log",
  "static_cell",
  "trouble-host-macros",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1467,6 +1468,26 @@ version = "0.2.2"
 source = "git+https://github.com/esp-rs/esp-hal.git?rev=5d0145eca901f42cbebe1e41cde10e79afba3af8#5d0145eca901f42cbebe1e41cde10e79afba3af8"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -18,6 +18,7 @@ futures = { version = "0.3", default-features = false }
 heapless = "0.8"
 trouble-host-macros = { path = "../host-macros", version = "0.1.0", optional = true }
 static_cell = "2.1.0"
+zerocopy = "0.8.21"
 
 # Logging
 log = { version = "0.4.16", optional = true }

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -365,10 +365,10 @@ pub enum AdStructure<'a> {
     Flags(u8),
 
     /// List of 16-bit service UUIDs.
-    ServiceUuids16(&'a [Uuid]),
+    ServiceUuids16(&'a [[u8; 2]]),
 
     /// List of 128-bit service UUIDs.
-    ServiceUuids128(&'a [Uuid]),
+    ServiceUuids128(&'a [[u8; 16]]),
 
     /// Service data with 16-bit service UUID.
     ServiceData16 {
@@ -421,13 +421,13 @@ impl AdStructure<'_> {
             AdStructure::ServiceUuids16(uuids) => {
                 w.append(&[(uuids.len() * 2 + 1) as u8, 0x02])?;
                 for uuid in uuids.iter() {
-                    w.write_ref(uuid)?;
+                    w.write_ref(&Uuid::Uuid16(*uuid))?;
                 }
             }
             AdStructure::ServiceUuids128(uuids) => {
                 w.append(&[(uuids.len() * 16 + 1) as u8, 0x07])?;
                 for uuid in uuids.iter() {
-                    w.write_ref(uuid)?;
+                    w.write_ref(&Uuid::Uuid128(*uuid))?;
                 }
             }
             AdStructure::ShortenedLocalName(name) => {
@@ -575,7 +575,7 @@ mod tests {
             AdStructure::encode_slice(
                 &[
                     AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
-                    AdStructure::ServiceUuids16(&[Uuid::Uuid16([0x0f, 0x18])]),
+                    AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
                     AdStructure::CompleteLocalName(b"12345678901234567890123"),
                 ],
                 &mut adv_data[..],

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -365,15 +365,15 @@ pub enum AdStructure<'a> {
     Flags(u8),
 
     /// List of 16-bit service UUIDs.
-    /// The UUID data is in network endian order.
+    /// The UUID data matches the ble network's endian order (should be little endian).
     ServiceUuids16(&'a [[u8; 2]]),
 
     /// List of 128-bit service UUIDs.
-    /// The UUID data is in network endian order.
+    /// The UUID data matches the ble network's endian order (should be little endian).
     ServiceUuids128(&'a [[u8; 16]]),
 
     /// Service data with 16-bit service UUID.
-    /// The UUID data is in network endian order.
+    /// The UUID data matches the ble network's endian order (should be little endian).
     ServiceData16 {
         /// The 16-bit service UUID.
         uuid: [u8; 2],

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -480,13 +480,71 @@ impl<'d> AdStructureIter<'d> {
         }
         let code: u8 = self.cursor.read()?;
         let data = self.cursor.slice(len as usize - 1)?;
+        // These codes correspond to the table in 2.3 Common Data Types table `assigned_numbers/core/ad_types.yaml` from <https://www.bluetooth.com/specifications/assigned-numbers/>
+        // Look there for more information on each.
         match code {
+            // Flags
             0x01 => Ok(AdStructure::Flags(data[0])),
-            // 0x02 => unimplemented!(),
-            // 0x07 => unimplemented!(),
+            // Incomplete List of 16-bit Service or Service Class UUIDs
+            // 0x02 =>
+            // Complete List of 16-bit Service or Service Class UUIDs
+            // 0x03 =>
+            // Incomplete List of 32-bit Service or Service Class UUIDs
+            // 0x04 =>
+            // Complete List of 32-bit Service or Service Class UUIDs
+            // 0x05
+            // Incomplete List of 128-bit Service or Service Class UUIDs
+            // 0x06
+            // Complete List of 128-bit Service or Service Class UUIDs
+            // 0x07
+            // Shortened Local Name
             0x08 => Ok(AdStructure::ShortenedLocalName(data)),
+            // Complete Local Name
             0x09 => Ok(AdStructure::CompleteLocalName(data)),
-            // 0x16 => unimplemented!(),
+            /*
+            0x0A Tx Power Level
+            0x0D Class of Device
+            0x0E Simple Pairing Hash C-192
+            0x0F Simple Pairing Randomizer R-192
+            0x10 Device ID Device: ID Profile (when used in EIR data)
+            0x10 Security Manager TK Value when used in OOB data blocks
+            0x11 Security Manager Out of Band Flags
+            0x12 Peripheral Connection Interval Range
+            0x14 List of 16-bit Service Solicitation UUIDs
+            0x15 List of 128-bit Service Solicitation UUIDs
+            0x16 Service Data - 16-bit UUID
+            0x17 Public Target Address
+            0x18 Random Target Address
+            0x19 Appearance
+            0x1A Advertising Interval
+            0x1B LE Bluetooth Device Address
+            0x1C LE Role
+            0x1D Simple Pairing Hash C-256
+            0x1E Simple Pairing Randomizer R-256
+            0x1F List of 32-bit Service Solicitation UUIDs
+            0x20 Service Data - 32-bit UUID
+            0x21 Service Data - 128-bit UUID
+            0x22 LE Secure Connections Confirmation Value
+            0x23 LE Secure Connections Random Value
+            0x24 URI
+            0x25 Indoor Positioning
+            0x26 Transport Discovery Data
+            0x27 LE Supported Features
+            0x28 Channel Map Update Indication
+            0x29 PB-ADV
+            0x2A Mesh Message
+            0x2B Mesh Beacon
+            0x2C BIGInfo
+            0x2D Broadcast_Code
+            0x2E Resolvable Set Identifier
+            0x2F Advertising Interval - long
+            0x30 Broadcast_Name
+            0x31 Encrypted Advertising Data
+            0x32 Periodic Advertising Response Timing
+            0x34 Electronic Shelf Label
+            0x3D 3D Information Data
+            */
+            // Manufacturer Specific Data
             0xff if data.len() >= 2 => Ok(AdStructure::ManufacturerSpecificData {
                 company_identifier: u16::from_le_bytes([data[0], data[1]]),
                 payload: &data[2..],


### PR DESCRIPTION
Add support for 16 bit complete, 16 bit with data, and 128 bit complete advertised service uuids.

I've only tested the 16bit complete service, but I assume the others works as well.

I'm not particularly familiar with Bluetooth, so I don't know if the same approach would work for the "Incomplete List" variants since I can't find where the format is specified.