### PR TITLE
Restore the GattData::process public API

### DIFF
--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -198,11 +198,11 @@ impl ServerBuilder {
                     })
                 }
 
-                #visibility fn get<T: trouble_host::attribute::AttributeHandle<Value = V>, V: FromGatt>(&self, attribute_handle: &T) -> Result<T::Value, Error> {
+                #visibility fn get<T: trouble_host::attribute::AttributeHandle<Value = V>, V: FromGatt>(&self, attribute_handle: &T) -> Result<T::Value, trouble_host::Error> {
                     self.server.table().get(attribute_handle)
                 }
 
-                #visibility fn set<T: trouble_host::attribute::AttributeHandle>(&self, attribute_handle: &T, input: &T::Value) -> Result<(), Error> {
+                #visibility fn set<T: trouble_host::attribute::AttributeHandle>(&self, attribute_handle: &T, input: &T::Value) -> Result<(), trouble_host::Error> {
                     self.server.table().set(attribute_handle, input)
 
                 }


### PR DESCRIPTION
As discussed in the Embassy Matrix chat, having a public `GattData::process` API allows for "mixed-processing" scenarios, where the ATT PDUs are pulled using the "raw" ATT `Connection` type - yet - some of those PDUs are delegated to (an) attribute server via `GattData::process`, while others are processed at the ATT PDU level.

This is precisely what the Matter BTP implementation over trouble does [here](https://github.com/ivmarkov/rs-matter-embassy/blob/79a2a7786ad28e2ae186e4136e22c93a2c343599/rs-matter-embassy/src/ble.rs#L301).

(This API was retired by GIT commit https://github.com/embassy-rs/trouble/commit/cb8985ea7373e5eb0cf47599602743cbf23881cc#diff-27c58f7be9fbba9f7582453b30b6cde8d67e41414fe9004daea290d4c87da375 and I'm just restoring it here, except based on `DynamicAttributeServer` now, as that's what the new `GattConnection` has and needs.)

===

Additionally, I've addressed two hygienic issues in the `#[gatt_server]` proc-macro, where an unqualified `Error` type was used which was clashing with whatever the user had imported in terms of `Error` and which furthermore required the user to explicitly import `trouble_host::Error` which is NOK.

===

Will un-draft once I test it a bit and confirm it works.