### PR TITLE
Don't depend on bt-hci/embassy-time

### DIFF
--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -89,7 +89,6 @@ checksum = "a496a585c0e2e00195e558af18342f79afd67598d3edb32e78c006e606a31386"
 dependencies = [
  "btuuid",
  "embassy-sync 0.7.0",
- "embassy-time",
  "embedded-io",
  "embedded-io-async",
  "futures-intrusive",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -19,7 +19,7 @@ target = "thumbv7em-none-eabi"
 
 [dependencies]
 aes = { version = "0.8.2", optional = true }
-bt-hci = { version = "0.4", features = ["embassy-time", "uuid"] }
+bt-hci = { version = "0.4", features = ["uuid"] }
 cmac = { version = "0.7.2", optional = true }
 embedded-io = { version = "0.6" }
 embassy-sync = "0.7"

--- a/host/src/advertise.rs
+++ b/host/src/advertise.rs
@@ -5,7 +5,7 @@ use embassy_time::Duration;
 
 use crate::cursor::{ReadCursor, WriteCursor};
 use crate::types::uuid::Uuid;
-use crate::{codec, Address};
+use crate::{bt_hci_duration, codec, Address};
 
 /// Transmit power levels.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -57,11 +57,7 @@ impl<'d> AdvertisementSet<'d> {
         let mut ret = [NEW_SET; N];
         for (i, set) in sets.iter().enumerate() {
             ret[i].adv_handle = AdvHandle::new(i as u8);
-            ret[i].duration = set
-                .params
-                .timeout
-                .unwrap_or(embassy_time::Duration::from_micros(0))
-                .into();
+            ret[i].duration = bt_hci_duration(set.params.timeout.unwrap_or(embassy_time::Duration::from_micros(0)));
             ret[i].max_ext_adv_events = set.params.max_events.unwrap_or(0);
         }
         ret

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -5,7 +5,7 @@ use bt_hci::param::{AddrKind, BdAddr, InitiatingPhy, LeConnRole, PhyParams};
 use embassy_futures::select::{select, Either};
 
 use crate::connection::{ConnectConfig, Connection, PhySet};
-use crate::{BleHostError, Error, PacketPool, Stack};
+use crate::{bt_hci_duration, BleHostError, Error, PacketPool, Stack};
 
 /// A type implementing the BLE central role.
 pub struct Central<'stack, C, P: PacketPool> {
@@ -37,18 +37,18 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         self.set_accept_filter(config.scan_config.filter_accept_list).await?;
 
         host.async_command(LeCreateConn::new(
-            config.scan_config.interval.into(),
-            config.scan_config.window.into(),
+            bt_hci_duration(config.scan_config.interval),
+            bt_hci_duration(config.scan_config.window),
             true,
             AddrKind::PUBLIC,
             BdAddr::default(),
             host.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC),
-            config.connect_params.min_connection_interval.into(),
-            config.connect_params.max_connection_interval.into(),
+            bt_hci_duration(config.connect_params.min_connection_interval),
+            bt_hci_duration(config.connect_params.max_connection_interval),
             config.connect_params.max_latency,
-            config.connect_params.supervision_timeout.into(),
-            config.connect_params.min_event_length.into(),
-            config.connect_params.max_event_length.into(),
+            bt_hci_duration(config.connect_params.supervision_timeout),
+            bt_hci_duration(config.connect_params.min_event_length),
+            bt_hci_duration(config.connect_params.max_event_length),
         ))
         .await?;
         match select(
@@ -91,14 +91,14 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         self.set_accept_filter(config.scan_config.filter_accept_list).await?;
 
         let initiating = InitiatingPhy {
-            scan_interval: config.scan_config.interval.into(),
-            scan_window: config.scan_config.window.into(),
-            conn_interval_min: config.connect_params.min_connection_interval.into(),
-            conn_interval_max: config.connect_params.max_connection_interval.into(),
+            scan_interval: bt_hci_duration(config.scan_config.interval),
+            scan_window: bt_hci_duration(config.scan_config.window),
+            conn_interval_min: bt_hci_duration(config.connect_params.min_connection_interval),
+            conn_interval_max: bt_hci_duration(config.connect_params.max_connection_interval),
             max_latency: config.connect_params.max_latency,
-            supervision_timeout: config.connect_params.supervision_timeout.into(),
-            min_ce_len: config.connect_params.min_event_length.into(),
-            max_ce_len: config.connect_params.max_event_length.into(),
+            supervision_timeout: bt_hci_duration(config.connect_params.supervision_timeout),
+            min_ce_len: bt_hci_duration(config.connect_params.min_event_length),
+            max_ce_len: bt_hci_duration(config.connect_params.max_event_length),
         };
         let phy_params = create_phy_params(initiating, config.scan_config.phys);
 

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -12,6 +12,7 @@ use bt_hci::cmd::status::ReadRssi;
 use bt_hci::cmd::{AsyncCmd, SyncCmd};
 use bt_hci::param::{AddrKind, BdAddr};
 use bt_hci::FromHciBytesError;
+use embassy_time::Duration;
 #[cfg(feature = "security")]
 use heapless::Vec;
 use rand_core::{CryptoRng, RngCore};
@@ -700,4 +701,12 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     pub fn get_bond_information(&self) -> Vec<BondInformation, BI_COUNT> {
         self.host.connections.security_manager.get_bond_information()
     }
+}
+
+pub(crate) fn bt_hci_duration<const US: u32>(d: Duration) -> bt_hci::param::Duration<US> {
+    bt_hci::param::Duration::from_micros(d.as_micros())
+}
+
+pub(crate) fn bt_hci_ext_duration<const US: u16>(d: Duration) -> bt_hci::param::ExtDuration<US> {
+    bt_hci::param::ExtDuration::from_micros(d.as_micros())
 }


### PR DESCRIPTION
This is part of my master plan to remove embassy-time from bt-hci. bt-hci depends on embassy-time for the `From` conversion, which is exactly 2 (or 6, depending on how you count it) lines of code and just means bt-hci needs to be updated more often than strictly necessary.