### PR TITLE
feat: allow updating advertisement data while advertising.

### DIFF
--- a/examples/apps/src/ble_beacon.rs
+++ b/examples/apps/src/ble_beacon.rs
@@ -1,0 +1,109 @@
+// BLE beacon example
+//
+// A beacon is a device that advertises packets that are constantly being
+// updated to reflect the current state of the device, but usually does not
+// accept any conections. This allows broadcasting device information.
+//
+
+use bt_hci::cmd::le::*;
+use bt_hci::controller::ControllerCmdSync;
+use embassy_futures::join::join;
+use embassy_time::{Duration, Instant, Timer};
+use trouble_host::prelude::*;
+
+// Use your company ID (register for free with Bluetooth SIG)
+const COMPANY_ID: u16 = 0xFFFF;
+
+fn make_adv_payload(start: Instant, update_count: u32) -> [u8; 8] {
+    let mut data = [0u8; 8];
+    let elapsed_ms = Instant::now().duration_since(start).as_millis() as u32;
+    data[0..4].copy_from_slice(&update_count.to_be_bytes());
+    data[4..8].copy_from_slice(&elapsed_ms.to_be_bytes());
+    data
+}
+
+pub async fn run<C>(controller: C)
+where
+    C: Controller
+        + for<'t> ControllerCmdSync<LeSetExtAdvData<'t>>
+        + ControllerCmdSync<LeClearAdvSets>
+        + ControllerCmdSync<LeSetExtAdvParams>
+        + ControllerCmdSync<LeSetAdvSetRandomAddr>
+        + ControllerCmdSync<LeReadNumberOfSupportedAdvSets>
+        + for<'t> ControllerCmdSync<LeSetExtAdvEnable<'t>>
+        + for<'t> ControllerCmdSync<LeSetExtScanResponseData<'t>>,
+{
+    let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    info!("Our address = {:?}", address);
+
+    let mut resources: HostResources<0, 0, 27> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let Host {
+        mut peripheral,
+        mut runner,
+        ..
+    } = stack.build();
+
+    let mut adv_data = [0; 64];
+    let mut update_count = 0u32;
+    let start = Instant::now();
+    let len = AdStructure::encode_slice(
+        &[
+            AdStructure::CompleteLocalName(b"Trouble Beacon"),
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            AdStructure::ManufacturerSpecificData {
+                company_identifier: COMPANY_ID,
+                payload: &make_adv_payload(start, update_count),
+            },
+        ],
+        &mut adv_data[..],
+    )
+    .unwrap();
+
+    info!("Starting advertising");
+    let _ = join(runner.run(), async {
+        loop {
+            let mut params = AdvertisementParameters::default();
+            params.interval_min = Duration::from_millis(25);
+            params.interval_max = Duration::from_millis(150);
+            let _advertiser = peripheral
+                .advertise(
+                    &params,
+                    Advertisement::NonconnectableNonscannableUndirected {
+                        adv_data: &adv_data[..len],
+                    },
+                )
+                .await
+                .unwrap();
+            loop {
+                Timer::after(Duration::from_millis(10)).await;
+                update_count = update_count.wrapping_add(1);
+
+                let len = AdStructure::encode_slice(
+                    &[
+                        AdStructure::CompleteLocalName(b"Trouble Beacon"),
+                        AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+                        AdStructure::ManufacturerSpecificData {
+                            company_identifier: COMPANY_ID,
+                            payload: &make_adv_payload(start, update_count),
+                        },
+                    ],
+                    &mut adv_data[..],
+                )
+                .unwrap();
+
+                peripheral
+                    .update_adv_data(Advertisement::NonconnectableNonscannableUndirected {
+                        adv_data: &adv_data[..len],
+                    })
+                    .await
+                    .unwrap();
+
+                if update_count % 100 == 0 {
+                    info!("Still running: Updated the beacon {} times", update_count);
+                }
+            }
+        }
+    })
+    .await;
+}

--- a/examples/apps/src/lib.rs
+++ b/examples/apps/src/lib.rs
@@ -9,6 +9,7 @@ pub mod ble_bas_central;
 pub mod ble_bas_central_sec;
 pub mod ble_bas_peripheral;
 pub mod ble_bas_peripheral_sec;
+pub mod ble_beacon;
 pub mod ble_l2cap_central;
 pub mod ble_l2cap_peripheral;
 pub mod ble_scanner;

