### PR TITLE
Support cccd table setting

### DIFF
--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -206,8 +206,12 @@ impl ServerBuilder {
                     self.server.table().set(attribute_handle, input)
                 }
 
-                #visibility fn cccd_tables(&self, connection: &trouble_host::connection::Connection) -> Option<trouble_host::prelude::CccdTable<_CCCD_TABLE_SIZE>> {
-                    self.server.cccd_tables(connection)
+                #visibility fn get_cccd_table(&self, connection: &trouble_host::connection::Connection) -> Option<trouble_host::prelude::CccdTable<_CCCD_TABLE_SIZE>> {
+                    self.server.get_cccd_table(connection)
+                }
+
+                #visibility fn set_cccd_table(&self, connection: &trouble_host::connection::Connection, table: trouble_host::prelude::CccdTable<_CCCD_TABLE_SIZE>) {
+                    self.server.set_cccd_table(connection, table);
                 }
             }
 

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -874,7 +874,7 @@ pub enum CCCDFlag {
 
 /// CCCD flag.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug, PartialEq)]
 pub struct CCCD(pub(crate) u16);
 
 impl<const T: usize> From<[CCCDFlag; T]> for CCCD {
@@ -884,6 +884,12 @@ impl<const T: usize> From<[CCCDFlag; T]> for CCCD {
             val |= prop as u16;
         }
         CCCD(val)
+    }
+}
+
+impl From<u16> for CCCD {
+    fn from(value: u16) -> Self {
+        CCCD(value)
     }
 }
 


### PR DESCRIPTION
This is a follow-up PR of #345, adds cccd table setting for attribute servers with some other updates making debugging and comparing CCCD values easier.

