### PR TITLE
stops unnecessary `.lock` regeneration 

### DIFF
--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "trouble-host"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "bt-hci",

--- a/examples/nrf-sdc/Cargo.lock
+++ b/examples/nrf-sdc/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "trouble-host"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "bt-hci",


### PR DESCRIPTION
The problem:

- `trouble-host` in `main` is now 0.5.0, but two lock files still have 0.4.0 in them.

This caused, at least for me, the IDE to insist that such locks must be updated. Yes, I could... but was working on PR's in the mean time so. Merging this PR should remove such a competition from the file system.