### PR TITLE
Add function which removes bond info, update existing bond info

### DIFF
--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -575,6 +575,12 @@ impl<'stack, C: Controller> Stack<'stack, C> {
     }
 
     #[cfg(feature = "security")]
+    /// Remove a bonded device
+    pub fn remove_bond_information(&self, address: BdAddr) -> Result<(), Error> {
+        self.host.connections.security_manager.remove_bond_information(address)
+    }
+
+    #[cfg(feature = "security")]
     /// Get bonded devices
     pub fn get_bond_information(&self) -> Vec<BondInformation, BI_COUNT> {
         self.host.connections.security_manager.get_bond_information()


### PR DESCRIPTION
This PR adds `remove_bond_information` to the stack and security manager, updates `add_bond_information` to replace existing bond information when the address is same