### PR TITLE
Fix descriptor cannot be recognized by Linux/Android

### DIFF
--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -318,9 +318,8 @@ impl ServiceBuilder {
                     quote_spanned! {characteristic.span=>
                         #identifier_assignment {
                             let value = #default_value;
-                            const CAPACITY: usize = if (#capacity) < 16 { 16 } else { #capacity }; // minimum capacity is 16 bytes
-                            static #name_screaming: static_cell::StaticCell<[u8; CAPACITY]> = static_cell::StaticCell::new();
-                            let store = #name_screaming.init([0; CAPACITY]);
+                            static #name_screaming: static_cell::StaticCell<[u8; #capacity]> = static_cell::StaticCell::new();
+                            let store = #name_screaming.init([0; #capacity]);
                             let value = trouble_host::types::gatt_traits::AsGatt::as_gatt(&value);
                             store[..value.len()].copy_from_slice(value);
                             builder.add_descriptor::<&[u8], _>(


### PR DESCRIPTION
Now the characteristic's descriptor has a minimal 16 bytes length, I cannot find any thing about this limitation on the [corresponding spec](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/host/generic-attribute-profile--gatt-.html#UUID-5262f33f-4943-5d8d-bf44-2e895938c9a1), and according to my testing, this limitation would result in `malformed att response` parsing error on Linux/Android(aka bluez) if the descriptor length is less than 16 bytes.

 