### PR TITLE
fix: use length from AdStructure::encode_slice in examples/tests

### DIFF
--- a/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
+++ b/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
@@ -82,13 +82,13 @@ async fn main(spawner: Spawner) {
     } = stack.build();
 
     let mut adv_data = [0; 31];
-    unwrap!(AdStructure::encode_slice(
+    let adv_data_len = unwrap!(AdStructure::encode_slice(
         &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
         &mut adv_data[..],
     ));
 
     let mut scan_data = [0; 31];
-    unwrap!(AdStructure::encode_slice(
+    let scan_data_len = unwrap!(AdStructure::encode_slice(
         &[AdStructure::CompleteLocalName(b"Trouble")],
         &mut scan_data[..]
     ));
@@ -100,8 +100,8 @@ async fn main(spawner: Spawner) {
                     .advertise(
                         &Default::default(),
                         Advertisement::ConnectableScannableUndirected {
-                            adv_data: &adv_data[..],
-                            scan_data: &scan_data[..],
+                            adv_data: &adv_data[..adv_data_len],
+                            scan_data: &scan_data[..scan_data_len],
                         },
                     )
                     .await

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -150,7 +150,7 @@ async fn advertise<'a, 'b, C: Controller>(
     server: &'b Server<'_>,
 ) -> Result<GattConnection<'a, 'b, DefaultPacketPool>, BleHostError<C::Error>> {
     let mut advertiser_data = [0; 31];
-    AdStructure::encode_slice(
+    let len = AdStructure::encode_slice(
         &[
             AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
             AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
@@ -162,7 +162,7 @@ async fn advertise<'a, 'b, C: Controller>(
         .advertise(
             &Default::default(),
             Advertisement::ConnectableScannableUndirected {
-                adv_data: &advertiser_data[..],
+                adv_data: &advertiser_data[..len],
                 scan_data: &[],
             },
         )

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -177,7 +177,7 @@ async fn advertise<'a, 'b, C: Controller>(
     server: &'b Server<'_>,
 ) -> Result<GattConnection<'a, 'b, DefaultPacketPool>, BleHostError<C::Error>> {
     let mut advertiser_data = [0; 31];
-    AdStructure::encode_slice(
+    let len = AdStructure::encode_slice(
         &[
             AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
             AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
@@ -189,7 +189,7 @@ async fn advertise<'a, 'b, C: Controller>(
         .advertise(
             &Default::default(),
             Advertisement::ConnectableScannableUndirected {
-                adv_data: &advertiser_data[..],
+                adv_data: &advertiser_data[..len],
                 scan_data: &[],
             },
         )

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -27,14 +27,14 @@ where
     } = stack.build();
 
     let mut adv_data = [0; 31];
-    AdStructure::encode_slice(
+    let adv_data_len = AdStructure::encode_slice(
         &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
         &mut adv_data[..],
     )
     .unwrap();
 
     let mut scan_data = [0; 31];
-    AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"Trouble")], &mut scan_data[..]).unwrap();
+    let scan_data_len = AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"Trouble")], &mut scan_data[..]).unwrap();
 
     let _ = join(runner.run(), async {
         loop {
@@ -43,8 +43,8 @@ where
                 .advertise(
                     &Default::default(),
                     Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &scan_data[..],
+                        adv_data: &adv_data[..adv_data_len],
+                        scan_data: &scan_data[..scan_data_len],
                     },
                 )
                 .await

--- a/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
@@ -30,14 +30,14 @@ where
     } = stack.build();
 
     let mut adv_data = [0; 31];
-    AdStructure::encode_slice(
+    let adv_data_len = AdStructure::encode_slice(
         &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
         &mut adv_data[..],
     )
     .unwrap();
 
     let mut scan_data = [0; 31];
-    AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"TroubleHT")], &mut scan_data[..]).unwrap();
+    let scan_data_len = AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"TroubleHT")], &mut scan_data[..]).unwrap();
 
     let _ = join(runner.run(), async {
         loop {
@@ -54,8 +54,8 @@ where
                 .advertise(
                     &Default::default(),
                     Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &scan_data[..],
+                        adv_data: &adv_data[..adv_data_len],
+                        scan_data: &scan_data[..scan_data_len],
                     },
                 )
                 .await

--- a/examples/tests/tests/ble_l2cap_central.rs
+++ b/examples/tests/tests/ble_l2cap_central.rs
@@ -62,13 +62,13 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
             }
             r = async {
                 let mut adv_data = [0; 31];
-                AdStructure::encode_slice(
+                let adv_data_len = AdStructure::encode_slice(
                     &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
                     &mut adv_data[..],
                 ).unwrap();
 
                 let mut scan_data = [0; 31];
-                AdStructure::encode_slice(
+                let scan_data_len = AdStructure::encode_slice(
                     &[AdStructure::CompleteLocalName(b"trouble-l2cap-example")],
                     &mut scan_data[..],
                 ).unwrap();
@@ -76,8 +76,8 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
                 loop {
                     println!("[peripheral] advertising");
                     let acceptor = peripheral.advertise(&Default::default(), Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &scan_data[..],
+                        adv_data: &adv_data[..adv_data_len],
+                        scan_data: &scan_data[..scan_data_len],
                     }).await?;
                     let conn = acceptor.accept().await?;
                     println!("[peripheral] connected");

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -72,13 +72,13 @@ async fn gatt_client_server() {
             }
             r = async {
                 let mut adv_data = [0; 31];
-                AdStructure::encode_slice(
+                let adv_data_len = AdStructure::encode_slice(
                     &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
                     &mut adv_data[..],
                 ).unwrap();
 
                 let mut scan_data = [0; 31];
-                AdStructure::encode_slice(
+                let scan_data_len = AdStructure::encode_slice(
                     &[AdStructure::CompleteLocalName(b"trouble-gatt-int")],
                     &mut scan_data[..],
                 ).unwrap();
@@ -87,8 +87,8 @@ async fn gatt_client_server() {
                 while !done {
                     println!("[peripheral] advertising");
                     let acceptor = peripheral.advertise(&Default::default(), Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &scan_data[..],
+                        adv_data: &adv_data[..adv_data_len],
+                        scan_data: &scan_data[..scan_data_len],
                     }).await?;
                     let conn = acceptor.accept().await?.with_attribute_server(&server)?;
                     println!("[peripheral] connected");

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -102,13 +102,13 @@ async fn gatt_client_server() {
             }
             r = async {
                 let mut adv_data = [0; 31];
-                AdStructure::encode_slice(
+                let adv_data_len = AdStructure::encode_slice(
                     &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
                     &mut adv_data[..],
                 ).unwrap();
 
                 let mut scan_data = [0; 31];
-                AdStructure::encode_slice(
+                let scan_data_len = AdStructure::encode_slice(
                     &[AdStructure::CompleteLocalName(b"trouble-gatt-int")],
                     &mut scan_data[..],
                 ).unwrap();
@@ -117,8 +117,8 @@ async fn gatt_client_server() {
                 while !done {
                     println!("[peripheral] advertising");
                     let acceptor = peripheral.advertise(&Default::default(), Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &scan_data[..],
+                        adv_data: &adv_data[..adv_data_len],
+                        scan_data: &scan_data[..scan_data_len],
                     }).await?;
                     let conn = acceptor.accept().await?.with_attribute_server(&server)?;
                     println!("[peripheral] connected");

--- a/host/tests/l2cap.rs
+++ b/host/tests/l2cap.rs
@@ -41,13 +41,13 @@ async fn l2cap_connection_oriented_channels() {
             }
             r = async {
                 let mut adv_data = [0; 31];
-                AdStructure::encode_slice(
+                let adv_data_len = AdStructure::encode_slice(
                     &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
                     &mut adv_data[..],
                 ).unwrap();
 
                 let mut scan_data = [0; 31];
-                AdStructure::encode_slice(
+                let scan_data_len = AdStructure::encode_slice(
                     &[AdStructure::CompleteLocalName(b"trouble-l2cap-int")],
                     &mut scan_data[..],
                 ).unwrap();
@@ -55,8 +55,8 @@ async fn l2cap_connection_oriented_channels() {
                 loop {
                     println!("[peripheral] advertising");
                     let acceptor = peripheral.advertise(&Default::default(), Advertisement::ConnectableScannableUndirected {
-                        adv_data: &adv_data[..],
-                        scan_data: &scan_data[..],
+                        adv_data: &adv_data[..adv_data_len],
+                        scan_data: &scan_data[..scan_data_len],
                     }).await?;
                     let conn = acceptor.accept().await?;
                     println!("[peripheral] connected");


### PR DESCRIPTION
When the length is not used, the stack will emit a packet with padding, which wastes bandwidth. Another risk that can arise if the example code is followed elsewhere, is when buffers are reused as `encode_slice` does not zero out the rest of the buffer.