### PR TITLE
Fix: catch up esp32 'sec' examples to use esp-hal 1.0.0-rc0 TRng API

### DIFF
--- a/examples/esp32/src/bin/ble_bas_central_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_central_sec.rs
@@ -3,6 +3,7 @@
 
 use embassy_executor::Spawner;
 use esp_hal::clock::CpuClock;
+use esp_hal::rng::{Trng, TrngSource};
 use esp_hal::timer::timg::TimerGroup;
 use esp_radio::Controller;
 use esp_radio::ble::controller::BleConnector;
@@ -21,7 +22,8 @@ async fn main(_s: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_preempt::start(timg0.timer0);
 
-    let mut rng = esp_hal::rng::Trng::new(peripherals.RNG, peripherals.ADC1);
+    let _trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1); // while alive, 'Trng::try_new()' succeeds
+    let mut trng = Trng::try_new().unwrap();
 
     static RADIO: StaticCell<Controller<'static>> = StaticCell::new();
     let radio = RADIO.init(esp_radio::init().unwrap());
@@ -40,5 +42,5 @@ async fn main(_s: Spawner) {
     let connector = BleConnector::new(radio, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
-    ble_bas_central_sec::run(controller, &mut rng).await;
+    ble_bas_central_sec::run(controller, &mut trng).await;
 }

--- a/examples/esp32/src/bin/ble_bas_central_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_central_sec.rs
@@ -22,8 +22,8 @@ async fn main(_s: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_preempt::start(timg0.timer0);
 
-    let _trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1); // while alive, 'Trng::try_new()' succeeds
-    let mut trng = Trng::try_new().unwrap();
+    let _trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1);
+    let mut trng = Trng::try_new().unwrap();    // Ok when there's a TrngSource accessible
 
     static RADIO: StaticCell<Controller<'static>> = StaticCell::new();
     let radio = RADIO.init(esp_radio::init().unwrap());

--- a/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
@@ -3,6 +3,7 @@
 
 use embassy_executor::Spawner;
 use esp_hal::clock::CpuClock;
+use esp_hal::rng::{Trng, TrngSource};
 use esp_hal::timer::timg::TimerGroup;
 use esp_radio::Controller;
 use esp_radio::ble::controller::BleConnector;
@@ -21,7 +22,8 @@ async fn main(_s: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_preempt::start(timg0.timer0);
 
-    let mut rng = esp_hal::rng::Trng::new(peripherals.RNG, peripherals.ADC1);
+    let _trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1); // while alive, 'Trng::try_new()' succeeds
+    let mut trng = Trng::try_new().unwrap();
 
     static RADIO: StaticCell<Controller<'static>> = StaticCell::new();
     let radio = RADIO.init(esp_radio::init().unwrap());
@@ -40,5 +42,5 @@ async fn main(_s: Spawner) {
     let connector = BleConnector::new(radio, bluetooth);
     let controller: ExternalController<_, 20> = ExternalController::new(connector);
 
-    ble_bas_peripheral_sec::run(controller, &mut rng).await;
+    ble_bas_peripheral_sec::run(controller, &mut trng).await;
 }

--- a/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
@@ -22,8 +22,8 @@ async fn main(_s: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_preempt::start(timg0.timer0);
 
-    let _trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1); // while alive, 'Trng::try_new()' succeeds
-    let mut trng = Trng::try_new().unwrap();
+    let _trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1);
+    let mut trng = Trng::try_new().unwrap();    // Ok when there's a TrngSource accessible
 
     static RADIO: StaticCell<Controller<'static>> = StaticCell::new();
     let radio = RADIO.init(esp_radio::init().unwrap());


### PR DESCRIPTION
Noticed that the `examples/esp32` files that deal with `TRng` (truly rng) were not quite up-to-date with upstream API change. Modified according to the [migration guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-1.0.0-rc.0.md#rng-changes).

A question of opinion regarding the `trng_source` variable's name:

The guide uses `trng_source` - which "needs to be alive" for the `try_new()` to succeed. If I leave the name like that, there's a build warning (yikes). I also tried just an underscore (`let _ = ...`), but that seems to affect the lifespan of the value, which was.. surprising to me.