### PR TITLE
feat: allow fetching conn/channel metrics

### DIFF
--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -11,6 +11,8 @@ use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::Duration;
 
 use crate::connection_manager::ConnectionManager;
+#[cfg(feature = "connection-metrics")]
+pub use crate::connection_manager::Metrics as ConnectionMetrics;
 use crate::pdu::Pdu;
 #[cfg(feature = "gatt")]
 use crate::prelude::{AttributeServer, GattConnection};
@@ -328,6 +330,12 @@ impl<'stack> Connection<'stack> {
     pub fn disconnect(&self) {
         self.manager
             .request_disconnect(self.index, DisconnectReason::RemoteUserTerminatedConn);
+    }
+
+    /// Read metrics for this connection
+    #[cfg(feature = "connection-metrics")]
+    pub fn metrics<F: FnOnce(&ConnectionMetrics)>(&self, f: F) {
+        self.manager.metrics(self.index, f);
     }
 
     /// The RSSI value for this connection.

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -519,9 +519,9 @@ where
     }
 
     /// Read current host metrics
-    pub(crate) fn metrics(&self) -> HostMetrics {
-        let m = self.metrics.borrow_mut().clone();
-        m
+    pub(crate) fn metrics<F: FnOnce(&HostMetrics)>(&self, f: F) {
+        let m = self.metrics.borrow();
+        f(&m);
     }
 
     /// Log status information of the host

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -556,8 +556,8 @@ impl<'stack, C: Controller> Stack<'stack, C> {
     }
 
     /// Read current host metrics
-    pub fn metrics(&self) -> HostMetrics {
-        self.host.metrics()
+    pub fn metrics<F: FnOnce(&HostMetrics)>(&self, f: F) {
+        self.host.metrics(f);
     }
 
     /// Log status information of the host


### PR DESCRIPTION
* Provide a closure based API for reading metrics that does not require cloning the metrics structure. Allow retrieving metrics for individual connections and channels.