### PR TITLE
Fix for build.rs: double colon issue

### DIFF
--- a/benchmarks/nrf-sdc/build.rs
+++ b/benchmarks/nrf-sdc/build.rs
@@ -32,15 +32,15 @@ fn main() {
         .unwrap()
         .write_all(linker_data())
         .unwrap();
-    println!("cargo::rustc-link-search={}", out.display());
+    println!("cargo:rustc-link-search={}", out.display());
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
-    println!("cargo::rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=memory.x");
 
-    println!("cargo::rustc-link-arg-bins=--nmagic");
-    println!("cargo::rustc-link-arg-bins=-Tlink.x");
-    println!("cargo::rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/apache-nimble/build.rs
+++ b/examples/apache-nimble/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    println!("cargo::rustc-link-arg-bins=--nmagic");
-    println!("cargo::rustc-link-arg-bins=-Tlink.x");
-    println!("cargo::rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/esp32/build.rs
+++ b/examples/esp32/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("cargo::rustc-link-arg-bins=-Tlinkall.x");
+    println!("cargo:rustc-link-arg-bins=-Tlinkall.x");
 }

--- a/examples/nrf52/build.rs
+++ b/examples/nrf52/build.rs
@@ -32,15 +32,15 @@ fn main() {
         .unwrap()
         .write_all(linker_data())
         .unwrap();
-    println!("cargo::rustc-link-search={}", out.display());
+    println!("cargo:rustc-link-search={}", out.display());
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
-    println!("cargo::rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=memory.x");
 
-    println!("cargo::rustc-link-arg-bins=--nmagic");
-    println!("cargo::rustc-link-arg-bins=-Tlink.x");
-    println!("cargo::rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/rp-pico-2-w/build.rs
+++ b/examples/rp-pico-2-w/build.rs
@@ -21,7 +21,7 @@ fn main() {
         .unwrap()
         .write_all(include_bytes!("memory.x"))
         .unwrap();
-    println!("cargo::rustc-link-search={}", out.display());
+    println!("cargo:rustc-link-search={}", out.display());
 
     #[cfg(not(feature = "skip-cyw43-firmware"))]
     download_cyw43_firmware();
@@ -30,11 +30,11 @@ fn main() {
     // any file in the project changes. By specifying `memory.x`
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
-    println!("cargo::rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=memory.x");
 
-    println!("cargo::rustc-link-arg-bins=--nmagic");
-    println!("cargo::rustc-link-arg-bins=-Tlink.x");
-    println!("cargo::rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }
 
 #[cfg(not(feature = "skip-cyw43-firmware"))]
@@ -49,8 +49,8 @@ fn download_cyw43_firmware() {
         "README.md",
     ];
 
-    println!("cargo::rerun-if-changed=build.rs");
-    println!("cargo::rerun-if-changed={}", download_folder);
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", download_folder);
     std::fs::create_dir_all(download_folder).expect("Failed to create download directory");
 
     // download each file into the folder "cyw43-firmware"

--- a/examples/rp-pico-w/build.rs
+++ b/examples/rp-pico-w/build.rs
@@ -21,7 +21,7 @@ fn main() {
         .unwrap()
         .write_all(include_bytes!("memory.x"))
         .unwrap();
-    println!("cargo::rustc-link-search={}", out.display());
+    println!("cargo:rustc-link-search={}", out.display());
 
     #[cfg(not(feature = "skip-cyw43-firmware"))]
     download_cyw43_firmware();
@@ -30,12 +30,12 @@ fn main() {
     // any file in the project changes. By specifying `memory.x`
     // here, we ensure the build script is only re-run when
     // `memory.x` is changed.
-    println!("cargo::rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=memory.x");
 
-    println!("cargo::rustc-link-arg-bins=--nmagic");
-    println!("cargo::rustc-link-arg-bins=-Tlink.x");
-    println!("cargo::rustc-link-arg-bins=-Tlink-rp.x");
-    println!("cargo::rustc-link-arg-bins=-Tdefmt.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tlink-rp.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }
 
 #[cfg(not(feature = "skip-cyw43-firmware"))]
@@ -50,8 +50,8 @@ fn download_cyw43_firmware() {
         "README.md",
         ];
 
-    println!("cargo::rerun-if-changed=build.rs");
-    println!("cargo::rerun-if-changed={}", download_folder);
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={}", download_folder);
     std::fs::create_dir_all(download_folder).expect("Failed to create download directory");
 
     // download each file into the folder "cyw43-firmware"

--- a/host/build.rs
+++ b/host/build.rs
@@ -30,9 +30,9 @@ fn main() {
 
     // We don't use any external files: only run the build script if it has changed.
     // Otherwise, Cargo will re-run it on each build.
-    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build.rs");
 
-    println!("cargo::rustc-check-cfg=cfg(test)");
+    println!("cargo:rustc-check-cfg=cfg(test)");
 
     // Check feature usage.
     //
@@ -120,7 +120,7 @@ fn main() {
 
     // Rebuild if config envvar changed.
     for (name, _) in CONFIGS {
-        println!("cargo::rerun-if-env-changed={crate_name}_{name}");
+        println!("cargo:rerun-if-env-changed={crate_name}_{name}");
     }
 
     let mut configs = HashMap::new();


### PR DESCRIPTION
# Fix incorrect Cargo directive in build.rs

## Description
The `build.rs` script currently uses a double colon (`::`) in the `cargo` directive, which is incorrect. Cargo expects a single colon (`:`) for key-value pairs in build script output.

## Current Behavior
```rust
println!("cargo::rustc-link-search={}", out.display());
```

## Expected Behavior
```rust
println!("cargo:rustc-link-search={}", out.display());
```
