### PR TITLE
refactor: provide separate writer and reader instead of clone

### DIFF
--- a/examples/nrf-sdc/Cargo.lock
+++ b/examples/nrf-sdc/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "heapless",
  "static_cell",
  "trouble-host-macros",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1239,4 +1240,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/examples/rp-pico-w/Cargo.lock
+++ b/examples/rp-pico-w/Cargo.lock
@@ -2414,6 +2414,7 @@ dependencies = [
  "heapless",
  "static_cell",
  "trouble-host-macros",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2819,6 +2820,26 @@ dependencies = [
  "quote",
  "syn 2.0.93",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
 ]
 
 [[package]]

--- a/examples/serial-hci/Cargo.lock
+++ b/examples/serial-hci/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "log",
  "static_cell",
  "trouble-host-macros",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1159,3 +1160,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -206,6 +206,21 @@ where {
             },
         )
     }
+
+    /// Merge writer and reader into a single channel again.
+    ///
+    /// This function will panic if the channels are not referring to the same channel id.
+    pub fn merge(writer: L2capChannelWriter<'d>, reader: L2capChannelReader<'d>) -> Self {
+        // A channel will not be reused unless the refcount is 0, so the index could
+        // never be stale.
+        assert_eq!(writer.index, reader.index);
+
+        let manager = writer.manager;
+        let index = writer.index;
+        manager.inc_ref(index);
+
+        Self { index, manager }
+    }
 }
 
 impl<'d> L2capChannelReader<'d> {

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -14,11 +14,16 @@ pub struct L2capChannel<'d> {
     manager: &'d dyn DynamicChannelManager,
 }
 
-impl Clone for L2capChannel<'_> {
-    fn clone(&self) -> Self {
-        self.manager.inc_ref(self.index);
-        L2capChannel::new(self.index, self.manager)
-    }
+/// Handle representing an L2CAP channel write endpoint.
+pub struct L2capChannelWriter<'d> {
+    index: ChannelIndex,
+    manager: &'d dyn DynamicChannelManager,
+}
+
+/// Handle representing an L2CAP channel write endpoint.
+pub struct L2capChannelReader<'d> {
+    index: ChannelIndex,
+    manager: &'d dyn DynamicChannelManager,
 }
 
 #[cfg(feature = "defmt")]
@@ -30,6 +35,34 @@ impl defmt::Format for L2capChannel<'_> {
 }
 
 impl Drop for L2capChannel<'_> {
+    fn drop(&mut self) {
+        self.manager.dec_ref(self.index);
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for L2capChannelWriter<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f, "{}, ", self.index);
+        self.manager.print(self.index, f);
+    }
+}
+
+impl Drop for L2capChannelWriter<'_> {
+    fn drop(&mut self) {
+        self.manager.dec_ref(self.index);
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for L2capChannelReader<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f, "{}, ", self.index);
+        self.manager.print(self.index, f);
+    }
+}
+
+impl Drop for L2capChannelReader<'_> {
     fn drop(&mut self) {
         self.manager.dec_ref(self.index);
     }
@@ -155,5 +188,84 @@ where {
                 &stack.host,
             )
             .await
+    }
+
+    /// Split the channel into a writer and reader for concurrently
+    /// writing to/reading from the channel.
+    pub fn split(self) -> (L2capChannelWriter<'d>, L2capChannelReader<'d>) {
+        self.manager.inc_ref(self.index);
+        self.manager.inc_ref(self.index);
+        (
+            L2capChannelWriter {
+                index: self.index,
+                manager: self.manager,
+            },
+            L2capChannelReader {
+                index: self.index,
+                manager: self.manager,
+            },
+        )
+    }
+}
+
+impl<'d> L2capChannelReader<'d> {
+    /// Disconnect this channel.
+    pub fn disconnect(&mut self) {
+        self.manager.disconnect(self.index);
+    }
+
+    /// Receive data on this channel and copy it into the buffer.
+    ///
+    /// The length provided buffer slice must be equal or greater to the agreed MTU.
+    pub async fn receive<T: Controller>(
+        &mut self,
+        stack: &Stack<'_, T>,
+        buf: &mut [u8],
+    ) -> Result<usize, BleHostError<T::Error>> {
+        stack.host.channels.receive(self.index, buf, &stack.host).await
+    }
+}
+
+impl<'d> L2capChannelWriter<'d> {
+    /// Disconnect this channel.
+    pub fn disconnect(&mut self) {
+        self.manager.disconnect(self.index);
+    }
+
+    /// Send the provided buffer over this l2cap channel.
+    ///
+    /// The buffer will be segmented to the maximum payload size agreed in the opening handshake.
+    ///
+    /// If the channel has been closed or the channel id is not valid, an error is returned.
+    /// If there are no available credits to send, waits until more credits are available.
+    pub async fn send<T: Controller, const TX_MTU: usize>(
+        &mut self,
+        stack: &Stack<'_, T>,
+        buf: &[u8],
+    ) -> Result<(), BleHostError<T::Error>> {
+        let mut p_buf = [0u8; TX_MTU];
+        stack
+            .host
+            .channels
+            .send(self.index, buf, &mut p_buf[..], &stack.host)
+            .await
+    }
+
+    /// Send the provided buffer over this l2cap channel.
+    ///
+    /// The buffer will be segmented to the maximum payload size agreed in the opening handshake.
+    ///
+    /// If the channel has been closed or the channel id is not valid, an error is returned.
+    /// If there are no available credits to send, returns Error::Busy.
+    pub fn try_send<T: Controller + blocking::Controller, const TX_MTU: usize>(
+        &mut self,
+        stack: &Stack<'_, T>,
+        buf: &[u8],
+    ) -> Result<(), BleHostError<T::Error>> {
+        let mut p_buf = [0u8; TX_MTU];
+        stack
+            .host
+            .channels
+            .try_send(self.index, buf, &mut p_buf[..], &stack.host)
     }
 }


### PR DESCRIPTION
Rather than supporting clone() of l2cap channels, provide a split() funciton for creating separate write and read endpoints, since this enforces that only a single user can write to or read from at a time.