### PR TITLE
Use Bluetooth specification conform L2CAP PSM

### DIFF
--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -2,6 +2,8 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
+use crate::common::PSM_L2CAP_EXAMPLES;
+
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
 
@@ -47,7 +49,7 @@ where
                 mtu: Some(PAYLOAD_LEN as u16),
                 ..Default::default()
             };
-            let mut ch1 = L2capChannel::create(&stack, &conn, 0x2349, &config)
+            let mut ch1 = L2capChannel::create(&stack, &conn, PSM_L2CAP_EXAMPLES, &config)
                 .await
                 .unwrap();
             info!("New l2cap channel created, sending some data!");

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -2,6 +2,8 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
+use crate::common::PSM_L2CAP_EXAMPLES;
+
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
 
@@ -55,7 +57,9 @@ where
                 mtu: Some(PAYLOAD_LEN as u16),
                 ..Default::default()
             };
-            let mut ch1 = L2capChannel::accept(&stack, &conn, &[0x2349], &config).await.unwrap();
+            let mut ch1 = L2capChannel::accept(&stack, &conn, &[PSM_L2CAP_EXAMPLES], &config)
+                .await
+                .unwrap();
 
             info!("L2CAP channel accepted");
 

--- a/examples/apps/src/common.rs
+++ b/examples/apps/src/common.rs
@@ -1,0 +1,7 @@
+// PSM from the dynamic range (0x0080-0x00FF) according to the Bluetooth
+// Specification for L2CAP channels using LE Credit Based Flow Control mode.
+// used for the BLE L2CAP examples.
+//
+// https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host/logical-link-control-and-adaptation-protocol-specification.html#UUID-1ffdf913-7b8a-c7ba-531e-2a9c6f6da8fb
+//
+pub(crate) const PSM_L2CAP_EXAMPLES: u16 = 0x0081;

--- a/examples/apps/src/high_throughput_ble_l2cap_central.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_central.rs
@@ -4,6 +4,8 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, Timer};
 use trouble_host::prelude::*;
 
+use crate::common::PSM_L2CAP_EXAMPLES;
+
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
 
@@ -83,7 +85,7 @@ where
                 initial_credits: Some(200),
             };
 
-            let mut ch1 = L2capChannel::create(&stack, &conn, 0x2349, &l2cap_channel_config)
+            let mut ch1 = L2capChannel::create(&stack, &conn, PSM_L2CAP_EXAMPLES, &l2cap_channel_config)
                 .await
                 .expect("L2capChannel create failed");
 

--- a/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
@@ -4,6 +4,8 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, Timer};
 use trouble_host::prelude::*;
 
+use crate::common::PSM_L2CAP_EXAMPLES;
+
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
 
@@ -72,7 +74,7 @@ where
                 initial_credits: Some(200),
             };
 
-            let mut ch1 = L2capChannel::accept(&stack, &conn, &[0x2349], &l2cap_channel_config)
+            let mut ch1 = L2capChannel::accept(&stack, &conn, &[PSM_L2CAP_EXAMPLES], &l2cap_channel_config)
                 .await
                 .expect("L2capChannel create failed");
 

--- a/examples/apps/src/lib.rs
+++ b/examples/apps/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![allow(dead_code)]
 
+pub(crate) mod common;
 pub(crate) mod fmt;
 
 pub mod ble_advertise;

--- a/examples/tests/tests/ble_l2cap_central.rs
+++ b/examples/tests/tests/ble_l2cap_central.rs
@@ -87,7 +87,7 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
                         mtu: Some(PAYLOAD_LEN as u16),
                         ..Default::default()
                     };
-                    let mut ch1 = L2capChannel::accept(&stack, &conn, &[0x2349], &config).await?;
+                    let mut ch1 = L2capChannel::accept(&stack, &conn, &[0x81], &config).await?;
 
                     println!("[peripheral] channel created");
 

--- a/examples/tests/tests/ble_l2cap_peripheral.rs
+++ b/examples/tests/tests/ble_l2cap_peripheral.rs
@@ -75,7 +75,7 @@ async fn run_l2cap_peripheral_test(labels: &[(&str, &str)], firmware: &str) {
                         mtu: Some(PAYLOAD_LEN as u16),
                         ..Default::default()
                     };
-                    let mut ch1 = L2capChannel::create(&stack, &conn, 0x2349, &config).await?;
+                    let mut ch1 = L2capChannel::create(&stack, &conn, 0x81, &config).await?;
                     log::info!("[central] channel created");
                     for i in 0..10 {
                         let tx = [i; PAYLOAD_LEN];


### PR DESCRIPTION
Use a PSM from the dynamic range (0x0080-0x00FF) according to the [Bluetooth Specification for L2CAP channels using LE Credit Based Flow Control mode](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host/logical-link-control-and-adaptation-protocol-specification.html#UUID-1ffdf913-7b8a-c7ba-531e-2a9c6f6da8fb).

With this the L2CAP peripheral examples also work with _non embedded_ centrals, like a Swift test client running on macOS using [CBPeripheral/openL2CAPChannel ](https://developer.apple.com/documentation/corebluetooth/cbperipheral/openl2capchannel(_:))

See #371
