### PR TITLE
`security` feature does not depend on `gatt` feature

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -76,7 +76,7 @@ controller-host-flow-control = []
 connection-metrics = []
 # Enable additional channel metrics
 channel-metrics = []
-security = [ "dep:p256", "dep:aes", "dep:cmac", "dep:rand_chacha", "gatt", "dep:rand" ]
+security = [ "dep:p256", "dep:aes", "dep:cmac", "dep:rand_chacha", "dep:rand" ]
 # Enable LE Legacy Pairing (BLE 4.0/4.1 fallback when peer doesn't support Secure Connections)
 legacy-pairing = ["security"]
 # For development. Disable security manager cryptographically secure pseudorandom number


### PR DESCRIPTION
My local build succeeds without the `gatt` feature. I think this was an accidental dependency.