### PR TITLE
Small changes that conflict the existing fmt/clippy rules, but aren't checked by the Ci.

### DIFF
--- a/host-macros/src/lib.rs
+++ b/host-macros/src/lib.rs
@@ -112,7 +112,7 @@ pub fn gatt_service(args: TokenStream, item: TokenStream) -> TokenStream {
         let desc = err.to_string();
         ctxt.error_spanned_by(
             err.into_compile_error(),
-            format!("Parsing characteristics was unsuccessful:\n{}", desc),
+            format!("Parsing characteristics was unsuccessful:\n{desc}"),
         );
         return ctxt.check().unwrap_err().into();
     }
@@ -249,5 +249,5 @@ fn check_for_characteristic(
 #[proc_macro]
 pub fn uuid(args: TokenStream) -> TokenStream {
     let uuid = parse_macro_input!(args as uuid::UuidArgs);
-    return uuid.uuid.into();
+    uuid.uuid.into()
 }

--- a/host-macros/src/uuid.rs
+++ b/host-macros/src/uuid.rs
@@ -7,7 +7,9 @@ use core::str::FromStr;
 use darling::{Error, FromMeta};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse::Result, spanned::Spanned, Expr};
+use syn::parse::Result;
+use syn::spanned::Spanned;
+use syn::Expr;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Uuid {

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -128,7 +128,7 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
             deadline: if config.timeout.as_ticks() == 0 {
                 None
             } else {
-                Some(Instant::now() + config.timeout.into())
+                Some(Instant::now() + config.timeout)
             },
             done: false,
         })

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -567,6 +567,7 @@ impl<const BOND_COUNT: usize> SecurityManager<BOND_COUNT> {
         event: LeEventPacket,
         connections: &ConnectionManager<'_, P>,
     ) -> Result<(), Error> {
+        #[allow(clippy::single_match)]
         match event.kind {
             LeEventKind::LeLongTermKeyRequest => {
                 let event_data = LeLongTermKeyRequest::from_hci_bytes_complete(event.data)?;
@@ -583,6 +584,7 @@ impl<const BOND_COUNT: usize> SecurityManager<BOND_COUNT> {
         event: EventPacket,
         connections: &ConnectionManager<'_, P>,
     ) -> Result<(), Error> {
+        #[allow(clippy::single_match)]
         match event.kind {
             EventKind::EncryptionChangeV1 => {
                 let event_data = EncryptionChangeV1::from_hci_bytes_complete(event.data)?;


### PR DESCRIPTION
This is a very small PR. It has things that get caught if CI test coverage is expanded to the `host-macros`, and to `host` with `feature="security"`.

While this doesn't change anything functionality-wise in the repo, it would help my work since locally I run everything with that extended test coverage.

To test, run these commands:

```
cargo +nightly fmt --check --manifest-path ./host/Cargo.toml
cargo +nightly fmt --check --manifest-path ./host-macros/Cargo.toml

cargo clippy --manifest-path ./host/Cargo.toml --features central,gatt,peripheral,scan,security
cargo clippy --manifest-path ./host-macros/Cargo.toml
```

Expectation:

They should pass, without warnings or errors.