### PR TITLE
Generic-queue feature should be specified by binary crates only

### DIFF
--- a/bt-hci-linux/Cargo.toml
+++ b/bt-hci-linux/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1", features = ["io-util", "net", "rt", "macros", "signal",
 embedded-io = { version = "0.7", features = ["std"] }
 libc = "0.2"
 bt-hci = "0.7"
-embassy-time = { version = "0.5", features = ["std", "generic-queue-8"] }
+embassy-time = { version = "0.5", features = ["std"] }
 rand = { version = "0.8.5", features = ["getrandom"] }
 env_logger = "0.11"
 log = "0.4"


### PR DESCRIPTION
Subject says it all, mostly.

Given that `bt-hci-linux` is a library, I don't think it has business with specifying the embassy-time generic queue size. This should be done by (the) binary crate using it.

A few other features which are a bit borderline for me as well:
- `std` on `embassy-time`. If I'm not mistaken, this enables the STD time driver. Shouldn't that be done by the binary crate as well? I mean, can't imagine some _other_ driver to be used with Linux, but still?
- `std` on `critical-section` - ditto

If you feel we should remove those too, let me know, I'll update the PR. I'm not 100% sure though hence why I did not touch those.
