### PR TITLE
chore: move reassembly into connection storage

### DIFF
--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -13,7 +13,7 @@ use crate::connection_manager::ConnectionManager;
 use crate::cursor::WriteCursor;
 use crate::host::BleHost;
 use crate::l2cap::L2capChannel;
-use crate::packet_pool::{Packet, Pool};
+use crate::packet_pool::Pool;
 use crate::pdu::Pdu;
 use crate::types::l2cap::{
     CommandRejectRes, ConnParamUpdateReq, ConnParamUpdateRes, DisconnectionReq, DisconnectionRes, L2capHeader,
@@ -298,7 +298,7 @@ impl<'d> ChannelManager<'d> {
     }
 
     /// Dispatch an incoming L2CAP packet to the appropriate channel.
-    pub(crate) fn dispatch(&self, header: L2capHeader, packet: Packet) -> Result<(), Error> {
+    pub(crate) fn dispatch(&self, header: L2capHeader, pdu: Pdu) -> Result<(), Error> {
         if header.channel < BASE_ID {
             return Err(Error::InvalidChannelId);
         }
@@ -326,7 +326,7 @@ impl<'d> ChannelManager<'d> {
                         #[cfg(feature = "channel-metrics")]
                         storage.metrics.received(1);
 
-                        storage.inbound.try_send(Pdu::new(packet, header.length as usize))?;
+                        storage.inbound.try_send(pdu)?;
                         break;
                     }
                     _ => {}

--- a/host/src/l2cap/sar.rs
+++ b/host/src/l2cap/sar.rs
@@ -1,8 +1,7 @@
-use core::cell::RefCell;
-
 use bt_hci::param::ConnHandle;
 
 use crate::packet_pool::Packet;
+use crate::pdu::Pdu;
 use crate::types::l2cap::L2capHeader;
 use crate::Error;
 
@@ -32,85 +31,68 @@ impl AssembledPacket {
         self.written
     }
 
-    pub(crate) fn finalize(self, header: L2capHeader) -> Result<(L2capHeader, Packet), Error> {
-        if header.length as usize != self.written {
+    pub(crate) fn finalize(self, length: usize) -> Result<Pdu, Error> {
+        if length != self.written {
             return Err(Error::InvalidValue);
         }
-        Ok((header, self.packet))
+        Ok(Pdu::new(self.packet, length))
     }
 }
 
 pub(crate) type SarType = Option<(ConnHandle, L2capHeader, AssembledPacket)>;
 
-// Handles reassembling of packets
-pub struct PacketReassembly<'d> {
-    handles: RefCell<&'d mut [SarType]>,
+// Handles reassembling of a packet.
+pub(crate) struct PacketReassembly {
+    state: Option<State>,
 }
-impl<'d> PacketReassembly<'d> {
-    pub fn new(handles: &'d mut [Option<(ConnHandle, L2capHeader, AssembledPacket)>]) -> Self {
-        Self {
-            handles: RefCell::new(handles), //[Self::EMPTY; CONNS]),
-        }
+
+pub(crate) struct State {
+    // L2cap header of this reassembly
+    header: L2capHeader,
+    // Assembled length so far
+    packet: AssembledPacket,
+}
+
+impl PacketReassembly {
+    pub const fn new() -> Self {
+        Self { state: None }
     }
 
-    /// Initializes a reassembly for a given connection
+    /// Initializes a reassembly.
     ///
     /// Returns InvalidState if there is already an ongoing reassembly for this connection
     /// Returns InsufficientSpace if there is no space for this reassembly
-    pub fn init(&self, handle: ConnHandle, header: L2capHeader, p: Packet, initial: usize) -> Result<(), Error> {
-        let mut state = self.handles.borrow_mut();
-
-        // Sanity check
-        for entry in state.iter().flatten() {
-            if entry.0 == handle {
-                return Err(Error::InvalidState);
-            }
+    pub fn init(&mut self, header: L2capHeader, p: Packet, initial: usize) -> Result<(), Error> {
+        if self.state.is_some() {
+            return Err(Error::InvalidState);
         }
-
-        // Sanity check
-        for entry in state.iter_mut() {
-            if entry.is_none() {
-                entry.replace((handle, header, AssembledPacket::new(p, initial)));
-                return Ok(());
-            }
-        }
-        Err(Error::InsufficientSpace)
+        self.state.replace(State {
+            header,
+            packet: AssembledPacket::new(p, initial),
+        });
+        Ok(())
     }
 
     /// Deletes any reassemblies for the disconnected handle.
-    pub fn disconnected(&self, handle: ConnHandle) {
-        let mut state = self.handles.borrow_mut();
-        for entry in state.iter_mut() {
-            match entry {
-                Some((conn, header, packet)) if *conn == handle => {
-                    entry.take();
-                }
-                _ => {}
-            }
-        }
+    pub fn disconnected(&mut self) {
+        self.state.take();
     }
 
     /// Updates any in progress packet assembly for the connection
     ///
-    /// If the reassembly is complete, the l2cap header + packet is returned.
-    pub fn update(&self, handle: ConnHandle, data: &[u8]) -> Result<Option<(L2capHeader, Packet)>, Error> {
-        let mut state = self.handles.borrow_mut();
-
-        for entry in state.iter_mut() {
-            match entry {
-                Some((conn, header, packet)) if *conn == handle => {
-                    let (conn, header, mut packet) = entry.take().unwrap();
-                    packet.write(data)?;
-                    if packet.len() == header.length as usize {
-                        return Ok(Some(packet.finalize(header)?));
-                    } else {
-                        entry.replace((conn, header, packet));
-                        return Ok(None);
-                    }
-                }
-                _ => {}
+    /// If the reassembly is complete, the complete PDU is returned.
+    pub fn update(&mut self, data: &[u8]) -> Result<Option<(L2capHeader, Pdu)>, Error> {
+        if let Some(mut state) = self.state.take() {
+            state.packet.write(data)?;
+            if state.packet.len() == state.header.length as usize {
+                let length = state.header.length as usize;
+                Ok(Some((state.header, state.packet.finalize(length)?)))
+            } else {
+                self.state.replace(state);
+                Ok(None)
             }
+        } else {
+            Err(Error::NotFound)
         }
-        Err(Error::NotFound)
     }
 }

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -419,8 +419,7 @@ impl<const BOND_COUNT: usize> SecurityManager<BOND_COUNT> {
     /// Handle packet
     pub(crate) fn handle(
         &self,
-        packet: &crate::packet_pool::Packet,
-        payload_size: usize,
+        pdu: Pdu,
         connections: &ConnectionManager,
         storage: &ConnectionStorage,
     ) -> Result<(), Error> {
@@ -437,9 +436,8 @@ impl<const BOND_COUNT: usize> SecurityManager<BOND_COUNT> {
         let result = {
             let mut buffer = [0u8; 72];
             let size = {
-                let packet_payload = packet.as_ref();
-                let size = payload_size.min(buffer.len());
-                buffer[..size].copy_from_slice(&packet_payload[..size]);
+                let size = pdu.len.min(buffer.len());
+                buffer[..size].copy_from_slice(&pdu.as_ref()[..size]);
                 size
             };
             if size < 2 {


### PR DESCRIPTION
* Simplify reassembly logic and move it into the connection storage.
* Use Pdu type instead of Packet + length.