### PR TITLE
Comment change; relationship of 'default-packet-pool' and '...-mtu-'

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -81,7 +81,7 @@ security = [ "dep:p256", "dep:aes", "dep:cmac", "dep:rand_chacha", "gatt", "dep:
 # generator (CSPRNG) to require a cryptographically secure seed
 dev-disable-csprng-seed-requirement = []
 
-# Default packet pool. Enabling this will make available a packet pool tuned according to the default-packet-pool->>mtu<< and default-packet-pool->>mtu<<.
+# Enabling this will make available a packet pool tuned according to the default-packet-pool-mtu and default-packet-pool-size.
 default-packet-pool = []
 
 # Optimization where l2cap SDU reassembly saves some buffer copy.


### PR DESCRIPTION
>"[...] default-packet-pool-mtu and defeault-packet-pool-mtu."

That likely wants to be "default-packet-pool-size and default-packet-pool-mtu."?  Which one would you prefer to be mentioned first (which one is more important)?

Also, may I split the line to two lines? Such tails never get attention, which may have contrinuted to the mistakes.

---

More vitally, I stumbled on this when my bringing in of `trouble` didn't succeed. Tried this (from my `Cargo.toml`):

```toml
trouble-host    = { version = "0.3.0", default-features = false, features = [
    "default-packet-pool-mtu-255",
    "derive",
    "gatt",
    "peripheral",
    "security"
] }
```

Error message:

```
DEFMT_LOG=esp_hal=info,debug cargo build --release --features=defmt --example custom-emb
   Compiling ble-custom v0.0.0 (/home/ubuntu/ZOO.comms/comms/ble-custom)
error[E0412]: cannot find type `DefaultPacketPool` in module `trouble_host::prelude`
   --> examples/custom-emb/server_ble.rs:21:1
    |
 21 | #[gatt_server]
    | ^^^^^^^^^^^^^^ not found in `trouble_host::prelude`
    |
```

If we want to keep `default-packet-pool` and its default-steering fellows separate, I could steer this PR to making a more informative error message (that one should enable both `...-mtu-...` and `default-packet-pool`. But couldn't we simply do it so that if one defines a default `mtu` or `size`, that automatically implies `default-packet-pool`, as well.

That would have made my initial - naive - attempt to just work.

I see no down side on that. The change is simply some implied features in the `trouble-host` `Cargo.toml`. 

My code stumbled on this, because I wanted to avoid the `central` feature from creeping in. I think that's a pretty common use case: many projects are either `peripheral` or `central`. 