### PR TITLE
feat: expose the l2cap channel psm

### DIFF
--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -113,6 +113,13 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         self.state.borrow_mut().next_request_id()
     }
 
+    pub(crate) fn psm(&self, index: ChannelIndex) -> u16 {
+        self.with_mut(|state| {
+            let chan = &mut state.channels[index.0 as usize];
+            chan.psm
+        })
+    }
+
     pub(crate) fn disconnect(&self, index: ChannelIndex) {
         self.with_mut(|state| {
             let chan = &mut state.channels[index.0 as usize];

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -106,6 +106,11 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         self.manager.disconnect(self.index);
     }
 
+    /// Get the PSM for this channel.
+    pub fn psm(&self) -> u16 {
+        self.manager.psm(self.index)
+    }
+
     /// Send the provided buffer over this l2cap channel.
     ///
     /// The buffer must be equal to or smaller than the MTU agreed for the channel.


### PR DESCRIPTION
Exposing the PSM allows the application to implement different behavior depending on which PSM.