### PR TITLE
Add missing lifetime use and import

### DIFF
--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -203,11 +203,9 @@ impl ServiceBuilder {
         self.code_build_chars.extend(quote_spanned! {characteristic.span=>
             let (#char_name, #(#named_descriptors),*) = {
                 static #name_screaming: static_cell::StaticCell<[u8; <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE]> = static_cell::StaticCell::new();
-                let mut val = <#ty>::default(); // constrain the type of the value here
-                val = #default_value; // update the temporary value with our new default
                 let store = #name_screaming.init([0; <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE]);
                 let mut builder = service
-                    .add_characteristic(#uuid, &[#(#properties),*], val, store);
+                    .add_characteristic(#uuid, &[#(#properties),*], #default_value, store);
                 #code_descriptors
 
                 (builder.build(), #(#named_descriptors),*)

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -1,5 +1,7 @@
 use core::cell::RefCell;
 use core::future::poll_fn;
+#[cfg(feature = "security")]
+use core::future::Future;
 use core::task::{Context, Poll};
 
 use bt_hci::param::{AddrKind, BdAddr, ConnHandle, DisconnectReason, LeConnRole, Status};
@@ -685,7 +687,7 @@ impl<'d> ConnectionManager<'d> {
     }
 
     #[cfg(feature = "security")]
-    pub(crate) fn poll_security_events(&self) -> impl Future<Output = Result<SecurityEventData, TimeoutError>> {
+    pub(crate) fn poll_security_events(&self) -> impl Future<Output = Result<SecurityEventData, TimeoutError>> + use<'_> {
         self.security_manager.poll_events()
     }
 }

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -1213,7 +1213,7 @@ impl<const BOND_COUNT: usize> SecurityManager<BOND_COUNT> {
     }
 
     /// Poll for security manager work
-    pub(crate) fn poll_events(&self) -> impl Future<Output = Result<SecurityEventData, TimeoutError>> {
+    pub(crate) fn poll_events(&self) -> impl Future<Output = Result<SecurityEventData, TimeoutError>> + use<'_, BOND_COUNT> { 
         // try to pop an event from the channel
         poll_fn(|cx| self.events.poll_receive(cx)).with_deadline(*self.timer_expires.borrow())
     }


### PR DESCRIPTION
When compiling with `security` feature on latest stable(1.85.1), compiler suggests some fixes, which are included in this PR.