### PR TITLE
feat: allow configuring custom pool allocator

### DIFF
--- a/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_central.rs
+++ b/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_central.rs
@@ -76,7 +76,8 @@ async fn main(spawner: Spawner) {
     Timer::after(Duration::from_millis(200)).await;
 
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(sdc, &mut resources).set_random_address(address);
     let Host {
         mut central,

--- a/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
+++ b/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
@@ -73,7 +73,8 @@ async fn main(spawner: Spawner) {
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
 
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(sdc, &mut resources).set_random_address(address);
     let Host {
         mut peripheral,

--- a/examples/apps/src/ble_advertise.rs
+++ b/examples/apps/src/ble_advertise.rs
@@ -18,7 +18,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<0, 0, 27> = HostResources::new();
+    let mut resources: HostResources<StandardConfig, 0, 0> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut peripheral,

--- a/examples/apps/src/ble_advertise_multiple.rs
+++ b/examples/apps/src/ble_advertise_multiple.rs
@@ -18,7 +18,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<0, 0, 27, 2> = HostResources::new();
+    let mut resources: HostResources<StandardConfig, 0, 0, 2> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut peripheral,

--- a/examples/apps/src/ble_bas_central.rs
+++ b/examples/apps/src/ble_bas_central.rs
@@ -17,7 +17,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut central,

--- a/examples/apps/src/ble_bas_central_sec.rs
+++ b/examples/apps/src/ble_bas_central_sec.rs
@@ -19,7 +19,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .set_random_generator_seed(random_generator);

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -37,7 +37,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut peripheral, runner, ..

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -39,7 +39,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .set_random_generator_seed(random_generator);

--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -17,7 +17,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut central,

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -16,7 +16,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut peripheral,

--- a/examples/apps/src/ble_scanner.rs
+++ b/examples/apps/src/ble_scanner.rs
@@ -1,6 +1,7 @@
+use core::cell::RefCell;
+
 use bt_hci::cmd::le::LeSetScanParams;
 use bt_hci::controller::ControllerCmdSync;
-use core::cell::RefCell;
 use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use heapless::Deque;
@@ -20,7 +21,8 @@ where
 
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
 
     let Host {

--- a/examples/apps/src/high_throughput_ble_l2cap_central.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_central.rs
@@ -22,7 +22,8 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut central,

--- a/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
@@ -1,8 +1,8 @@
+use bt_hci::cmd::le::LeReadLocalSupportedFeatures;
+use bt_hci::controller::ControllerCmdSync;
 use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, Timer};
 use trouble_host::prelude::*;
-use bt_hci::cmd::le::LeReadLocalSupportedFeatures;
-use bt_hci::controller::ControllerCmdSync;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
@@ -12,14 +12,14 @@ const L2CAP_CHANNELS_MAX: usize = 3; // Signal + att + CoC
 
 pub async fn run<C, const L2CAP_MTU: usize>(controller: C)
 where
-    C: Controller
-    + ControllerCmdSync<LeReadLocalSupportedFeatures>,
+    C: Controller + ControllerCmdSync<LeReadLocalSupportedFeatures>,
 {
     // Hardcoded peripheral address
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, L2CAP_MTU> = HostResources::new();
+    let mut resources: HostResources<StandardConfig<L2CAP_MTU>, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
     let Host {
         mut peripheral,
@@ -31,7 +31,8 @@ where
     AdStructure::encode_slice(
         &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
         &mut adv_data[..],
-    ).unwrap();
+    )
+    .unwrap();
 
     let mut scan_data = [0; 31];
     AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"TroubleHT")], &mut scan_data[..]).unwrap();
@@ -39,7 +40,10 @@ where
     let _ = join(runner.run(), async {
         loop {
             // Check that the controller used supports the necessary features for high throughput.
-            let res = stack.command(LeReadLocalSupportedFeatures::new()).await.expect("LeReadLocalSupportedFeatures command failed");
+            let res = stack
+                .command(LeReadLocalSupportedFeatures::new())
+                .await
+                .expect("LeReadLocalSupportedFeatures command failed");
             assert!(res.supports_le_data_packet_length_extension());
             assert!(res.supports_le_2m_phy());
 
@@ -52,7 +56,8 @@ where
                         scan_data: &scan_data[..],
                     },
                 )
-                .await.expect("Advertising failed");
+                .await
+                .expect("Advertising failed");
             let conn = advertiser.accept().await.expect("Connection failed");
 
             info!("Connection established");
@@ -65,7 +70,8 @@ where
             };
 
             let mut ch1 = L2capChannel::accept(&stack, &conn, &[0x2349], &l2cap_channel_config)
-                .await.expect("L2capChannel create failed");
+                .await
+                .expect("L2capChannel create failed");
 
             info!("L2CAP channel accepted");
 
@@ -91,12 +97,14 @@ where
 
             let duration = start.elapsed();
 
-            info!("L2CAP data of {} bytes echoed at {} kbps.",
+            info!(
+                "L2CAP data of {} bytes echoed at {} kbps.",
                 (PAYLOAD_LEN as u64 * NUM_PAYLOADS as u64),
-                ((PAYLOAD_LEN as u64 * NUM_PAYLOADS as u64 * 8).div_ceil(duration.as_millis())));
+                ((PAYLOAD_LEN as u64 * NUM_PAYLOADS as u64 * 8).div_ceil(duration.as_millis()))
+            );
 
             Timer::after(Duration::from_secs(60)).await;
         }
     })
