### PR TITLE
feat: Support static data for read-only characteristics

### DIFF
--- a/examples/apps/src/ble_dis_peripheral.rs
+++ b/examples/apps/src/ble_dis_peripheral.rs
@@ -1,0 +1,144 @@
+use embassy_futures::join::join;
+use trouble_host::prelude::*;
+
+/// Max number of connections
+const CONNECTIONS_MAX: usize = 1;
+
+/// Max number of L2CAP channels.
+const L2CAP_CHANNELS_MAX: usize = 2; // Signal + att
+
+// GATT Server definition
+#[gatt_server]
+struct Server {
+    info_service: DeviceInformationService,
+}
+
+/// Battery service
+#[gatt_service(uuid = service::DEVICE_INFORMATION)]
+struct DeviceInformationService {
+    /// Manufacturer name
+    #[characteristic(uuid = characteristic::MANUFACTURER_NAME_STRING, read, value = "Embassy Developers")]
+    mfg_name: &'static str,
+    /// Model number
+    #[characteristic(uuid = characteristic::MODEL_NUMBER_STRING, read, value = "EX-DIS")]
+    model_number: &'static str,
+}
+
+/// Run the BLE stack.
+pub async fn run<C>(controller: C)
+where
+    C: Controller,
+{
+    // Using a fixed "random" address can be useful for testing. In real scenarios, one would
+    // use e.g. the MAC 6 byte array as the address (how to get that varies by the platform).
+    let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    info!("Our address = {:?}", address);
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let Host {
+        mut peripheral, runner, ..
+    } = stack.build();
+
+    info!("Starting advertising and GATT service");
+    let server = Server::new_with_config(GapConfig::Peripheral(PeripheralConfig {
+        name: "TrouBLE",
+        appearance: &appearance::power_device::GENERIC_POWER_DEVICE,
+    }))
+    .unwrap();
+
+    let _ = join(ble_task(runner), async {
+        loop {
+            match advertise("Trouble Example", &mut peripheral, &server).await {
+                Ok(conn) => {
+                    // set up tasks when the connection is established to a central, so they don't run when no one is connected.
+                    let _ = gatt_events_task(&conn).await;
+                }
+                Err(e) => {
+                    #[cfg(feature = "defmt")]
+                    let e = defmt::Debug2Format(&e);
+                    panic!("[adv] error: {:?}", e);
+                }
+            }
+        }
+    })
+    .await;
+}
+
+/// This is a background task that is required to run forever alongside any other BLE tasks.
+///
+/// ## Alternative
+///
+/// If you didn't require this to be generic for your application, you could statically spawn this with i.e.
+///
+/// ```rust,ignore
+///
+/// #[embassy_executor::task]
+/// async fn ble_task(mut runner: Runner<'static, SoftdeviceController<'static>>) {
+///     runner.run().await;
+/// }
+///
+/// spawner.must_spawn(ble_task(runner));
+/// ```
+async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
+    loop {
+        if let Err(e) = runner.run().await {
+            #[cfg(feature = "defmt")]
+            let e = defmt::Debug2Format(&e);
+            panic!("[ble_task] error: {:?}", e);
+        }
+    }
+}
+
+/// Stream Events until the connection closes.
+///
+/// This function will handle the GATT events and process them.
+/// This is how we interact with read and write requests.
+async fn gatt_events_task<P: PacketPool>(conn: &GattConnection<'_, '_, P>) -> Result<(), Error> {
+    let reason = loop {
+        match conn.next().await {
+            GattConnectionEvent::Disconnected { reason } => break reason,
+            GattConnectionEvent::Gatt { event } => {
+                // This step is also performed at drop(), but writing it explicitly is necessary
+                // in order to ensure reply is sent.
+                match event.accept() {
+                    Ok(reply) => reply.send().await,
+                    Err(e) => warn!("[gatt] error sending response: {:?}", e),
+                };
+            }
+            _ => {} // ignore other Gatt Connection Events
+        }
+    };
+    info!("[gatt] disconnected: {:?}", reason);
+    Ok(())
+}
+
+/// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
+async fn advertise<'values, 'server, C: Controller>(
+    name: &'values str,
+    peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+    server: &'server Server<'values>,
+) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
+    let mut advertiser_data = [0; 31];
+    let len = AdStructure::encode_slice(
+        &[
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            AdStructure::ServiceUuids16(&[[0x0a, 0x18]]),
+            AdStructure::CompleteLocalName(name.as_bytes()),
+        ],
+        &mut advertiser_data[..],
+    )?;
+    let advertiser = peripheral
+        .advertise(
+            &Default::default(),
+            Advertisement::ConnectableScannableUndirected {
+                adv_data: &advertiser_data[..len],
+                scan_data: &[],
+            },
+        )
+        .await?;
+    info!("[adv] advertising");
+    let conn = advertiser.accept().await?.with_attribute_server(server)?;
+    info!("[adv] connection established");
+    Ok(conn)
+}

