### PR TITLE
Add collapse_debuginfo attribute to fmt macros

### DIFF
--- a/host/src/fmt.rs
+++ b/host/src/fmt.rs
@@ -6,6 +6,7 @@ use core::fmt::{Debug, Display, LowerHex};
 #[cfg(all(feature = "defmt", feature = "log"))]
 compile_error!("You may not enable both `defmt` and `log` features.");
 
+#[collapse_debuginfo(yes)]
 macro_rules! assert {
     ($($x:tt)*) => {
         {
@@ -17,6 +18,7 @@ macro_rules! assert {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
@@ -28,6 +30,7 @@ macro_rules! assert_eq {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
@@ -39,6 +42,7 @@ macro_rules! assert_ne {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
@@ -50,6 +54,7 @@ macro_rules! debug_assert {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
@@ -61,6 +66,7 @@ macro_rules! debug_assert_eq {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
@@ -72,6 +78,7 @@ macro_rules! debug_assert_ne {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! todo {
     ($($x:tt)*) => {
         {
@@ -83,6 +90,7 @@ macro_rules! todo {
     };
 }
 
+#[collapse_debuginfo(yes)]
 #[cfg(not(feature = "defmt"))]
 macro_rules! unreachable {
     ($($x:tt)*) => {
@@ -90,6 +98,7 @@ macro_rules! unreachable {
     };
 }
 
+#[collapse_debuginfo(yes)]
 #[cfg(feature = "defmt")]
 macro_rules! unreachable {
     ($($x:tt)*) => {
@@ -97,6 +106,7 @@ macro_rules! unreachable {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! panic {
     ($($x:tt)*) => {
         {
@@ -108,6 +118,7 @@ macro_rules! panic {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
@@ -121,6 +132,7 @@ macro_rules! trace {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
@@ -134,6 +146,7 @@ macro_rules! debug {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
@@ -147,6 +160,7 @@ macro_rules! info {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
@@ -160,6 +174,7 @@ macro_rules! warn {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
@@ -173,6 +188,7 @@ macro_rules! error {
     };
 }
 
+#[collapse_debuginfo(yes)]
 #[cfg(feature = "defmt")]
 macro_rules! unwrap {
     ($($x:tt)*) => {
@@ -180,6 +196,7 @@ macro_rules! unwrap {
     };
 }
 
+#[collapse_debuginfo(yes)]
 #[cfg(not(feature = "defmt"))]
 macro_rules! unwrap {
     ($arg:expr) => {


### PR DESCRIPTION
This PR fixes the location of defmt logs.

Before:
```
00:00:00.001 [INFO ] trouble_host/src/fmt.rs:143                   [host] using packet pool with MTU 251 capacity 16
00:00:00.001 [INFO ] trouble_host/src/fmt.rs:143                   [host] filter accept list size: 8
00:00:00.001 [INFO ] trouble_host/src/fmt.rs:143                   [host] setting txq to 3, fragmenting at 27
00:00:00.001 [INFO ] trouble_host/src/fmt.rs:143                   [host] configuring host buffers (1 packets of size 255)
00:00:00.001 [INFO ] trouble_host/src/fmt.rs:143                   [host] initialized
00:00:00.001 [TRACE] trouble_host/src/fmt.rs:117                   [host] enabling advertising
```

After:
```
00:00:00.001 [INFO ] trouble_host/src/host.rs:1056                 [host] using packet pool with MTU 251 capacity 16
00:00:00.001 [INFO ] trouble_host/src/host.rs:1063                 [host] filter accept list size: 8
00:00:00.001 [INFO ] trouble_host/src/host.rs:1066                 [host] setting txq to 3, fragmenting at 27
00:00:00.001 [INFO ] trouble_host/src/host.rs:1075                 [host] configuring host buffers (1 packets of size 255)
00:00:00.001 [INFO ] trouble_host/src/host.rs:1094                 [host] initialized
00:00:00.001 [TRACE] trouble_host/src/peripheral.rs:98             [host] enabling advertising
```