-        .await;
+    .await;
 }

--- a/examples/tests/tests/ble_l2cap_central.rs
+++ b/examples/tests/tests/ble_l2cap_central.rs
@@ -1,7 +1,7 @@
 use futures::future::join;
 use std::time::Duration;
 use tokio::select;
-use trouble_example_tests::{serial, TestContext};
+use trouble_example_tests::{TestContext, serial};
 use trouble_host::prelude::*;
 
 #[tokio::test]
@@ -48,7 +48,7 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
     let peripheral = tokio::task::spawn_local(async move {
         let controller_peripheral = serial::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<2, 4, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, 2, 4> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources).set_random_address(peripheral_address);
         let Host {
             mut peripheral,

--- a/examples/tests/tests/ble_l2cap_peripheral.rs
+++ b/examples/tests/tests/ble_l2cap_peripheral.rs
@@ -1,7 +1,7 @@
 use futures::future::join;
 use std::time::Duration;
 use tokio::select;
-use trouble_example_tests::{serial, TestContext};
+use trouble_example_tests::{TestContext, serial};
 use trouble_host::prelude::*;
 
 #[tokio::test]
@@ -45,7 +45,7 @@ async fn run_l2cap_peripheral_test(labels: &[(&str, &str)], firmware: &str) {
     let peripheral_address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     let central = tokio::task::spawn_local(async move {
         let controller_central = serial::create_controller(&central).await;
-        let mut resources: HostResources<2, 4, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, 2, 4> = HostResources::new();
         let stack = trouble_host::new(controller_central, &mut resources);
         let Host {
             mut central,

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -13,8 +13,8 @@ use crate::connection_manager::ConnectionManager;
 use crate::cursor::WriteCursor;
 use crate::host::BleHost;
 use crate::l2cap::L2capChannel;
-use crate::packet_pool::Pool;
 use crate::pdu::Pdu;
+use crate::pool::Pool;
 use crate::types::l2cap::{
     CommandRejectRes, ConnParamUpdateReq, ConnParamUpdateRes, DisconnectionReq, DisconnectionRes, L2capHeader,
     L2capSignalCode, L2capSignalHeader, LeCreditConnReq, LeCreditConnRes, LeCreditConnResultCode, LeCreditFlowInd,
@@ -1122,11 +1122,17 @@ mod tests {
 
     use super::*;
     use crate::mock_controller::MockController;
-    use crate::HostResources;
+    use crate::prelude::*;
+
+    struct TestConfig;
+    impl HostResourcesConfig for TestConfig {
+        type TxPool = PacketPool<27, 8>;
+        type RxPool = PacketPool<27, 8>;
+    }
 
     #[test]
     fn channel_refcount() {
-        let mut resources: HostResources<2, 2, 27> = HostResources::new();
+        let mut resources: HostResources<TestConfig, 2, 2> = HostResources::new();
         let ble = MockController::new();
 
         let builder = crate::new(ble, &mut resources);

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -250,7 +250,7 @@ impl<'stack> Connection<'stack> {
     }
 
     #[cfg(feature = "gatt")]
-    pub(crate) fn alloc_tx(&self) -> Result<crate::packet_pool::Packet, Error> {
+    pub(crate) fn alloc_tx(&self) -> Result<crate::pool::Packet, Error> {
         self.manager.alloc_tx()
     }
 

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -12,9 +12,10 @@ use embassy_sync::waitqueue::WakerRegistration;
 use embassy_time::TimeoutError;
 
 use crate::connection::{Connection, ConnectionEventData};
-#[cfg(feature = "gatt")]
-use crate::packet_pool::{Packet, Pool};
 use crate::pdu::Pdu;
+use crate::pool::Packet;
+#[cfg(feature = "gatt")]
+use crate::pool::Pool;
 use crate::prelude::sar::PacketReassembly;
 #[cfg(feature = "security")]
 use crate::security_manager::{SecurityEventData, SecurityManager};
@@ -307,7 +308,7 @@ impl<'d> ConnectionManager<'d> {
         &self,
         h: ConnHandle,
         header: L2capHeader,
-        p: crate::packet_pool::Packet,
+        p: Packet,
         initial: usize,
     ) -> Result<(), Error> {
         self.with_connected_handle(h, |storage| storage.reassembly.init(header, p, initial))

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -43,8 +43,8 @@ use crate::command::CommandState;
 use crate::connection::ConnectionEventData;
 use crate::connection_manager::{ConnectionManager, ConnectionStorage, PacketGrant};
 use crate::cursor::WriteCursor;
-use crate::packet_pool::Pool;
 use crate::pdu::Pdu;
+use crate::pool::Pool;
 #[cfg(feature = "security")]
 use crate::security_manager::SecurityEventData;
 use crate::types::l2cap::{

--- a/host/src/l2cap/sar.rs
+++ b/host/src/l2cap/sar.rs
@@ -1,7 +1,7 @@
 use bt_hci::param::ConnHandle;
 
-use crate::packet_pool::Packet;
 use crate::pdu::Pdu;
+use crate::pool::Packet;
 use crate::types::l2cap::L2capHeader;
 use crate::Error;
 

--- a/host/src/pdu.rs
+++ b/host/src/pdu.rs
@@ -1,4 +1,4 @@
-use crate::packet_pool::Packet;
+use crate::pool::Packet;
 
 pub(crate) struct Pdu {
     pub packet: Packet,

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -31,7 +31,7 @@ async fn gatt_client_server() {
     let peripheral = local.spawn_local(async move {
         let controller_peripheral = common::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address);
         let Host {
@@ -132,7 +132,7 @@ async fn gatt_client_server() {
     // Spawn central
     let central = local.spawn_local(async move {
         let controller_central = common::create_controller(&central).await;
-        let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_central, &mut resources);
         let Host {
             mut central,

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -73,7 +73,7 @@ async fn gatt_client_server() {
     let peripheral = local.spawn_local(async move {
         let controller_peripheral = common::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address);
         let Host {
@@ -163,7 +163,7 @@ async fn gatt_client_server() {
     // Spawn central
     let central = local.spawn_local(async move {
         let controller_central = common::create_controller(&central).await;
-        let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_central, &mut resources);
         let Host {
             mut central,

--- a/host/tests/l2cap.rs
+++ b/host/tests/l2cap.rs
@@ -26,7 +26,7 @@ async fn l2cap_connection_oriented_channels() {
     let peripheral = local.spawn_local(async move {
         let controller_peripheral = common::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address);
         let Host {
@@ -92,7 +92,7 @@ async fn l2cap_connection_oriented_channels() {
     // Spawn central
     let central = local.spawn_local(async move {
         let controller_central = common::create_controller(&central).await;
-        let mut resources: HostResources<CONNECTIONS_MAX, L2CAP_CHANNELS_MAX, 27> = HostResources::new();
+        let mut resources: HostResources<StandardConfig, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
 
         let stack = trouble_host::new(controller_central, &mut resources);
         let Host {


### PR DESCRIPTION
* Add HostResourcesConfig trait which contains configuration to be used
  by the host.
* Add RxPool and TxPool associated types that can be used to provide any
  allocator that implements the Pool trait.
* Add StandardConfig type which provide allocators based on the existing
  PacketPool allocator using a const generic of the l2cap mtu and
feature config.
