### PR TITLE
[Proposal] reexport ExternalController and SerialTransport from prelude

### DIFF
--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -1507,7 +1507,6 @@ dependencies = [
 name = "trouble-esp32-examples"
 version = "0.1.0"
 dependencies = [
- "bt-hci",
  "embassy-executor",
  "esp-alloc",
  "esp-backtrace",

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -13,7 +13,6 @@ esp-alloc = { version = "0.7.0" }
 esp-println = { version = "0.13.0", features = ["log"] }
 esp-wifi = { version = "0.13.0", features = [ "ble" ] }
 trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["log"] }
-bt-hci = { version = "0.3" }
 trouble-host = { path = "../../host", features = ["default-packet-pool-mtu-255"] }
 
 [features]

--- a/examples/esp32/src/bin/ble_bas_central.rs
+++ b/examples/esp32/src/bin/ble_bas_central.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
 use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_bas_central;
+use trouble_host::prelude::ExternalController;
 use {esp_alloc as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]

--- a/examples/esp32/src/bin/ble_bas_central_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_central_sec.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
 use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_bas_central_sec;
+use trouble_host::prelude::ExternalController;
 use {esp_alloc as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]

--- a/examples/esp32/src/bin/ble_bas_peripheral.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
 use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_bas_peripheral;
+use trouble_host::prelude::ExternalController;
 use {esp_alloc as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]

--- a/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
 use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_bas_peripheral_sec;
+use trouble_host::prelude::ExternalController;
 use {esp_alloc as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]

--- a/examples/esp32/src/bin/ble_l2cap_central.rs
+++ b/examples/esp32/src/bin/ble_l2cap_central.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
 use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_l2cap_central;
+use trouble_host::prelude::ExternalController;
 use {esp_alloc as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]

--- a/examples/esp32/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/esp32/src/bin/ble_l2cap_peripheral.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
 use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_l2cap_peripheral;
+use trouble_host::prelude::ExternalController;
 use {esp_alloc as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]

--- a/examples/esp32/src/bin/ble_scanner.rs
+++ b/examples/esp32/src/bin/ble_scanner.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
 use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
 use esp_wifi::ble::controller::BleConnector;
 use trouble_example_apps::ble_scanner;
+use trouble_host::prelude::ExternalController;
 use {esp_alloc as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]

--- a/examples/rp-pico-2-w/Cargo.toml
+++ b/examples/rp-pico-2-w/Cargo.toml
@@ -12,7 +12,6 @@ embassy-futures = "0.1.1"
 embassy-sync = { version = "0.6", features = ["defmt"] }
 
 futures = { version = "0.3", default-features = false, features = ["async-await"]}
-bt-hci = { version = "0.3", default-features = false, features = ["defmt"] }
 trouble-example-apps= { version = "0.1.0", path = "../apps", features = ["defmt"] }
 trouble-host = { path = "../../host", features = ["default-packet-pool-mtu-128"] }
 cyw43 = { version = "0.3", features = ["defmt", "firmware-logs", "bluetooth"] }

--- a/examples/rp-pico-2-w/src/bin/ble_bas_central.rs
+++ b/examples/rp-pico-2-w/src/bin/ble_bas_central.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use cyw43_pio::{PioSpi, RM2_CLOCK_DIVIDER};
 use defmt::*;
 use embassy_executor::Spawner;
@@ -11,6 +10,7 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use static_cell::StaticCell;
 use trouble_example_apps::ble_bas_central;
+use trouble_host::prelude::ExternalController;
 use {defmt_rtt as _, embassy_time as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {

--- a/examples/rp-pico-2-w/src/bin/ble_bas_peripheral.rs
+++ b/examples/rp-pico-2-w/src/bin/ble_bas_peripheral.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use cyw43_pio::{PioSpi, RM2_CLOCK_DIVIDER};
 use defmt::*;
 use embassy_executor::Spawner;
@@ -11,6 +10,7 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use static_cell::StaticCell;
 use trouble_example_apps::ble_bas_peripheral;
+use trouble_host::prelude::ExternalController;
 use {defmt_rtt as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {

--- a/examples/rp-pico-w/Cargo.lock
+++ b/examples/rp-pico-w/Cargo.lock
@@ -2406,7 +2406,6 @@ dependencies = [
 name = "trouble-rp-examples"
 version = "0.1.0"
 dependencies = [
- "bt-hci",
  "cortex-m",
  "cortex-m-rt",
  "cyw43",

--- a/examples/rp-pico-w/Cargo.toml
+++ b/examples/rp-pico-w/Cargo.toml
@@ -12,7 +12,6 @@ embassy-futures = "0.1.1"
 embassy-sync = { version = "0.6", features = ["defmt"] }
 
 futures = { version = "0.3", default-features = false, features = ["async-await"]}
-bt-hci = { version = "0.3", default-features = false, features = ["defmt"] }
 trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["defmt"] }
 trouble-host = { path = "../../host", features = ["default-packet-pool-mtu-128"] }
 cyw43 = { version = "0.3.0", features = ["defmt", "firmware-logs", "bluetooth"] }

--- a/examples/rp-pico-w/src/bin/ble_bas_central.rs
+++ b/examples/rp-pico-w/src/bin/ble_bas_central.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use cyw43_pio::PioSpi;
 use defmt::*;
 use embassy_executor::Spawner;
@@ -11,6 +10,7 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use static_cell::StaticCell;
 use trouble_example_apps::ble_bas_central;
+use trouble_host::prelude::ExternalController;
 use {defmt_rtt as _, embassy_time as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {

--- a/examples/rp-pico-w/src/bin/ble_bas_peripheral.rs
+++ b/examples/rp-pico-w/src/bin/ble_bas_peripheral.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use cyw43_pio::PioSpi;
 use defmt::*;
 use embassy_executor::Spawner;
@@ -11,6 +10,7 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use static_cell::StaticCell;
 use trouble_example_apps::ble_bas_peripheral;
+use trouble_host::prelude::ExternalController;
 use {defmt_rtt as _, embassy_time as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {

--- a/examples/rp-pico-w/src/bin/ble_beacon.rs
+++ b/examples/rp-pico-w/src/bin/ble_beacon.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use bt_hci::controller::ExternalController;
 use cyw43_pio::PioSpi;
 use defmt::*;
 use embassy_executor::Spawner;
@@ -11,6 +10,7 @@ use embassy_rp::peripherals::{DMA_CH0, PIO0};
 use embassy_rp::pio::{InterruptHandler, Pio};
 use static_cell::StaticCell;
 use trouble_example_apps::ble_beacon;
+use trouble_host::prelude::ExternalController;
 use {defmt_rtt as _, embassy_time as _, panic_probe as _};
 
 bind_interrupts!(struct Irqs {

--- a/examples/serial-hci/Cargo.lock
+++ b/examples/serial-hci/Cargo.lock
@@ -1003,7 +1003,6 @@ dependencies = [
 name = "serial-hci"
 version = "0.1.0"
 dependencies = [
- "bt-hci",
  "critical-section",
  "embassy-sync",
  "embassy-time",

--- a/examples/serial-hci/Cargo.toml
+++ b/examples/serial-hci/Cargo.toml
@@ -13,7 +13,6 @@ critical-section = { version = "1.1", features = ["std"] }
 rand = "0.8.5"
 tokio = { version = "1", features = ["full"] }
 tokio-serial = "5.4"
-bt-hci = { version = "0.3", default-features = false, features = ["log"] }
 trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["log"] }
 trouble-host = { path = "../../host" }
 

--- a/examples/serial-hci/src/bin/ble_bas_central.rs
+++ b/examples/serial-hci/src/bin/ble_bas_central.rs
@@ -1,11 +1,10 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::ble_bas_central;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[tokio::main]
 async fn main() {

--- a/examples/serial-hci/src/bin/ble_bas_central_sec.rs
+++ b/examples/serial-hci/src/bin/ble_bas_central_sec.rs
@@ -1,12 +1,11 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use rand::rngs::OsRng;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::ble_bas_central_sec;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[tokio::main]
 async fn main() {

--- a/examples/serial-hci/src/bin/ble_bas_peripheral.rs
+++ b/examples/serial-hci/src/bin/ble_bas_peripheral.rs
@@ -1,11 +1,10 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::ble_bas_peripheral;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[tokio::main]
 async fn main() {

--- a/examples/serial-hci/src/bin/ble_bas_peripheral_sec.rs
+++ b/examples/serial-hci/src/bin/ble_bas_peripheral_sec.rs
@@ -1,12 +1,11 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use rand::rngs::OsRng;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::ble_bas_peripheral_sec;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[tokio::main]
 async fn main() {

--- a/examples/serial-hci/src/bin/ble_l2cap_central.rs
+++ b/examples/serial-hci/src/bin/ble_l2cap_central.rs
@@ -1,11 +1,10 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::ble_l2cap_central;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[tokio::main]
 async fn main() {

--- a/examples/serial-hci/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/serial-hci/src/bin/ble_l2cap_peripheral.rs
@@ -1,11 +1,10 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::ble_l2cap_peripheral;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[tokio::main]
 async fn main() {

--- a/examples/serial-hci/src/bin/high_throughput_ble_l2cap_central.rs
+++ b/examples/serial-hci/src/bin/high_throughput_ble_l2cap_central.rs
@@ -1,11 +1,10 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::high_throughput_ble_l2cap_central;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[path = "../alloc.rs"]
 mod alloc;

--- a/examples/serial-hci/src/bin/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/serial-hci/src/bin/high_throughput_ble_l2cap_peripheral.rs
@@ -1,11 +1,10 @@
 // Use with any serial HCI
-use bt_hci::controller::ExternalController;
-use bt_hci::transport::SerialTransport;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use log::*;
 use tokio::time::Duration;
 use tokio_serial::{DataBits, Parity, SerialStream, StopBits};
 use trouble_example_apps::high_throughput_ble_l2cap_peripheral;
+use trouble_host::prelude::{ExternalController, SerialTransport};
 
 #[path = "../alloc.rs"]
 mod alloc;

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -69,7 +69,9 @@ use host::{AdvHandleState, BleHost, HostMetrics, Runner};
 
 pub mod prelude {
     //! Convenience include of most commonly used types.
+    pub use bt_hci::controller::ExternalController;
     pub use bt_hci::param::{AddrKind, BdAddr, LeConnRole as Role, PhyKind, PhyMask};
+    pub use bt_hci::transport::SerialTransport;
     pub use bt_hci::uuid::*;
     #[cfg(feature = "derive")]
     pub use heapless::String as HeaplessString;


### PR DESCRIPTION
For most projects, ExternalController (and sometimes SerialTransport) are the only structs required from bt_hci directly.  Bringing them in directly from Trouble would help developers with one fewer dependency to directly manage and reduce noise.

There is also a a namespace called `bt_hci::cmd::info` in the bt_hci crate that vscode always wants to import instead of `log::info` for me, so not having that in the project would also make that interaction nicer.