### PR TITLE
Replace unmaintained inflector dependency with convert_case

### DIFF
--- a/host-macros/Cargo.toml
+++ b/host-macros/Cargo.toml
@@ -8,11 +8,11 @@ keywords = ["no-std"]
 categories = ["embedded", "hardware-support", "no-std"]
 
 [dependencies]
+convert_case = "0.8.0"
 syn = { version = "^2", features = ["full", "extra-traits"] }
 quote = "1.0.7"
 darling = "0.20.10"
 proc-macro2 = "1.0.18"
-Inflector = "0.11.4"
 uuid = "1.10.0"
 
 [lib]

--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -5,7 +5,7 @@
 //! generate the code required to create the service.
 
 use darling::{Error, FromMeta};
-use inflector::cases::screamingsnakecase::to_screaming_snake_case;
+use convert_case::{Case, Casing};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::parse::Result;
@@ -189,7 +189,7 @@ impl ServiceBuilder {
     /// Construct instructions for adding a characteristic to the service, with static storage.
     fn construct_characteristic_static(&mut self, characteristic: Characteristic) {
         let (code_descriptors, named_descriptors) = self.build_descriptors(&characteristic);
-        let name_screaming = format_ident!("{}", to_screaming_snake_case(characteristic.name.as_str()));
+        let name_screaming = format_ident!("{}", characteristic.name.as_str().to_case(Case::Constant));
         let char_name = format_ident!("{}", characteristic.name);
         let ty = characteristic.ty;
         let access = &characteristic.args.access;
@@ -287,7 +287,7 @@ impl ServiceBuilder {
                 .enumerate()
                 .map(|(index, args)| {
                     let name_screaming =
-                        format_ident!("DESC_{index}_{}", to_screaming_snake_case(characteristic.name.as_str()));
+                        format_ident!("DESC_{index}_{}", characteristic.name.as_str().to_case(Case::Constant));
                     let identifier = args.name.as_ref().map(|name| format_ident!("{}_{}_descriptor", characteristic.name.as_str(), name.value()));
                     let access = &args.access;
                     let properties = set_access_properties(access);


### PR DESCRIPTION
I wasn't sure how to test this change, as `cargo test` in the host-macros directory didn't actually succeed before or after this.

The repository for the inflector crate at https://github.com/whatisinternet/Inflector
was archived last october, and hasn't been updated for 7 years.

This changes it to use the https://crates.io/crates/convert_case which was the most maintained crate I could find offering
the functionality, it is used as an optional dependency by the `derive-more` crate.

The relevant documentation for the before/after.
https://docs.rs/Inflector/latest/inflector/cases/screamingsnakecase/fn.to_screaming_snake_case.html
https://docs.rs/convert_case/latest/convert_case/enum.Case.html#variant.Constant

I'm assuming the usage of the alloc crate in the proc-macro is okay since it seemed like inflector also relied upon std.