--- a/examples/rp-pico-w/src/bin/ble_beacon.rs
+++ b/examples/rp-pico-w/src/bin/ble_beacon.rs
@@ -1,0 +1,69 @@
+#![no_std]
+#![no_main]
+
+use bt_hci::controller::ExternalController;
+use cyw43_pio::PioSpi;
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_rp::bind_interrupts;
+use embassy_rp::gpio::{Level, Output};
+use embassy_rp::peripherals::{DMA_CH0, PIO0};
+use embassy_rp::pio::{InterruptHandler, Pio};
+use static_cell::StaticCell;
+use trouble_example_apps::ble_beacon;
+use {defmt_rtt as _, embassy_time as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    PIO0_IRQ_0 => InterruptHandler<PIO0>;
+});
+
+#[embassy_executor::task]
+async fn cyw43_task(runner: cyw43::Runner<'static, Output<'static>, PioSpi<'static, PIO0, 0, DMA_CH0>>) -> ! {
+    runner.run().await
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+
+    #[cfg(feature = "skip-cyw43-firmware")]
+    let (fw, clm, btfw) = (&[], &[], &[]);
+
+    #[cfg(not(feature = "skip-cyw43-firmware"))]
+    let (fw, clm, btfw) = {
+        // IMPORTANT
+        //
+        // Download and make sure these files from https://github.com/embassy-rs/embassy/tree/main/cyw43-firmware
+        // are available in `./examples/rp-pico-w`. (should be automatic)
+        //
+        // IMPORTANT
+        let fw = include_bytes!("../../cyw43-firmware/43439A0.bin");
+        let clm = include_bytes!("../../cyw43-firmware/43439A0_clm.bin");
+        let btfw = include_bytes!("../../cyw43-firmware/43439A0_btfw.bin");
+        (fw, clm, btfw)
+    };
+
+    let pwr = Output::new(p.PIN_23, Level::Low);
+    let cs = Output::new(p.PIN_25, Level::High);
+    let mut pio = Pio::new(p.PIO0, Irqs);
+    let spi = PioSpi::new(
+        &mut pio.common,
+        pio.sm0,
+        cyw43_pio::DEFAULT_CLOCK_DIVIDER,
+        pio.irq0,
+        cs,
+        p.PIN_24,
+        p.PIN_29,
+        p.DMA_CH0,
+    );
+
+    static STATE: StaticCell<cyw43::State> = StaticCell::new();
+    let state = STATE.init(cyw43::State::new());
+    let (_net_device, bt_device, mut control, runner) = cyw43::new_with_bluetooth(state, pwr, spi, fw, btfw).await;
+    unwrap!(spawner.spawn(cyw43_task(runner)));
+    control.init(clm).await;
+
+    let controller: ExternalController<_, 10> = ExternalController::new(bt_device);
+
+    ble_beacon::run(controller).await;
+}

--- a/host/src/peripheral.rs
+++ b/host/src/peripheral.rs
@@ -113,10 +113,7 @@ impl<'d, C: Controller> Peripheral<'d, C> {
     /// does not accept any connections.
     pub async fn update_adv_data<'k>(&mut self, data: Advertisement<'k>) -> Result<(), BleHostError<C::Error>>
     where
-        C: for<'t> ControllerCmdSync<LeSetAdvData>
-            + ControllerCmdSync<LeSetAdvParams>
-            + for<'t> ControllerCmdSync<LeSetAdvEnable>
-            + for<'t> ControllerCmdSync<LeSetScanResponseData>,
+        C: for<'t> ControllerCmdSync<LeSetAdvData> + for<'t> ControllerCmdSync<LeSetScanResponseData>,
     {
         let host = &self.stack.host;
         let data: RawAdvertisement = data.into();

--- a/host/src/peripheral.rs
+++ b/host/src/peripheral.rs
@@ -106,6 +106,38 @@ impl<'d, C: Controller> Peripheral<'d, C> {
         })
     }
 
+    /// Update the advertisment adv_data and/or scan_data. Does not change any
+    /// other advertising parameters. If no advertising is active, this will not
+    /// produce any observable effect. This is typically useful when
+    /// implementing a BLE beacon that only broadcasts advertisement data and
+    /// does not accept any connections.
+    pub async fn update_adv_data<'k>(&mut self, data: Advertisement<'k>) -> Result<(), BleHostError<C::Error>>
+    where
+        C: for<'t> ControllerCmdSync<LeSetAdvData>
+            + ControllerCmdSync<LeSetAdvParams>
+            + for<'t> ControllerCmdSync<LeSetAdvEnable>
+            + for<'t> ControllerCmdSync<LeSetScanResponseData>,
+    {
+        let host = &self.stack.host;
+        let data: RawAdvertisement = data.into();
+        if !data.props.legacy_adv() {
+            return Err(Error::InvalidValue.into());
+        }
+        if !data.adv_data.is_empty() {
+            let mut buf = [0; 31];
+            let to_copy = data.adv_data.len().min(buf.len());
+            buf[..to_copy].copy_from_slice(&data.adv_data[..to_copy]);
+            host.command(LeSetAdvData::new(to_copy as u8, buf)).await?;
+        }
+        if !data.scan_data.is_empty() {
+            let mut buf = [0; 31];
+            let to_copy = data.scan_data.len().min(buf.len());
+            buf[..to_copy].copy_from_slice(&data.scan_data[..to_copy]);
+            host.command(LeSetScanResponseData::new(to_copy as u8, buf)).await?;
+        }
+        Ok(())
+    }
+
     /// Starts sending BLE advertisements according to the provided config.
     ///
     /// The handles are required to provide the storage while advertising, and


### PR DESCRIPTION
This adds a new `update_adv_data` method to Peripheral that allows updating advertisement data without otherwise affecting any active advertisements.