### PR TITLE
default cccd to 0 if value missing

### DIFF
--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -701,6 +701,7 @@ impl<'reference, C: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
             AttRsp::ReadByType { mut it } => {
                 if let Some(Ok((handle, item))) = it.next() {
                     // As defined in the bluetooth spec [3.3.3.3. Client Characteristic Configuration](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/generic-attribute-profile--gatt-.html#UUID-09487be3-178b-eeca-f49f-f783e8d462f6)
+                    // "The Client Characteristic Configuration declaration is an optional characteristic descriptor" and
                     // "The default value for the Client Characteristic Configuration descriptor value shall be 0x0000."
                     if item.is_empty() {
                         Ok((handle, CCCD(0)))

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -700,10 +700,16 @@ impl<'reference, C: Controller, const MAX_SERVICES: usize, const L2CAP_MTU: usiz
         match Self::response(response.pdu.as_ref())? {
             AttRsp::ReadByType { mut it } => {
                 if let Some(Ok((handle, item))) = it.next() {
-                    Ok((
-                        handle,
-                        CCCD(u16::from_le_bytes(item.try_into().map_err(|_| Error::OutOfMemory)?)),
-                    ))
+                    // As defined in the bluetooth spec [3.3.3.3. Client Characteristic Configuration](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/generic-attribute-profile--gatt-.html#UUID-09487be3-178b-eeca-f49f-f783e8d462f6)
+                    // "The default value for the Client Characteristic Configuration descriptor value shall be 0x0000."
+                    if item.is_empty() {
+                        Ok((handle, CCCD(0)))
+                    } else {
+                        Ok((
+                            handle,
+                            CCCD(u16::from_le_bytes(item.try_into().map_err(|_| Error::InvalidValue)?)),
+                        ))
+                    }
                 } else {
                     Err(Error::NotFound.into())
                 }


### PR DESCRIPTION
Fixes #305.

Since the spec says "The Client Characteristic Configuration declaration is an optional characteristic descriptor" and "The default value for the Client Characteristic Configuration descriptor value shall be 0x0000." and the peripheral in that issue works with this pr, I think this is correct.

I also changed the error on incorrect sized values (not 0 or 2) to be `InvalidValue` since the previous error of `OutOfMemroy` doesn't make sense.