### PR TITLE
suggestion on reducing deps in 'examples/apps'

### DIFF
--- a/examples/apps/Cargo.toml
+++ b/examples/apps/Cargo.toml
@@ -8,15 +8,16 @@ license = "MIT OR Apache-2.0"
 trouble-host = { path = "../../host", features = ["derive", "scan"] }
 bt-hci = { version = "0.5" }
 embassy-futures = "0.1.1"
-embassy-executor = { version = "0.9" }
 embassy-sync = { version = "0.7" }
 embassy-time = "0.5"
-embedded-hal = "1.0"
+#embedded-hal = "1.0"
 embedded-hal-async = "1.0"
 static_cell = "2"
-embedded-io = "0.6"
+#embedded-io = "0.6"
 heapless = "0.9"
 rand_core = { version = "0.6", default-features = false }
+
+# Used by 'security' feature
 embedded-storage-async = { version = "0.4.1", optional = true }
 sequential-storage = { version = "5.0.0", optional = true }
 
@@ -29,8 +30,8 @@ defmt = [
     "dep:defmt",
     "trouble-host/defmt",
     "bt-hci/defmt",
-    "embedded-io/defmt-03",
-    "embedded-hal/defmt-03"
+    #"embedded-io/defmt-03",
+    #"embedded-hal/defmt-03"
 ]
 log = [
     "dep:log",


### PR DESCRIPTION
I was collecting dependencies needed to use `trouble` in my project, and noticed some of the ones in `examples/apps/Cargo.toml` aren't really necessary, are they?

Contextual comments on each change.