### PR TITLE
Simplify and generify GattEvent; allow again for custom processing of GATT events

### DIFF
--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -1,7 +1,6 @@
 use embassy_futures::join::join;
 use embassy_futures::select::select;
 use embassy_time::Timer;
-use trouble_host::att::{AttClient, AttCmd, AttReq};
 use trouble_host::prelude::*;
 
 /// Max number of connections
@@ -108,18 +107,16 @@ async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnect
         match conn.next().await {
             GattConnectionEvent::Disconnected { reason } => break reason,
             GattConnectionEvent::Gatt { event } => {
-                match event.payload().incoming() {
-                    AttClient::Request(AttReq::Read { handle, .. })
-                    | AttClient::Request(AttReq::ReadBlob { handle, .. }) => {
-                        if handle == level.handle {
+                match &event {
+                    GattEvent::Read(event) => {
+                        if event.handle() == level.handle {
                             let value = server.get(&level);
-                            info!("[gatt] Read from Level Characteristic: {:?}", value);
+                            info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                         }
                     }
-                    AttClient::Request(AttReq::Write { handle, data })
-                    | AttClient::Command(AttCmd::Write { handle, data }) => {
-                        if handle == level.handle {
-                            info!("[gatt] Write to Level Characteristic: {:?}", data);
+                    GattEvent::Write(event) => {
+                        if event.handle() == level.handle {
+                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
                         }
                     }
                     _ => {}

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -2,7 +2,6 @@ use embassy_futures::join::join;
 use embassy_futures::select::select;
 use embassy_time::Timer;
 use rand_core::{CryptoRng, RngCore};
-use trouble_host::att::{AttClient, AttCmd, AttReq};
 use trouble_host::prelude::*;
 
 /// Max number of connections
@@ -112,46 +111,43 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
         match conn.next().await {
             GattConnectionEvent::Disconnected { reason } => break reason,
             GattConnectionEvent::Gatt { event } => {
-                #[allow(unused_mut)]
-                let mut reject_handle = None;
-
-                match event.payload().incoming() {
-                    AttClient::Request(AttReq::Read { handle, .. })
-                    | AttClient::Request(AttReq::ReadBlob { handle, .. }) => {
-                        if handle == level.handle {
+                let result = match &event {
+                    GattEvent::Read(event) => {
+                        if event.handle() == level.handle {
                             let value = server.get(&level);
-                            info!("[gatt] Read from Level Characteristic: {:?}", value);
+                            info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                         }
-
                         #[cfg(feature = "security")]
-                        if !conn.raw().encrypted() {
-                            reject_handle = Some(handle);
+                        if conn.raw().encrypted() {
+                            None
+                        } else {
+                            Some(AttErrorCode::INSUFFICIENT_ENCRYPTION)
                         }
+                        #[cfg(not(feature = "security"))]
+                        None
                     }
-                    AttClient::Request(AttReq::Write { handle, data })
-                    | AttClient::Command(AttCmd::Write { handle, data }) => {
-                        if handle == level.handle {
-                            info!("[gatt] Write to Level Characteristic: {:?}", data);
+                    GattEvent::Write(event) => {
+                        if event.handle() == level.handle {
+                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
                         }
-
                         #[cfg(feature = "security")]
-                        if !conn.raw().encrypted() {
-                            reject_handle = Some(handle);
+                        if conn.raw().encrypted() {
+                            None
+                        } else {
+                            Some(AttErrorCode::INSUFFICIENT_ENCRYPTION)
                         }
+                        #[cfg(not(feature = "security"))]
+                        None
                     }
-                    _ => {}
+                    _ => None,
                 };
 
-                let reply = if let Some(reject_handle) = reject_handle {
-                    // Reject the request with an error code if the connection is not encrypted.
-                    event.reject(reject_handle, AttErrorCode::INSUFFICIENT_ENCRYPTION)
+                let reply_result = if let Some(code) = result {
+                    event.reject(code)
                 } else {
-                    // This step is also performed at drop(), but writing it explicitly is necessary
-                    // in order to ensure reply is sent.
                     event.accept()
                 };
-
-                match reply {
+                match reply_result {
                     Ok(reply) => reply.send().await,
                     Err(e) => warn!("[gatt] error sending response: {:?}", e),
                 }

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -34,7 +34,8 @@ where
     .unwrap();
 
     let mut scan_data = [0; 31];
-    let scan_data_len = AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"Trouble")], &mut scan_data[..]).unwrap();
+    let scan_data_len =
+        AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"Trouble")], &mut scan_data[..]).unwrap();
 
     let _ = join(runner.run(), async {
         loop {

--- a/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
@@ -37,7 +37,8 @@ where
     .unwrap();
 
     let mut scan_data = [0; 31];
-    let scan_data_len = AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"TroubleHT")], &mut scan_data[..]).unwrap();
+    let scan_data_len =
+        AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"TroubleHT")], &mut scan_data[..]).unwrap();
 
     let _ = join(runner.run(), async {
         loop {

--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "linked_list_allocator"
@@ -1478,9 +1478,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -2,10 +2,7 @@ use std::time::Duration;
 
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use tokio::select;
-use trouble_host::{
-    att::{AttClient, AttCmd, AttReq},
-    prelude::*,
-};
+use trouble_host::prelude::*;
 
 mod common;
 
@@ -102,25 +99,22 @@ async fn gatt_client_server() {
                                 println!("Disconnected: {:?}", reason);
                                 break;
                             }
-                            GattConnectionEvent::Gatt { event } => match event.payload().incoming() {
-                                AttClient::Request(AttReq::Write { handle, .. }) | AttClient::Command(AttCmd::Write { handle, .. }) => {
-                                    let characteristic = server.table().find_characteristic_by_value_handle(handle).unwrap();
-                                    assert_eq!(characteristic.handle, handle);
-                                    event.accept().unwrap().send().await;
+                            GattConnectionEvent::Gatt { event: GattEvent::Write(event) } => {
+                                let characteristic = server.table().find_characteristic_by_value_handle(event.handle()).unwrap();
+                                assert_eq!(characteristic.handle, event.handle());
+                                event.accept().unwrap().send().await;
 
-                                    let value: u8 = server.table().get(&characteristic).unwrap();
-                                    println!("[peripheral] write value: {}", value);
-                                    assert_eq!(expected, value);
-                                    expected = expected.wrapping_add(1);
-                                    writes += 1;
-                                    if writes == 2 {
-                                        println!("expected value written twice, test pass");
-                                        // NOTE: Ensure that adapter gets polled again
-                                        tokio::time::sleep(Duration::from_secs(2)).await;
-                                        done = true;
-                                    }
+                                let value: u8 = server.table().get(&characteristic).unwrap();
+                                println!("[peripheral] write value: {}", value);
+                                assert_eq!(expected, value);
+                                expected = expected.wrapping_add(1);
+                                writes += 1;
+                                if writes == 2 {
+                                    println!("expected value written twice, test pass");
+                                    // NOTE: Ensure that adapter gets polled again
+                                    tokio::time::sleep(Duration::from_secs(2)).await;
+                                    done = true;
                                 }
-                                _ => {}
                             }
                             _ => {}
                         }

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use tokio::select;
-use trouble_host::att::{AttClient, AttCmd, AttReq};
 use trouble_host::prelude::*;
 
 mod common;
@@ -130,25 +129,22 @@ async fn gatt_client_server() {
                                 println!("Disconnected: {:?}", reason);
                                 break;
                             }
-                            GattConnectionEvent::Gatt { event } => match event.payload().incoming() {
-                                AttClient::Request(AttReq::Write { handle, .. }) | AttClient::Command(AttCmd::Write { handle, .. }) => {
-                                    if writes == 0 {
-                                        event.reject(handle, AttErrorCode::VALUE_NOT_ALLOWED).unwrap().send().await;
-                                        writes += 1;
-                                    } else {
-                                        let characteristic = server.table().find_characteristic_by_value_handle(handle).unwrap();
-                                        let value: u8 = server.table().get(&characteristic).unwrap();
-                                        assert_eq!(expected, value);
-                                        expected = expected.wrapping_add(2);
-                                        writes += 1;
-                                        if writes == 2 {
-                                            println!("expected value written twice, test pass");
+                            GattConnectionEvent::Gatt { event: GattEvent::Write(event) } => {
+                                if writes == 0 {
+                                    event.reject(AttErrorCode::VALUE_NOT_ALLOWED).unwrap().send().await;
+                                    writes += 1;
+                                } else {
+                                    let characteristic = server.table().find_characteristic_by_value_handle(event.handle()).unwrap();
+                                    let value: u8 = server.table().get(&characteristic).unwrap();
+                                    assert_eq!(expected, value);
+                                    expected = expected.wrapping_add(2);
+                                    writes += 1;
+                                    if writes == 2 {
+                                        println!("expected value written twice, test pass");
 
-                                            done = true;
-                                        }
+                                        done = true;
                                     }
                                 }
-                                _ => {}
                             }
                             _ => {}
                         }


### PR DESCRIPTION
[`GattEvent`](https://github.com/embassy-rs/trouble/blob/cb4b2cd424cdb2af54bad52922798a58d8786d7f/host/src/gatt.rs#L234) is currently an enum with only two variants:
- `Write` - captures ATT Write requests and Write commands
- `Read` - captures ATT Read and ReadBlob requesats

(1) This modeling is _incomplete_. 

There are many more ATT payloads that are currently impossible to capture with `GattEvent`. Rather than extending `GattEvent` to model all of those, the GATT layer currently just doesn't model these additional ATT payloads with a `GattEvent` _at all_ and instead [directly processes those payloads](https://github.com/embassy-rs/trouble/blob/cb4b2cd424cdb2af54bad52922798a58d8786d7f/host/src/gatt.rs#L222) _without even notifying the user that such a processing is due / had happened_.

(2) Another problem with `GattEvent` is that if the user code would like to - for whatever reason - not call `GattEvent::accept` or `GattEvent::reject` but do its own processing of the original `PDU` / `GattData` payload, it is currently just not possible, as once a `GattEvent` is constructed by `GattConnection`, it is either `accept` or `reject`, no other way.

(1) and (2) cause problems to `rs-matter` which wants to do its own custom processing for a handful of ATT payloads, while still delegating the majority of the ATT payloads to a proc-macro derived attribute server which saves a great deal of boilerplate code for your typical meta-data "what attributes are in there?" type of ATT queries.

===

This PR is solving both (1) and (2) as follows:

For (1), the PR
- Converts `GattEvent` from an enum into a struct with two fields: `payload: GattData` (the GATT payload) and `server` - the type-erased attribute server
- **Removes** the silent, direct processing of "other" payloads from `GattConnection::next`, which I think is a big win. ALL ATT payloads are now converted to a `GattEvent` and are only processed if the user calls `accept` (or on drop, as before)
- `ReadEvent` and `WriteEvent` are now gone. They were anyway pre-dating the `AttClient`/`AttServer` enumerations which were introduced with PR #267 , and with that PR in place, they seem obsolete
- Rather than `match`-ing on `GattEvent::Read` and `GattEvent::Write`, user can now match on `GattEvent::payload().incoming()` which does provide a **complete** modeling of the ATT payload, and not just on "read" and "write", where the fidelity of the exact read and write ATT operation was even lost

For (2), the PR
- Introduces a new method, `GattEvent::into_payload` which converts the `GattEvent` instance back into the `GattData` payload it encloses, thus leaving it up to the caller to handle the payload however she sees fit. Given that #267 also introduced `GattData::reply` and `GattData::send`, this is completely possible.


===

Pros and cons:
(+) No more "silent processing bypassing GattEvent"
(+) For accepting/rejecting/`into_payload`-ing GATT events, user can now inspect/query the payload of GattEvent at a much greater detail, by matching on all possible ATT payloads supported by BLE
(+) Possibility to to do custom processing of the GATT event by `GattEvent::into_payload`
(-) Inspecting the payload of the `GattEvent` is more verbose now, as can be seen in the unit tests and examples, as e.g. "reads" and "writes" in the ATT layer can come in different shapes (i.e. a "write" could be a write request or a write command; a "read" could be a read request, or a read blob request, and so on)
