### PR TITLE
Implement a helper proc macro for defining UUIDs cleaner

### DIFF
--- a/host-macros/src/ctxt.rs
+++ b/host-macros/src/ctxt.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 use std::thread;
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, quote};
+use quote::{quote, ToTokens};
 
 /// A type to collect errors together and format them.
 ///

--- a/host-macros/src/lib.rs
+++ b/host-macros/src/lib.rs
@@ -231,3 +231,23 @@ fn check_for_characteristic(
     characteristics.push(Characteristic::new(field, args));
     REMOVE // Successfully parsed, remove the field from the fields vec.
 }
+
+/// Create a UUID object from a string or other convertible literal, similar to how UUIDs can be
+/// specified in a [macro@gatt_service] derivation.
+///
+/// Useful for exporting UUIDs into user contexts.
+///
+/// # Example
+///
+/// ```rust
+/// use trouble_host::prelude::*;
+///
+/// const MY_LONG_UUID: Uuid = uuid!("01234567-89AB-CDEF-0123-456789ABCDEF");
+/// const MY_SHORT_UUID: Uuid = uuid!("9999");
+/// const MY_INT_UUID: Uuid = uuid!(1337u16);
+/// ```
+#[proc_macro]
+pub fn uuid(args: TokenStream) -> TokenStream {
+    let uuid = parse_macro_input!(args as uuid::UuidArgs);
+    return uuid.uuid.into();
+}

--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -8,7 +8,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, quote_spanned};
 use syn::meta::ParseNestedMeta;
 use syn::spanned::Spanned;
-use syn::{Expr, Result, parse_quote};
+use syn::{parse_quote, Expr, Result};
 
 #[derive(Default)]
 pub(crate) struct ServerArgs {

--- a/host-macros/src/uuid.rs
+++ b/host-macros/src/uuid.rs
@@ -4,9 +4,10 @@
 
 use core::str::FromStr;
 
-use darling::FromMeta;
+use darling::{Error, FromMeta};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use syn::{parse::Result, spanned::Spanned, Expr};
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Uuid {
@@ -46,5 +47,56 @@ impl quote::ToTokens for Uuid {
                 tokens.extend(quote!(::trouble_host::types::uuid::Uuid::new_long([#s])));
             }
         }
+    }
+}
+
+/// Parse the UUID argument of the service attribute.
+///
+/// The UUID can be specified as a string literal, an integer literal, or an expression that impl Into<Uuid>.
+pub(crate) fn parse_arg_uuid(value: &Expr) -> Result<TokenStream2> {
+    match value {
+        Expr::Lit(lit) => {
+            if let syn::Lit::Str(lit_str) = &lit.lit {
+                let uuid_string = Uuid::from_string(&lit_str.value()).map_err(|_| {
+                    Error::custom(
+                        "Invalid UUID string.  Expect i.e. \"180f\" or \"0000180f-0000-1000-8000-00805f9b34fb\"",
+                    )
+                    .with_span(&lit.span())
+                })?;
+                Ok(quote::quote! {#uuid_string})
+            } else if let syn::Lit::Int(lit_int) = &lit.lit {
+                let uuid_string = Uuid::Uuid16(lit_int.base10_parse::<u16>().map_err(|_| {
+                    Error::custom("Invalid 16bit UUID literal.  Expect i.e. \"0x180f\"").with_span(&lit.span())
+                })?);
+                Ok(quote::quote! {#uuid_string})
+            } else {
+                Err(Error::custom(
+                    "Invalid UUID literal.  Expect i.e. \"180f\" or \"0000180f-0000-1000-8000-00805f9b34fb\"",
+                )
+                .with_span(&lit.span())
+                .into())
+            }
+        }
+        other => {
+            let span = other.span(); // span will highlight if the value does not impl Into<Uuid>
+            Ok(quote::quote_spanned! { span =>
+                {
+                    let uuid: trouble_host::types::uuid::Uuid = #other.into();
+                    uuid
+                }
+            })
+        }
+    }
+}
+
+pub(crate) struct UuidArgs {
+    pub uuid: proc_macro2::TokenStream,
+}
+
+impl syn::parse::Parse for UuidArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let expr = input.parse()?;
+        let uuid = parse_arg_uuid(&expr)?;
+        Ok(UuidArgs { uuid })
     }
 }


### PR DESCRIPTION
Just in time to miss the 0.3.0 release ;)

I wanted a helper so I could declare UUIDs with the string syntax nicely, in one place, so I made it.

Let me know if you want changes or there was a different way to do this already :P