### PR TITLE
made scan_command_state.cancel in scan_ext use the right argument

### DIFF
--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -44,7 +44,7 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
     {
         let host = &self.central.stack.host;
         let drop = crate::host::OnDrop::new(|| {
-            host.scan_command_state.cancel(false);
+            host.scan_command_state.cancel(true);
         });
         host.scan_command_state.request().await;
         self.central.set_accept_filter(config.filter_accept_list).await?;


### PR DESCRIPTION
I believe this was incorrectly set to false. Now if this fires, it cancels extended scanning (based on reading host.rs) and not regular scanning (one has no impact on the other from what I understand).