### PR TITLE
Early check of 'host' feature consistency

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -67,7 +67,7 @@ central = []
 # Enable GATT support
 gatt = []
 # Enable scan support
-scan = []
+scan = ["central"]
 # Enable macros
 derive = ["trouble-host-macros"]
 # Enable controller-to-host flow control
@@ -122,24 +122,24 @@ l2cap-tx-queue-size-32 = []
 l2cap-tx-queue-size-64 = []
 
 # Controls the pool size of the default packet pool, if enabled.
-default-packet-pool-size-1 = []
-default-packet-pool-size-2 = []
-default-packet-pool-size-4 = []
-default-packet-pool-size-8 = []
-default-packet-pool-size-16 = [] # Default
-default-packet-pool-size-32 = []
-default-packet-pool-size-64 = []
-default-packet-pool-size-128 = []
+default-packet-pool-size-1 = ["default-packet-pool"]
+default-packet-pool-size-2 = ["default-packet-pool"]
+default-packet-pool-size-4 = ["default-packet-pool"]
+default-packet-pool-size-8 = ["default-packet-pool"]
+default-packet-pool-size-16 = ["default-packet-pool"] # Default
+default-packet-pool-size-32 = ["default-packet-pool"]
+default-packet-pool-size-64 = ["default-packet-pool"]
+default-packet-pool-size-128 = ["default-packet-pool"]
 
 # Controls the packet MTU of the default packet pool, if enabled.
-default-packet-pool-mtu-27 = []
-default-packet-pool-mtu-48 = []
-default-packet-pool-mtu-64 = []
-default-packet-pool-mtu-128 = []
-default-packet-pool-mtu-251 = [] # Default
-default-packet-pool-mtu-255 = []
-default-packet-pool-mtu-512 = []
-default-packet-pool-mtu-1024 = []
+default-packet-pool-mtu-27 = ["default-packet-pool"]
+default-packet-pool-mtu-48 = ["default-packet-pool"]
+default-packet-pool-mtu-64 = ["default-packet-pool"]
+default-packet-pool-mtu-128 = ["default-packet-pool"]
+default-packet-pool-mtu-251 = ["default-packet-pool"] # Default
+default-packet-pool-mtu-255 = ["default-packet-pool"]
+default-packet-pool-mtu-512 = ["default-packet-pool"]
+default-packet-pool-mtu-1024 = ["default-packet-pool"]
 
 # When using the GATT client, this controls how many subscribers can be created.
 gatt-client-notification-max-subscribers-1 = [] # Default

--- a/host/build.rs
+++ b/host/build.rs
@@ -58,26 +58,29 @@ fn main() {
         {
             let n = 0;
             #[cfg(feature = "default-packet-pool-size-1")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-size-2")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-size-4")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-size-8")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-size-16")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-size-32")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-size-64")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-size-128")]
-            let n = n+1;
+            let n = n + 1;
 
-            assert!(n <= 1, "📍 More than one 'default-packet-pool-size-X' feature is enabled.");
+            assert!(
+                n <= 1,
+                "📍 More than one 'default-packet-pool-size-X' feature is enabled."
+            );
 
             #[cfg(not(feature = "default-packet-pool"))]
-            if n>0 {
+            if n > 0 {
                 panic!("📍 'default-packet-pool-size-{{X}}' feature also needs 'default-packet-pool' to be enabled.");
             }
         }
@@ -86,26 +89,29 @@ fn main() {
         {
             let n = 0;
             #[cfg(feature = "default-packet-pool-mtu-27")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-mtu-48")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-mtu-64")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-mtu-128")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-mtu-251")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-mtu-255")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-mtu-512")]
-            let n = n+1;
+            let n = n + 1;
             #[cfg(feature = "default-packet-pool-mtu-1024")]
-            let n = n+1;
+            let n = n + 1;
 
-            assert!(n <= 1, "📍 More than one 'default-packet-pool-mtu-X' feature is enabled.");
+            assert!(
+                n <= 1,
+                "📍 More than one 'default-packet-pool-mtu-X' feature is enabled."
+            );
 
             #[cfg(not(feature = "default-packet-pool"))]
-            if n>0 {
+            if n > 0 {
                 panic!("📍 'default-packet-pool-mtu-{{X}}' feature also needs 'default-packet-pool' to be enabled.");
             }
         }


### PR DESCRIPTION
As discussed, here's a start for checking feature invariants in `build.rs`. 

This is something I've taken to be a habit of doing in my own projects. It seems to help to *understand* the relations between features - if there are any. At the moment, these are documented, and some checked in the source (which is fine; they can well be checked in two different levels - it serves slightly different aims).

I don't mean that this needs to get in. It's just a sample on how this works.

If possible, I've used `compile_error!`, which provides better error messages than panicing when the script is actually run. I think also the remaining cases can be made to use `compile_error!` by using consts. Let me know if that's something worth doing.

In addition to the tests, there are some suggestions to the `Cargo.toml`: any feature (looking at `scan`) that only makes sense in relation to another (`central`) should/could imho infer that feature. Us developers often check the "fingerprint" of a package by reading its Cargo.toml so this is partly/mostly documentation.

I'm aware the `fault-packet-pool-{size|mtu]-{N}` are generated. @lulf mentioned he'd (separately) work on the Python script, to - perhaps - feed in the `"default-packet-pool"` in them.

Anyways, it's a start. I'm getting to know the source more fully, and this helped.