### PR TITLE
feat: Add `Connection::peer_addr_kind` method

### DIFF
--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -296,6 +296,11 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         self.manager.role(self.index)
     }
 
+    /// The peer address kind for this connection.
+    pub fn peer_addr_kind(&self) -> AddrKind {
+        self.manager.peer_addr_kind(self.index)
+    }
+
     /// The peer address for this connection.
     pub fn peer_address(&self) -> BdAddr {
         self.manager.peer_address(self.index)

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -151,6 +151,13 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         poll_fn(|cx| self.with_mut(|state| state.connections[index as usize].gatt_client.poll_receive(cx))).await
     }
 
+    pub(crate) fn peer_addr_kind(&self, index: u8) -> AddrKind {
+        self.with_mut(|state| {
+            let state = &mut state.connections[index as usize];
+            state.peer_addr_kind.unwrap_or_default()
+        })
+    }
+
     pub(crate) fn peer_address(&self, index: u8) -> BdAddr {
         self.with_mut(|state| {
             let state = &mut state.connections[index as usize];


### PR DESCRIPTION
This is needed in order to, for example, create a `Advertisement::ConnectableNonscannableDirectedHighDuty` advertisement to reconnect to a peer if the connection is lost.

I also have an alternate implementation which changes the address inside `Identity` from `BdAddr` to `Address` (which contains the `AddrKind`). Then `peer_addr_kind` can be removed from `ConnectionStorage` and `Connection::peer_address` can be changed to return an `Address` instead of `BdAddr`. That option results in somewhat more far-reaching changes so I lean towards this simpler implementation unless there are other considerations which would prefer the alternative.