### PR TITLE
fix/gatt: incorrect packet length

### DIFF
--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -375,7 +375,7 @@ fn process_accept<'stack>(
         let mtu = connection.get_att_mtu();
         data.commit(written)?;
         data.truncate(mtu as usize);
-        header.write(written as u16)?;
+        header.write(data.len() as u16)?;
         header.write(4_u16)?;
         let len = header.len() + data.len();
         let pdu = Pdu::new(tx, len);


### PR DESCRIPTION
Packet length is incorrect, when the size of ATT value is larger than MTU. The BLE stack's parser of Android rely on the packet length field strictly. With incorrect value, it will trigger error and fail to go ahead.