--- a/examples/apps/src/lib.rs
+++ b/examples/apps/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ble_bas_central_sec;
 pub mod ble_bas_peripheral;
 pub mod ble_bas_peripheral_sec;
 pub mod ble_beacon;
+pub mod ble_dis_peripheral;
 pub mod ble_l2cap_central;
 pub mod ble_l2cap_peripheral;
 pub mod ble_scanner;

--- a/host-macros/src/characteristic.rs
+++ b/host-macros/src/characteristic.rs
@@ -48,6 +48,12 @@ pub struct AccessArgs {
     pub indicate: bool,
 }
 
+impl AccessArgs {
+    pub fn is_read_only(&self) -> bool {
+        self.read && !self.write && !self.write_without_response && !self.notify && !self.indicate
+    }
+}
+
 /// Descriptor attribute arguments.
 ///
 /// Descriptors are optional and can be used to add additional metadata to the characteristic.

--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -178,6 +178,31 @@ impl ServiceBuilder {
         ));
     }
 
+    /// Construct instructions for adding a read-only characteristic to the service.
+    fn construct_characteristic_ro(&mut self, characteristic: Characteristic) {
+        let (code_descriptors, named_descriptors) = self.build_descriptors(&characteristic);
+        let char_name = format_ident!("{}", characteristic.name);
+        let ty = characteristic.ty;
+        let uuid = characteristic.args.uuid;
+        let default_value = match characteristic.args.default_value {
+            Some(val) => quote!(#val),                                       // if set by user
+            None => quote_spanned!(characteristic.span => <#ty>::default()), // or default otherwise
+        };
+
+        self.code_build_chars.extend(quote_spanned! {characteristic.span=>
+            let (#char_name, #(#named_descriptors),*) = {
+                let mut builder = service.add_characteristic_ro(#uuid, #default_value);
+                #code_descriptors
+
+                (builder.build(), #(#named_descriptors),*)
+            };
+        });
+
+        self.code_struct_init.extend(quote_spanned!(characteristic.span=>
+            #char_name,
+        ));
+    }
+
     /// Consume the lists of fields and fields marked as characteristics and prepare the code to add them to the service
     /// by generating the macro blueprints for any methods, fields, and static storage required.
     pub fn process_characteristics_and_fields(
@@ -199,7 +224,19 @@ impl ServiceBuilder {
         // Process characteristic fields
         for ch in characteristics {
             let char_name = format_ident!("{}", ch.name);
-            let ty = &ch.ty;
+
+            let mut ty = &ch.ty;
+            let mut ro = false;
+            if let syn::Type::Reference(type_ref) = ty {
+                if ch.args.access.is_read_only()
+                    && type_ref.mutability.is_none()
+                    && type_ref.lifetime.as_ref().is_some_and(|lt| lt.ident == "static")
+                {
+                    ty = &type_ref.elem;
+                    ro = true;
+                }
+            }
+
             // add fields for each characteristic value handle
             fields.push(syn::Field {
                 ident: Some(char_name.clone()),
@@ -213,7 +250,11 @@ impl ServiceBuilder {
 
             self.increment_attributes(&ch.args.access);
 
-            self.construct_characteristic_static(ch);
+            if ro {
+                self.construct_characteristic_ro(ch);
+            } else {
+                self.construct_characteristic_static(ch);
+            }
         }
         assert_eq!(fields.len(), doc_strings.len());
         // Processing common to all fields


### PR DESCRIPTION
This allows the gatt_service macro to use `&'static` values for read-only characteristics. It currently only supports references with an explicit `static` lifetime. This could probably be loosened since the compiler will complain if the value does not outlive the attribute table. It also only supports characteristics that only enable the `read` property.

To make this work properly, I needed to rework the `AsGatt`/`FromGatt`/`FixedSizeGatt` trait hierarchy slightly. There is now a blanket `AsGatt` impl for references to any type which impls `AsGatt`. I also loosened the type bounds on `Characteristic` to be `T: AsGatt + ?Sized` in most cases. This allows, for example, a `Characteristic<str>` to exist as the type of service characteristics with a `&'static str` value.

I added a `ble_dis_peripheral.rs` example demonstrating the feature.

Fixes #357