### PR TITLE
feat: Add `handle_range` method to services

### DIFF
--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -142,6 +142,11 @@ impl ServiceBuilder {
                         #code_struct_init
                     }
                 }
+
+                #visibility fn handle_range(&self) -> core::ops::Range<u16> {
+                    self.handle..(self.handle + Self::ATTRIBUTE_COUNT as u16)
+                }
+
                 #code_impl
             }
         }


### PR DESCRIPTION
It is useful for a server to be able to determine which service a handle belongs to. By giving each service a `handle_range` method returning the handles that service owns a server can quickly and efficiently dispatch an event to the correct service.