### PR TITLE
Respond with multiple entries from read by group and group type

### DIFF
--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -427,29 +427,66 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         end: u16,
         group_type: &Uuid,
     ) -> Result<usize, codec::Error> {
-        // TODO respond with all finds - not just one
         let mut handle = start;
         let mut data = WriteCursor::new(buf);
-
         let (mut header, mut body) = data.split(2)?;
+        // Multiple entries can be returned in the response as long as they are of equal length.
         let err = self.att_table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
+            // ret either holds the length of the attribute, or the error code encountered.
+            let mut ret: Result<usize, AttErrorCode> = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
-                // trace!("[read_by_group] Check attribute {:x} {}", att.uuid, att.handle);
+                // trace!("[read_by_group] Check attribute {:x?} {}", att.uuid, att.handle);
                 if &att.uuid == group_type && att.handle >= start && att.handle <= end {
-                    // debug!("[read_by_group] found! {:x} {}", att.uuid, att.handle);
+                    // debug!("[read_by_group] found! {:x?} handle: {}", att.uuid, att.handle);
                     handle = att.handle;
 
                     body.write(att.handle)?;
                     body.write(att.last_handle_in_group)?;
-                    err = self.read_attribute_data(connection, 0, att, body.write_buf());
-                    if let Ok(len) = err {
-                        body.commit(len)?;
+                    let new_ret = self.read_attribute_data(connection, 0, att, body.write_buf());
+                    match (new_ret, ret) {
+                        (Ok(first_length), Err(_)) => {
+                            // First successful read, store this length, all subsequent ones must match it.
+                            // debug!("[read_by_group] found first entry {:x?}, handle {}", att.uuid, handle);
+                            ret = new_ret;
+                            body.commit(first_length)?;
+                        }
+                        (Ok(new_length), Ok(old_length)) => {
+                            // Any matching attribute after the first, verify the lengths are identical, if not break.
+                            if new_length == old_length {
+                                // debug!("[read_by_group] found equal length {}, handle {}", new_length, handle);
+                                body.commit(new_length)?;
+                            } else {
+                                // We encountered a different length,  unwind the handle and last_handle written.
+                                // debug!("[read_by_group] different length: {}, old: {}", new_length, old_length);
+                                body.truncate(body.len() - 4);
+                                // And then break to ensure we respond with the previously found entries.
+                                break;
+                            }
+                        }
+                        (Err(error_code), Ok(_old_length)) => {
+                            // New read failed, but we had a previous value, return what we had thus far, truncate to
+                            // remove the previously written handle and last handle.
+                            body.truncate(body.len() - 4);
+                            // We do silently drop the error here.
+                            // debug!("[read_by_group] new error: {:?}, returning result thus far", error_code);
+                            break;
+                        }
+                        (Err(_), Err(_)) => {
+                            // Error on the first possible read, return this error.
+                            ret = new_ret;
+                            break;
+                        }
                     }
-                    break;
+                    // If we get here, we always have had a successful read, and we can check that we still have space
+                    // left in the buffer to write the next entry if it exists.
+                    if let Ok(expected_length) = ret {
+                        if body.available() < expected_length + 4 {
+                            break;
+                        }
+                    }
                 }
             }
-            err
+            ret
         });
 
         match err {
@@ -912,7 +949,8 @@ mod tests {
                     // we failed to retrieve the third service.
                     assert_eq!(response[0], att::ATT_READ_BY_GROUP_TYPE_RSP);
                     // The last handle of this group is at byte 4 & 5, so retrieve that and update the start for the
-                    // next cycle.
+                    // next cycle. We only check the first response here, and ignore any others that may be in the
+                    // response.
                     let last_handle = u16::from_le_bytes([response[4], response[5]]);
                     start = last_handle + 1;
                 }

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -390,23 +390,58 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
 
         let (mut header, mut body) = data.split(2)?;
         let err = self.att_table.iterate(|mut it| {
-            let mut err = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
+            let mut ret = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
             while let Some(att) = it.next() {
                 // trace!("[read_by_type] Check attribute {:?} {}", att.uuid, att.handle);
                 if &att.uuid == attribute_type && att.handle >= start && att.handle <= end {
                     body.write(att.handle)?;
                     handle = att.handle;
 
-                    err = self.read_attribute_data(connection, 0, att, body.write_buf());
-                    if let Ok(len) = err {
-                        body.commit(len)?;
+                    let new_ret = self.read_attribute_data(connection, 0, att, body.write_buf());
+                    match (new_ret, ret) {
+                        (Ok(first_length), Err(_)) => {
+                            // First successful read, store this length, all subsequent ones must match it.
+                            // debug!("[read_by_type] found first entry {:x?}, handle {}", att.uuid, handle);
+                            ret = new_ret;
+                            body.commit(first_length)?;
+                        }
+                        (Ok(new_length), Ok(old_length)) => {
+                            // Any matching attribute after the first, verify the lengths are identical, if not break.
+                            if new_length == old_length {
+                                // debug!("[read_by_type] found equal length {}, handle {}", new_length, handle);
+                                body.commit(new_length)?;
+                            } else {
+                                // We encountered a different length,  unwind the handle.
+                                // debug!("[read_by_type] different length: {}, old: {}", new_length, old_length);
+                                body.truncate(body.len() - 2);
+                                // And then break to ensure we respond with the previously found entries.
+                                break;
+                            }
+                        }
+                        (Err(error_code), Ok(_old_length)) => {
+                            // New read failed, but we had a previous value, return what we had thus far, truncate to
+                            // remove the previously written handle.
+                            body.truncate(body.len() - 2);
+                            // We do silently drop the error here.
+                            // debug!("[read_by_group] new error: {:?}, returning result thus far", error_code);
+                            break;
+                        }
+                        (Err(_), Err(_)) => {
+                            // Error on the first possible read, return this error.
+                            ret = new_ret;
+                            break;
+                        }
                     }
-
-                    // debug!("[read_by_type] found! {:?} {}", att.uuid, att.handle);
-                    break;
+                    // If we get here, we always have had a successful read, and we can check that we still have space
+                    // left in the buffer to write the next entry if it exists.
+                    if let Ok(expected_length) = ret {
+                        if body.available() < expected_length + 2 {
+                            break;
+                        }
+                    }
                 }
             }
-            err
+            ret
         });
 
         match err {


### PR DESCRIPTION
Hi, me again, I spotted this todo `// TODO respond with all finds - not just one` while working on #443 yesterday and thought I would take a stab at incorporating that this evening to make the discovery/enumeration process faster.

In my situation this change reduces `read_by_group_type` from 7 requests for down to 3, and we do see the start values jumping up in chunks, with debug prints enabled it now looks like this:
```
TRACE trouble_host::host] [host] inbound l2cap header channel = 4, fragment len = 7, total = 7
INFO  main_ble::ble_bas_peripheral] [gatt-attclient]: ReadByGroupType { start: 1, end: 65535, group_type: Uuid16([0, 40]) }
INFO  main_ble::ble_bas_peripheral] [gatt] other event 
DEBUG trouble_host::attribute_server] [read_by_group] found first entry Uuid16([0, 28]), handle 1
DEBUG trouble_host::attribute_server] [read_by_group] found equal length 2, handle 16
DEBUG trouble_host::attribute_server] [read_by_group] different length: 16, old: 2
TRACE trouble_host::host] [host] granted send packets = 1, len = 22
TRACE trouble_host::host] [host] sent acl packet len = 18
TRACE trouble_host::host] [host] inbound l2cap header channel = 4, fragment len = 7, total = 7
INFO  main_ble::ble_bas_peripheral] [gatt-attclient]: ReadByGroupType { start: 18, end: 65535, group_type: Uuid16([0, 40]) }
INFO  main_ble::ble_bas_peripheral] [gatt] other event 
DEBUG trouble_host::attribute_server] [read_by_group] found first entry Uuid16([0, 28]), handle 32
DEBUG trouble_host::attribute_server] [read_by_group] found equal length 16, handle 64
DEBUG trouble_host::attribute_server] [read_by_group] found equal length 16, handle 80
DEBUG trouble_host::attribute_server] [read_by_group] found equal length 16, handle 96
TRACE trouble_host::host] [host] granted send packets = 1, len = 90
TRACE trouble_host::host] [host] sent acl packet len = 86
TRACE trouble_host::host] [host] inbound l2cap header channel = 4, fragment len = 7, total = 7
INFO  main_ble::ble_bas_peripheral] [gatt-attclient]: ReadByGroupType { start: 109, end: 65535, group_type: Uuid16([0, 40]) }
INFO  main_ble::ble_bas_peripheral] [gatt] other event 
```

It wasn't as big a speedup as I had hoped, so I tacked on the same change to the other endpoint that supports returning multiple values: the `read_by_type` endpoint. This is in 55c86c6dd9bb04b126fa2263b250badbaf92f67d, prints for that also show that chunks (don't know the proper terminology, but looks like every attribute of a service?) are now retrieved in one go by iOS:
```
INFO  main_ble::ble_bas_peripheral] [gatt-attclient]: ReadByType { start: 80, end: 95, attribute_type: Uuid16([3, 40]) }
INFO  main_ble::ble_bas_peripheral] [gatt] other event 
DEBUG trouble_host::attribute_server] [read_by_type] found first entry Uuid16([3, 28]), handle 81
DEBUG trouble_host::attribute_server] [read_by_type] found equal length 19, handle 83
DEBUG trouble_host::attribute_server] [read_by_type] found equal length 19, handle 86
DEBUG trouble_host::attribute_server] [read_by_type] found equal length 19, handle 89
DEBUG trouble_host::attribute_server] [read_by_type] found equal length 19, handle 92
TRACE trouble_host::host] [host] granted send packets = 1, len = 115
```

Which is a little bit better. Before this change, the enumeration took 19 instances of `sent acl packet` in the log, now the same section takes only 10 instances, to a 50%'ish reduction? Time wise it is only 1 second difference in my situation (I had hoped more), I guess it would be more impactful on larger gatt servers? I feel it's a lot of extra complexity for just a slight speed increase, so if we close this without merging that's perfectly fine, at least we know that todo may not be necessary then?

Messages are now longer, I'm not sure if we have to worry about tradeoffs about losing transmissions if messages get longer? Both nRF connect & Apple Home on iOS behave as before the change. The remaining stuff I see in the discovery process is `Read` and `FindInformation`, which I don't think can be combined into a single message.

The unit test I added yesterday still works, though it only tests the first response in a message that now contains multiple. In lieu of a parser for these messages I think that's fine for now. I'm not a huge fan of the duplication, but I think these are the only two endpoints where we can do this, so perhaps the duplication is fine, I'm not sure how a generalized writer would really look for this. Comments may be a little bit much, but I wanted to clearly write out the logic. The third commit is a drive by documentation update on the writer, because I had to read its source code to understand what `commit` did.
