### PR TITLE
Add serde feature for `BondInformation`

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -32,6 +32,7 @@ p256 = { version = "0.13.2", default-features = false, features = ["ecdh","arith
 rand_core = "0.6"
 rand_chacha = { version = "0.3", default-features = false, optional = true }
 rand = { version="0.8", default-features = false, optional = true}
+serde = { version = "1.0.228", optional = true, default-features = false, features = ["derive"] }
 static_cell = "2.1.0"
 zerocopy = "0.8.21"
 
@@ -97,6 +98,8 @@ connection-params-update = []
 
 # Allow L2CAP SPSU values that are reserved for future use
 allow-reserved-l2cap-psu = []
+
+serde = ["dep:serde", "bt-hci/serde"]
 
 default = ["peripheral", "central", "gatt", "derive", "default-packet-pool"]
 

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -34,6 +34,7 @@ use crate::{bt_hci_duration, BleHostError, Error, Identity, PacketPool, Stack};
 ///
 /// This describes the various security levels that are supported.
 ///
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SecurityLevel {

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -196,6 +196,7 @@ impl defmt::Format for Address {
 /// Because sometimes the peer uses the static or public address even though the IRK is sent.
 /// In this case, the IRK exists but the used address is not RPA.
 /// Should `Address` be used instead?
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Identity {
     /// Random static or public address

--- a/host/src/security_manager/crypto.rs
+++ b/host/src/security_manager/crypto.rs
@@ -11,6 +11,7 @@ use rand_core::{CryptoRng, RngCore};
 use crate::Address;
 
 /// LE Secure Connections Long Term Key.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[must_use]
 #[repr(transparent)]
@@ -55,6 +56,7 @@ impl defmt::Format for LongTermKey {
 }
 
 /// Identity Resolving Key.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[must_use]
 #[repr(transparent)]

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -49,6 +49,7 @@ pub(crate) enum SecurityEventData {
 }
 
 /// Bond Information
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct BondInformation {
     /// Long Term Key (LTK)


### PR DESCRIPTION
This was discussed in https://github.com/embassy-rs/trouble/pull/286#issuecomment-2725795975.

Now `bt-hci` has a `serde` feature, so `trouble-host` can also have one. This will simplify the storing / loading of bonds in bonding examples.