### PR TITLE
Emit bonded event after bonding

### DIFF
--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -14,7 +14,7 @@ use crate::connection_manager::ConnectionManager;
 use crate::pdu::Pdu;
 #[cfg(feature = "gatt")]
 use crate::prelude::{AttributeServer, GattConnection};
-use crate::{BleHostError, Error, Stack};
+use crate::{BleHostError, BondInformation, Error, Stack};
 
 /// Connection configuration.
 pub struct ConnectConfig<'d> {
@@ -112,6 +112,11 @@ pub enum ConnectionEvent {
         /// Supervision timeout.
         supervision_timeout: Duration,
     },
+    /// Bonded event.
+    Bonded {
+        /// Bond info for this connection
+        bond_info: BondInformation,
+    },
 }
 
 /// A connection event.
@@ -138,6 +143,11 @@ pub enum ConnectionEvent<'stack> {
         /// Supervision timeout.
         supervision_timeout: Duration,
     },
+    /// Bonded event.
+    Bonded {
+        /// Bond info for this connection
+        bond_info: BondInformation,
+    },
     /// GATT event.
     Gatt {
         /// The event that was returned
@@ -157,6 +167,9 @@ pub(crate) enum ConnectionEventData {
         conn_interval: Duration,
         peripheral_latency: u16,
         supervision_timeout: Duration,
+    },
+    Bonded {
+        bond_info: BondInformation,
     },
     Gatt {
         data: Pdu,
@@ -268,6 +281,7 @@ impl<'stack> Connection<'stack> {
                 supervision_timeout,
             },
             ConnectionEventData::PhyUpdated { tx_phy, rx_phy } => ConnectionEvent::PhyUpdated { tx_phy, rx_phy },
+            ConnectionEventData::Bonded { bond_info } => ConnectionEvent::Bonded { bond_info },
             ConnectionEventData::Gatt { data } => ConnectionEvent::Gatt {
                 data: crate::gatt::GattData::new(data, self.clone()),
             },

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -14,7 +14,9 @@ use crate::connection_manager::ConnectionManager;
 use crate::pdu::Pdu;
 #[cfg(feature = "gatt")]
 use crate::prelude::{AttributeServer, GattConnection};
-use crate::{BleHostError, BondInformation, Error, Stack};
+#[cfg(feature = "security")]
+use crate::security_manager::BondInformation;
+use crate::{BleHostError, Error, Stack};
 
 /// Connection configuration.
 pub struct ConnectConfig<'d> {
@@ -112,6 +114,7 @@ pub enum ConnectionEvent {
         /// Supervision timeout.
         supervision_timeout: Duration,
     },
+    #[cfg(feature = "security")]
     /// Bonded event.
     Bonded {
         /// Bond info for this connection
@@ -143,6 +146,7 @@ pub enum ConnectionEvent<'stack> {
         /// Supervision timeout.
         supervision_timeout: Duration,
     },
+    #[cfg(feature = "security")]
     /// Bonded event.
     Bonded {
         /// Bond info for this connection
@@ -168,6 +172,7 @@ pub(crate) enum ConnectionEventData {
         peripheral_latency: u16,
         supervision_timeout: Duration,
     },
+    #[cfg(feature = "security")]
     Bonded {
         bond_info: BondInformation,
     },
@@ -281,10 +286,11 @@ impl<'stack> Connection<'stack> {
                 supervision_timeout,
             },
             ConnectionEventData::PhyUpdated { tx_phy, rx_phy } => ConnectionEvent::PhyUpdated { tx_phy, rx_phy },
-            ConnectionEventData::Bonded { bond_info } => ConnectionEvent::Bonded { bond_info },
             ConnectionEventData::Gatt { data } => ConnectionEvent::Gatt {
                 data: crate::gatt::GattData::new(data, self.clone()),
             },
+            #[cfg(feature = "security")]
+            ConnectionEventData::Bonded { bond_info } => ConnectionEvent::Bonded { bond_info },
         }
     }
 

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -24,7 +24,7 @@ use crate::pdu::Pdu;
 use crate::prelude::ConnectionEvent;
 use crate::types::gatt_traits::{AsGatt, FromGatt, FromGattError};
 use crate::types::l2cap::L2capHeader;
-use crate::{config, BleHostError, Error, Stack};
+use crate::{config, BleHostError, BondInformation, Error, Stack};
 
 /// A GATT connection event.
 pub enum GattConnectionEvent<'stack, 'server> {
@@ -48,6 +48,11 @@ pub enum GattConnectionEvent<'stack, 'server> {
         peripheral_latency: u16,
         /// Supervision timeout.
         supervision_timeout: Duration,
+    },
+    /// Bonded event.
+    Bonded {
+        /// Bond info for this connection
+        bond_info: BondInformation,
     },
     /// GATT event.
     Gatt {
@@ -101,6 +106,9 @@ impl<'stack, 'server> GattConnection<'stack, 'server> {
                 }
                 ConnectionEvent::PhyUpdated { tx_phy, rx_phy } => {
                     return GattConnectionEvent::PhyUpdated { tx_phy, rx_phy };
+                }
+                ConnectionEvent::Bonded { bond_info } => {
+                    return GattConnectionEvent::Bonded { bond_info };
                 }
                 ConnectionEvent::Gatt { data } => match data.process(self.server).await {
                     Ok(event) => match event {

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -22,9 +22,11 @@ use crate::connection_manager::ConnectionManager;
 use crate::cursor::{ReadCursor, WriteCursor};
 use crate::pdu::Pdu;
 use crate::prelude::ConnectionEvent;
+#[cfg(feature = "security")]
+use crate::security_manager::BondInformation;
 use crate::types::gatt_traits::{AsGatt, FromGatt, FromGattError};
 use crate::types::l2cap::L2capHeader;
-use crate::{config, BleHostError, BondInformation, Error, Stack};
+use crate::{config, BleHostError, Error, Stack};
 
 /// A GATT connection event.
 pub enum GattConnectionEvent<'stack, 'server> {
@@ -49,6 +51,7 @@ pub enum GattConnectionEvent<'stack, 'server> {
         /// Supervision timeout.
         supervision_timeout: Duration,
     },
+    #[cfg(feature = "security")]
     /// Bonded event.
     Bonded {
         /// Bond info for this connection
@@ -107,6 +110,7 @@ impl<'stack, 'server> GattConnection<'stack, 'server> {
                 ConnectionEvent::PhyUpdated { tx_phy, rx_phy } => {
                     return GattConnectionEvent::PhyUpdated { tx_phy, rx_phy };
                 }
+                #[cfg(feature = "security")]
                 ConnectionEvent::Bonded { bond_info } => {
                     return GattConnectionEvent::Bonded { bond_info };
                 }

--- a/host/src/security_manager/crypto.rs
+++ b/host/src/security_manager/crypto.rs
@@ -8,7 +8,7 @@ use rand_core::{CryptoRng, RngCore};
 use crate::Address;
 
 /// LE Secure Connections Long Term Key.
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[must_use]
 #[repr(transparent)]
 pub struct LongTermKey(pub u128);


### PR DESCRIPTION
This PR adds `Bonded` event to the connection, which would be emitted after bonding(not pairing).

`ltk` and `addr` are set public, making it easier for downstream developers to serialize `BondInformation`.

Closes #328.