### PR TITLE
Tidy up ble bas peripheral example

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -52,7 +52,7 @@ where
 
     let _ = join(ble_task(runner), async {
         loop {
-            match advertise("Trouble Example", &server, &mut peripheral).await {
+            match advertise("Trouble Example", &mut peripheral, &server).await {
                 Ok(conn) => {
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let a = gatt_events_task(&server, &conn);
@@ -138,8 +138,8 @@ async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnect
 /// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
 async fn advertise<'values, 'server, C: Controller>(
     name: &'values str,
-    server: &'server Server<'values>,
     peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+    server: &'server Server<'values>,
 ) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
     let mut advertiser_data = [0; 31];
     let len = AdStructure::encode_slice(

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -52,7 +52,7 @@ where
 
     let _ = join(ble_task(runner), async {
         loop {
-            match server.advertise("Trouble Example", &mut peripheral).await {
+            match advertise("Trouble Example", &server, &mut peripheral).await {
                 Ok(conn) => {
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let a = gatt_events_task(&server, &conn);
@@ -135,36 +135,34 @@ async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnect
     Ok(())
 }
 
-impl<'values> Server<'values> {
-    /// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
-    pub async fn advertise<'server, C: Controller>(
-        &'server self,
-        name: &str,
-        peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
-    ) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
-        let mut advertiser_data = [0; 31];
-        let len = AdStructure::encode_slice(
-            &[
-                AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
-                AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
-                AdStructure::CompleteLocalName(name.as_bytes()),
-            ],
-            &mut advertiser_data[..],
-        )?;
-        let advertiser = peripheral
-            .advertise(
-                &Default::default(),
-                Advertisement::ConnectableScannableUndirected {
-                    adv_data: &advertiser_data[..len],
-                    scan_data: &[],
-                },
-            )
-            .await?;
-        info!("[adv] advertising");
-        let conn = advertiser.accept().await?.with_attribute_server(self)?;
-        info!("[adv] connection established");
-        Ok(conn)
-    }
+/// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
+async fn advertise<'values, 'server, C: Controller>(
+    name: &'values str,
+    server: &'server Server<'values>,
+    peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
+    let mut advertiser_data = [0; 31];
+    let len = AdStructure::encode_slice(
+        &[
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
+            AdStructure::CompleteLocalName(name.as_bytes()),
+        ],
+        &mut advertiser_data[..],
+    )?;
+    let advertiser = peripheral
+        .advertise(
+            &Default::default(),
+            Advertisement::ConnectableScannableUndirected {
+                adv_data: &advertiser_data[..len],
+                scan_data: &[],
+            },
+        )
+        .await?;
+    info!("[adv] advertising");
+    let conn = advertiser.accept().await?.with_attribute_server(server)?;
+    info!("[adv] connection established");
+    Ok(conn)
 }
 
 /// Example task to use the BLE notifier interface.

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -56,7 +56,7 @@ where
 
     let _ = join(ble_task(runner), async {
         loop {
-            match advertise("Trouble Example", &mut peripheral, &server).await {
+            match server.advertise("Trouble Example", &mut peripheral).await {
                 Ok(conn) => {
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let a = gatt_events_task(&server, &conn);
@@ -107,97 +107,90 @@ async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
 /// This is how we interact with read and write requests.
 async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, DefaultPacketPool>) -> Result<(), Error> {
     let level = server.battery_service.level;
-    loop {
+    let reason = loop {
         match conn.next().await {
-            GattConnectionEvent::Disconnected { reason } => {
-                info!("[gatt] disconnected: {:?}", reason);
-                break;
-            }
-            GattConnectionEvent::Gatt { event } => match event {
-                Ok(event) => {
-                    let result = match &event {
-                        GattEvent::Read(event) => {
-                            if event.handle() == level.handle {
-                                let value = server.get(&level);
-                                info!("[gatt] Read Event to Level Characteristic: {:?}", value);
-                            }
-                            #[cfg(feature = "security")]
-                            if conn.raw().encrypted() {
-                                None
-                            } else {
-                                Some(AttErrorCode::INSUFFICIENT_ENCRYPTION)
-                            }
-                            #[cfg(not(feature = "security"))]
+            GattConnectionEvent::Disconnected { reason } => break reason,
+            GattConnectionEvent::Gatt { event: Err(e) } => warn!("[gatt] error processing event: {:?}", e),
+            GattConnectionEvent::Gatt { event: Ok(event) } => {
+                let result = match &event {
+                    GattEvent::Read(event) => {
+                        if event.handle() == level.handle {
+                            let value = server.get(&level);
+                            info!("[gatt] Read Event to Level Characteristic: {:?}", value);
+                        }
+                        #[cfg(feature = "security")]
+                        if conn.raw().encrypted() {
                             None
+                        } else {
+                            Some(AttErrorCode::INSUFFICIENT_ENCRYPTION)
                         }
-                        GattEvent::Write(event) => {
-                            if event.handle() == level.handle {
-                                info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
-                            }
-                            #[cfg(feature = "security")]
-                            if conn.raw().encrypted() {
-                                None
-                            } else {
-                                Some(AttErrorCode::INSUFFICIENT_ENCRYPTION)
-                            }
-                            #[cfg(not(feature = "security"))]
-                            None
-                        }
-                    };
-
-                    // This step is also performed at drop(), but writing it explicitly is necessary
-                    // in order to ensure reply is sent.
-                    let result = if let Some(code) = result {
-                        event.reject(code)
-                    } else {
-                        event.accept()
-                    };
-                    match result {
-                        Ok(reply) => {
-                            reply.send().await;
-                        }
-                        Err(e) => {
-                            warn!("[gatt] error sending response: {:?}", e);
-                        }
+                        #[cfg(not(feature = "security"))]
+                        None
                     }
+                    GattEvent::Write(event) => {
+                        if event.handle() == level.handle {
+                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
+                        }
+                        #[cfg(feature = "security")]
+                        if conn.raw().encrypted() {
+                            None
+                        } else {
+                            Some(AttErrorCode::INSUFFICIENT_ENCRYPTION)
+                        }
+                        #[cfg(not(feature = "security"))]
+                        None
+                    }
+                };
+
+                // This step is also performed at drop(), but writing it explicitly is necessary
+                // in order to ensure reply is sent.
+                let reply_result = if let Some(code) = result {
+                    event.reject(code)
+                } else {
+                    event.accept()
+                };
+                match reply_result {
+                    Ok(reply) => reply.send().await,
+                    Err(e) => warn!("[gatt] error sending response: {:?}", e),
                 }
-                Err(e) => warn!("[gatt] error processing event: {:?}", e),
-            },
-            _ => {}
+            }
+            _ => {} // ignore other Gatt Connection Events
         }
-    }
-    info!("[gatt] task finished");
+    };
+    info!("[gatt] disconnected: {:?}", reason);
     Ok(())
 }
 
-/// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
-async fn advertise<'a, 'b, C: Controller>(
-    name: &'a str,
-    peripheral: &mut Peripheral<'a, C, DefaultPacketPool>,
-    server: &'b Server<'_>,
-) -> Result<GattConnection<'a, 'b, DefaultPacketPool>, BleHostError<C::Error>> {
-    let mut advertiser_data = [0; 31];
-    let len = AdStructure::encode_slice(
-        &[
-            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
-            AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
-            AdStructure::CompleteLocalName(name.as_bytes()),
-        ],
-        &mut advertiser_data[..],
-    )?;
-    let advertiser = peripheral
-        .advertise(
-            &Default::default(),
-            Advertisement::ConnectableScannableUndirected {
-                adv_data: &advertiser_data[..len],
-                scan_data: &[],
-            },
-        )
-        .await?;
-    info!("[adv] advertising");
-    let conn = advertiser.accept().await?.with_attribute_server(server)?;
-    info!("[adv] connection established");
-    Ok(conn)
+impl<'values> Server<'values> {
+    /// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
+    pub async fn advertise<'server, C: Controller>(
+        &'server self,
+        name: &str,
+        peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+    ) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
+        let mut advertiser_data = [0; 31];
+        let len = AdStructure::encode_slice(
+            &[
+                AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+                AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
+                AdStructure::CompleteLocalName(name.as_bytes()),
+            ],
+            &mut advertiser_data[..],
+        )?;
+        let advertiser = peripheral
+            .advertise(
+                &Default::default(),
+                Advertisement::ConnectableScannableUndirected {
+                    adv_data: &advertiser_data[..len],
+                    scan_data: &[],
+                },
+            )
+            .await?;
+        info!("[adv] advertising");
+        let conn = advertiser.accept().await?.with_attribute_server(self)?;
+        info!("[adv] connection established");
+        Ok(conn)
+    }
 }
 
 /// Example task to use the BLE notifier interface.

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -56,7 +56,7 @@ where
 
     let _ = join(ble_task(runner), async {
         loop {
-            match advertise("Trouble Example", &server, &mut peripheral).await {
+            match advertise("Trouble Example", &mut peripheral, &server).await {
                 Ok(conn) => {
                     // set up tasks when the connection is established to a central, so they don't run when no one is connected.
                     let a = gatt_events_task(&server, &conn);
@@ -164,8 +164,8 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
 /// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
 async fn advertise<'values, 'server, C: Controller>(
     name: &'values str,
-    server: &'server Server<'values>,
     peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+    server: &'server Server<'values>,
 ) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
     let mut advertiser_data = [0; 31];
     let len = AdStructure::encode_slice(

--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -2,7 +2,7 @@
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
 channel = "nightly-2025-02-17"
-components = [ "rust-src", "rustfmt" ]
+components = [ "rust-src", "rustfmt", "llvm-tools-preview", "clippy" ]
 targets = [
     "thumbv7em-none-eabi"
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
 channel = "1.85"
-components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
+components = [ "rust-src", "rustfmt", "llvm-tools-preview", "clippy"]
 targets = [
     "thumbv8m.main-none-eabihf",
     "thumbv7em-none-eabi",


### PR DESCRIPTION
Small refactor of the gatt peripheral examples to tidy up their structure.  I also tend to implement advertiser as a method on the Server, so wanted your thoughts on if this is a patter you're happy with.  (I think we might also move to having a macro generated advertiser function in future too...)