### PR TITLE
fix(l2cap): Add L2capChannelListener

### DIFF
--- a/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
+++ b/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
@@ -77,6 +77,7 @@ async fn main(spawner: Spawner) {
     let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(sdc, &mut resources)
         .set_random_address(address)
+        .register_l2cap_psm(0xF2)
         .build();
     let mut runner = stack.runner();
     let mut peripheral = stack.peripheral();
@@ -115,7 +116,7 @@ async fn main(spawner: Spawner) {
                 mtu: Some(PAYLOAD_LEN as u16),
                 mps: Some(L2CAP_MTU as u16 - 4),
             };
-            let mut ch1 = unwrap!(L2capChannel::accept(&stack, &conn, &[0xF2], &config).await);
+            let mut ch1 = unwrap!(L2capChannel::listen(&stack, &conn).accept(&config).await);
 
             let mut rx = [0; PAYLOAD_LEN];
             for i in 0..500 {

--- a/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
+++ b/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
@@ -77,7 +77,7 @@ async fn main(spawner: Spawner) {
     let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(sdc, &mut resources)
         .set_random_address(address)
-        .register_l2cap_psm(0xF2)
+        .register_l2cap_spsm(0xF2)
         .build();
     let mut runner = stack.runner();
     let mut peripheral = stack.peripheral();

--- a/docs/pages/concepts.adoc
+++ b/docs/pages/concepts.adoc
@@ -71,7 +71,7 @@ The *Logical Link Control and Adaptation Protocol (L2CAP)* provides the data tra
 
 In addition to the fixed channels used by GATT and signaling, BLE supports *Connection-Oriented Channels (CoC)* for transferring arbitrary data with credit-based flow control. CoC channels are useful when GATT's attribute-based model is too restrictive, such as bulk data transfer or custom protocols.
 
-Each CoC is identified by a *PSM (Protocol/Service Multiplexer)* value, similar to a port number.
+Each CoC is identified by a *SPSM (Simplified Protocol/Service Multiplexer)* value, similar to a port number.
 
 == Security
 

--- a/docs/pages/l2cap.adoc
+++ b/docs/pages/l2cap.adoc
@@ -51,17 +51,17 @@ let config = L2capChannelConfig {
 let mut ch = L2capChannel::create(&stack, &conn, 0x0081, &config).await.unwrap();
 ----
 
-The third argument is the PSM (Protocol/Service Multiplexer). Values in the range `0x0080`-`0x00FF` are available for custom use.
+The third argument is the SPSM (Simplified Protocol/Service Multiplexer). Values in the range `0x0080`-`0x00FF` are available for custom use.
 
 === Peripheral (responder)
 
-PSMs must be registered on the `StackBuilder` before use:
+SPSMs must be registered on the `StackBuilder` before use:
 
 [source,rust]
 ----
 let (stack, runner) = trouble_host::new(controller, &mut resources, &mut stack)
     .set_random_address(address)
-    .register_l2cap_psm(0x0081)
+    .register_l2cap_spsm(0x0081)
     .build();
 ----
 
@@ -87,7 +87,7 @@ let listener = L2capChannel::listen(&stack, &conn);
 let pending = listener.next().await.unwrap();
 
 // Inspect the incoming request
-let psm = pending.psm();
+let spsm = pending.spsm();
 let peer_mtu = pending.mtu();
 
 // Accept or reject
@@ -164,11 +164,11 @@ let ch = L2capChannel::merge(writer, reader);
 
 [source,rust]
 ----
-ch.mtu()       // Local negotiated MTU
-ch.mps()       // Local negotiated MPS
-ch.peer_mtu()  // Remote device's MTU
-ch.peer_mps()  // Remote device's MPS
-ch.psm()       // Protocol/Service Multiplexer
+ch.mtu()        // Local negotiated MTU
+ch.mps()        // Local negotiated MPS
+ch.peer_mtu()   // Remote device's MTU
+ch.peer_mps()   // Remote device's MPS
+ch.spsm()       // Simplified Protocol/Service Multiplexer
 ch.disconnect() // Disconnect the channel
 ----
 
@@ -191,7 +191,7 @@ pub async fn run<C: Controller>(controller: C) {
         HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
-        .register_l2cap_psm(0x0081)
+        .register_l2cap_spsm(0x0081)
         .build();
     let mut runner = stack.runner();
     let mut peripheral = stack.peripheral();

--- a/docs/pages/l2cap.adoc
+++ b/docs/pages/l2cap.adoc
@@ -55,7 +55,17 @@ The third argument is the PSM (Protocol/Service Multiplexer). Values in the rang
 
 === Peripheral (responder)
 
-The simplest approach accepts any incoming channel request on the given PSMs:
+PSMs must be registered on the `StackBuilder` before use:
+
+[source,rust]
+----
+let (stack, runner) = trouble_host::new(controller, &mut resources, &mut stack)
+    .set_random_address(address)
+    .register_l2cap_psm(0x0081)
+    .build();
+----
+
+The simplest approach accepts any incoming channel request:
 
 [source,rust]
 ----
@@ -65,14 +75,16 @@ let config = L2capChannelConfig {
     mtu: Some(PAYLOAD_LEN as u16),
     ..Default::default()
 };
-let mut ch = L2capChannel::accept(&stack, &conn, &[0x0081], &config).await.unwrap();
+let mut ch = L2capChannel::listen(&stack, &conn).accept(&config).await.unwrap();
 ----
 
-For more control, use `listen` to inspect the request before accepting:
+For more control, use `listen` to get a listener, then `next` to inspect each request before accepting:
 
 [source,rust]
 ----
-let pending = L2capChannel::listen(&stack, &conn, &[0x0081]).await.unwrap();
+let listener = L2capChannel::listen(&stack, &conn);
+
+let pending = listener.next().await.unwrap();
 
 // Inspect the incoming request
 let psm = pending.psm();
@@ -179,6 +191,7 @@ pub async fn run<C: Controller>(controller: C) {
         HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
+        .register_l2cap_psm(0x0081)
         .build();
     let mut runner = stack.runner();
     let mut peripheral = stack.peripheral();
@@ -205,9 +218,7 @@ pub async fn run<C: Controller>(controller: C) {
                 mtu: Some(PAYLOAD_LEN as u16),
                 ..Default::default()
             };
-            let mut ch = L2capChannel::accept(&stack, &conn, &[0x0081], &config)
-                .await
-                .unwrap();
+            let mut ch = L2capChannel::listen(&stack, &conn).accept(&config).await.unwrap();
 
             // Echo received data
             let mut buf = [0; PAYLOAD_LEN];

--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -2,7 +2,7 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
-use crate::common::PSM_L2CAP_EXAMPLES;
+use crate::common::SPSM_L2CAP_EXAMPLES;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
@@ -48,7 +48,7 @@ where
                 mtu: Some(PAYLOAD_LEN as u16),
                 ..Default::default()
             };
-            let mut ch1 = L2capChannel::create(&stack, &conn, PSM_L2CAP_EXAMPLES, &config)
+            let mut ch1 = L2capChannel::create(&stack, &conn, SPSM_L2CAP_EXAMPLES, &config)
                 .await
                 .unwrap();
             info!("New l2cap channel created, sending some data!");

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -2,7 +2,7 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use trouble_host::prelude::*;
 
-use crate::common::PSM_L2CAP_EXAMPLES;
+use crate::common::SPSM_L2CAP_EXAMPLES;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
@@ -21,7 +21,7 @@ where
     let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
-        .register_l2cap_psm(PSM_L2CAP_EXAMPLES)
+        .register_l2cap_spsm(SPSM_L2CAP_EXAMPLES)
         .build();
     let mut peripheral = stack.peripheral();
     let mut runner = stack.runner();

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -21,6 +21,7 @@ where
     let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
+        .register_l2cap_psm(PSM_L2CAP_EXAMPLES)
         .build();
     let mut peripheral = stack.peripheral();
     let mut runner = stack.runner();
@@ -57,9 +58,7 @@ where
                 mtu: Some(PAYLOAD_LEN as u16),
                 ..Default::default()
             };
-            let mut ch1 = L2capChannel::accept(&stack, &conn, &[PSM_L2CAP_EXAMPLES], &config)
-                .await
-                .unwrap();
+            let mut ch1 = L2capChannel::listen(&stack, &conn).accept(&config).await.unwrap();
 
             info!("L2CAP channel accepted");
 

--- a/examples/apps/src/common.rs
+++ b/examples/apps/src/common.rs
@@ -1,7 +1,7 @@
-// PSM from the dynamic range (0x0080-0x00FF) according to the Bluetooth
+// SPSM from the dynamic range (0x0080-0x00FF) according to the Bluetooth
 // Specification for L2CAP channels using LE Credit Based Flow Control mode.
 // used for the BLE L2CAP examples.
 //
 // https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-60/out/en/host/logical-link-control-and-adaptation-protocol-specification.html#UUID-1ffdf913-7b8a-c7ba-531e-2a9c6f6da8fb
 //
-pub(crate) const PSM_L2CAP_EXAMPLES: u16 = 0x0081;
+pub(crate) const SPSM_L2CAP_EXAMPLES: u16 = 0x0081;

--- a/examples/apps/src/high_throughput_ble_l2cap_central.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_central.rs
@@ -4,7 +4,7 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, Timer};
 use trouble_host::prelude::*;
 
-use crate::common::PSM_L2CAP_EXAMPLES;
+use crate::common::SPSM_L2CAP_EXAMPLES;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
@@ -84,7 +84,7 @@ where
                 initial_credits: Some(200),
             };
 
-            let mut ch1 = L2capChannel::create(&stack, &conn, PSM_L2CAP_EXAMPLES, &l2cap_channel_config)
+            let mut ch1 = L2capChannel::create(&stack, &conn, SPSM_L2CAP_EXAMPLES, &l2cap_channel_config)
                 .await
                 .expect("L2capChannel create failed");
 

--- a/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
@@ -4,7 +4,7 @@ use embassy_futures::join::join;
 use embassy_time::{Duration, Instant, Timer};
 use trouble_host::prelude::*;
 
-use crate::common::PSM_L2CAP_EXAMPLES;
+use crate::common::SPSM_L2CAP_EXAMPLES;
 
 /// Max number of connections
 const CONNECTIONS_MAX: usize = 1;
@@ -24,7 +24,7 @@ where
     let mut resources: HostResources<_, P, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
-        .register_l2cap_psm(PSM_L2CAP_EXAMPLES)
+        .register_l2cap_spsm(SPSM_L2CAP_EXAMPLES)
         .build();
     let mut peripheral = stack.peripheral();
     let mut runner = stack.runner();

--- a/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
@@ -24,6 +24,7 @@ where
     let mut resources: HostResources<_, P, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
+        .register_l2cap_psm(PSM_L2CAP_EXAMPLES)
         .build();
     let mut peripheral = stack.peripheral();
     let mut runner = stack.runner();
@@ -74,9 +75,10 @@ where
                 initial_credits: Some(200),
             };
 
-            let mut ch1 = L2capChannel::accept(&stack, &conn, &[PSM_L2CAP_EXAMPLES], &l2cap_channel_config)
+            let mut ch1 = L2capChannel::listen(&stack, &conn)
+                .accept(&l2cap_channel_config)
                 .await
-                .expect("L2capChannel create failed");
+                .expect("L2capChannel accept failed");
 
             info!("L2CAP channel accepted");
 

--- a/examples/serial-hci/Cargo.lock
+++ b/examples/serial-hci/Cargo.lock
@@ -1129,24 +1129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial-hci"
-version = "0.1.0"
-dependencies = [
- "critical-section",
- "embassy-sync 0.7.2",
- "embassy-time",
- "embedded-io-adapters",
- "env_logger",
- "log",
- "rand",
- "rand_core 0.3.1",
- "tokio",
- "tokio-serial",
- "trouble-example-apps",
- "trouble-host",
-]
-
-[[package]]
 name = "serialport"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1349,24 @@ dependencies = [
  "quote",
  "syn",
  "uuid",
+]
+
+[[package]]
+name = "trouble-serial-hci-examples"
+version = "0.1.0"
+dependencies = [
+ "critical-section",
+ "embassy-sync 0.7.2",
+ "embassy-time",
+ "embedded-io-adapters",
+ "env_logger",
+ "log",
+ "rand",
+ "rand_core 0.3.1",
+ "tokio",
+ "tokio-serial",
+ "trouble-example-apps",
+ "trouble-host",
 ]
 
 [[package]]

--- a/examples/tests/tests/ble_l2cap_central.rs
+++ b/examples/tests/tests/ble_l2cap_central.rs
@@ -49,6 +49,7 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
         let mut resources: HostResources<_, DefaultPacketPool, 1, 1> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
+            .register_l2cap_psm(0x81)
             .build();
         let mut runner = stack.runner();
         let mut peripheral = stack.peripheral();
@@ -84,7 +85,7 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
                         mtu: Some(PAYLOAD_LEN as u16),
                         ..Default::default()
                     };
-                    let mut ch1 = L2capChannel::accept(&stack, &conn, &[0x81], &config).await?;
+                    let mut ch1 = L2capChannel::listen(&stack, &conn).accept(&config).await?;
 
                     println!("[peripheral] channel created");
 

--- a/examples/tests/tests/ble_l2cap_central.rs
+++ b/examples/tests/tests/ble_l2cap_central.rs
@@ -49,7 +49,7 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
         let mut resources: HostResources<_, DefaultPacketPool, 1, 1> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
-            .register_l2cap_psm(0x81)
+            .register_l2cap_spsm(0x81)
             .build();
         let mut runner = stack.runner();
         let mut peripheral = stack.peripheral();

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -31,8 +31,8 @@ struct State {
     accept_waker: WakerRegistration,
     create_waker: WakerRegistration,
     disconnect_waker: WakerRegistration,
-    /// Bitmask tracking which PSMs (0x0001..=0x00FF) have active listeners.
-    registered_psms: [u32; 8],
+    /// Bitmask tracking which SPSMs (0x0001..=0x00FF) have active listeners.
+    registered_spsms: [u32; 8],
 }
 
 /// Channel manager for L2CAP channels used directly by clients.
@@ -76,24 +76,24 @@ impl<P, const QLEN: usize> PacketChannel<P, QLEN> {
 }
 
 impl State {
-    /// Register a PSM for listening.
-    fn register_psm(&mut self, psm: u16) {
-        if (1..=255).contains(&psm) {
-            let idx = psm as usize / 32;
-            let bit = psm as usize % 32;
-            self.registered_psms[idx] |= 1 << bit;
+    /// Register a SPSM for listening.
+    fn register_spsm(&mut self, spsm: u16) {
+        if (1..=255).contains(&spsm) {
+            let idx = spsm as usize / 32;
+            let bit = spsm as usize % 32;
+            self.registered_spsms[idx] |= 1 << bit;
         }
     }
 
-    /// Check if a PSM has an active listener.
-    fn is_psm_registered(&self, psm: u16) -> bool {
-        if !(1..=255).contains(&psm) {
+    /// Check if a SPSM has an active listener.
+    fn is_spsm_registered(&self, spsm: u16) -> bool {
+        if !(1..=255).contains(&spsm) {
             // When the allow-reserved-l2ca-psu feature is enable, treat all reserved PSUs as registered
             return cfg!(feature = "allow-reserved-l2cap-psu");
         }
-        let idx = psm as usize / 32;
-        let bit = psm as usize % 32;
-        self.registered_psms[idx] & (1 << bit) != 0
+        let idx = spsm as usize / 32;
+        let bit = spsm as usize % 32;
+        self.registered_spsms[idx] & (1 << bit) != 0
     }
 
     fn next_request_id(&mut self) -> u8 {
@@ -115,7 +115,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
                 accept_waker: WakerRegistration::new(),
                 create_waker: WakerRegistration::new(),
                 disconnect_waker: WakerRegistration::new(),
-                registered_psms: [0; 8],
+                registered_spsms: [0; 8],
             }),
             channels,
         }
@@ -129,16 +129,16 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         RefMut::map(self.channels.borrow_mut(), |x| &mut x[index.0 as usize])
     }
 
-    pub(crate) fn register_psm(&self, psm: u16) {
-        self.state.borrow_mut().register_psm(psm);
+    pub(crate) fn register_spsm(&self, spsm: u16) {
+        self.state.borrow_mut().register_spsm(spsm);
     }
 
     fn next_request_id(&self) -> u8 {
         self.state.borrow_mut().next_request_id()
     }
 
-    pub(crate) fn psm(&self, index: ChannelIndex) -> u16 {
-        self.channel(index).psm
+    pub(crate) fn spsm(&self, index: ChannelIndex) -> u16 {
+        self.channel(index).spsm
     }
 
     pub(crate) fn mtu(&self, index: ChannelIndex) -> u16 {
@@ -254,7 +254,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
     /// Wait for an incoming L2CAP connection request on the given connection.
     ///
     /// Returns a [`L2capPendingConnection`] that can be inspected and then accepted or rejected.
-    /// PSMs must be registered globally via [`StackBuilder::register_l2cap_psm`].
+    /// SPSMs must be registered globally via [`StackBuilder::register_l2cap_spsm`].
     pub(crate) async fn next_pending(
         &'d self,
         conn: ConnHandle,
@@ -411,7 +411,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
     pub(crate) async fn create<T: Controller>(
         &'d self,
         conn: ConnHandle,
-        psm: u16,
+        spsm: u16,
         config: &L2capChannelConfig,
         ble: &BleHost<'_, T, P>,
     ) -> Result<L2capChannel<'d, P>, BleHostError<T::Error>> {
@@ -436,7 +436,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         let idx = self.alloc(conn, None, |storage| {
             cid = storage.cid;
             credits = initial_credits.unwrap_or(config::L2CAP_RX_QUEUE_SIZE.min(P::capacity()) as u16);
-            storage.psm = psm;
+            storage.spsm = spsm;
             storage.mtu = mtu;
             storage.mps = mps;
             storage.flow_control = CreditFlowControl::new(*flow_policy, credits);
@@ -446,7 +446,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         let mut tx = [0; 18];
         // Send the initial connect request.
         let command = LeCreditConnReq {
-            psm,
+            spsm,
             mps,
             scid: cid,
             mtu,
@@ -742,14 +742,14 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
     ) -> Result<(), Error> {
         let result = {
             let mut state = self.state.borrow_mut();
-            if !state.is_psm_registered(req.psm) {
+            if !state.is_spsm_registered(req.spsm) {
                 Err(LeCreditConnResultCode::SpsmNotSupported)
             } else if !manager.is_l2cap_listening(conn) {
                 Err(LeCreditConnResultCode::NoResources)
             } else {
                 match self.alloc(conn, Some(req.scid), |storage| {
                     storage.conn = Some(conn);
-                    storage.psm = req.psm;
+                    storage.spsm = req.spsm;
                     storage.peer_credits = req.credits;
                     storage.peer_mps = req.mps;
                     storage.peer_mtu = req.mtu;
@@ -770,8 +770,8 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
             Ok(()) => Ok(()),
             Err(result) => {
                 debug!(
-                    "[l2cap][conn = {:?}] rejecting connection for PSM 0x{:04x}: {:?}",
-                    conn, req.psm, result
+                    "[l2cap][conn = {:?}] rejecting connection for SPSM 0x{:04x}: {:?}",
+                    conn, req.spsm, result
                 );
                 Self::try_send_signal(conn, identifier, &LeCreditConnRes::reject(result), manager)
             }
@@ -1295,7 +1295,7 @@ pub struct ChannelStorage<P> {
     state: ChannelState,
     conn: Option<ConnHandle>,
     cid: u16,
-    psm: u16,
+    spsm: u16,
     mps: u16,
     mtu: u16,
     flow_control: CreditFlowControl,
@@ -1427,7 +1427,7 @@ impl<P> ChannelStorage<P> {
             cid: 0,
             mps: 0,
             mtu: 0,
-            psm: 0,
+            spsm: 0,
 
             flow_control: CreditFlowControl::new(CreditFlowPolicy::Every(1), 0),
             peer_cid: 0,
@@ -1484,7 +1484,7 @@ impl<P> ChannelStorage<P> {
         self.conn = None;
         self.mps = 0;
         self.mtu = 0;
-        self.psm = 0;
+        self.spsm = 0;
         self.peer_cid = 0;
         self.peer_mps = 0;
         self.peer_mtu = 0;

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -76,36 +76,12 @@ impl<P, const QLEN: usize> PacketChannel<P, QLEN> {
 }
 
 impl State {
-    /// Register PSMs for listening. Returns Err(AlreadyInUse) if any PSM is already registered.
-    fn register_psms(&mut self, psms: &[u16]) -> Result<(), Error> {
-        // Validate and check for overlap first
-        for &psm in psms {
-            if !(1..=255).contains(&psm) && !cfg!(feature = "allow-reserved-l2cap-psu") {
-                return Err(Error::InvalidValue);
-            } else if self.is_psm_registered(psm) && !cfg!(feature = "allow-reserved-l2cap-psu") {
-                return Err(Error::AlreadyInUse);
-            }
-        }
-
-        // All clear, set the bits
-        for &psm in psms {
-            if (1..=255).contains(&psm) {
-                let idx = psm as usize / 32;
-                let bit = psm as usize % 32;
-                self.registered_psms[idx] |= 1 << bit;
-            }
-        }
-        Ok(())
-    }
-
-    /// Unregister PSMs from listening.
-    fn unregister_psms(&mut self, psms: &[u16]) {
-        for &psm in psms {
-            if (1..=255).contains(&psm) {
-                let idx = psm as usize / 32;
-                let bit = psm as usize % 32;
-                self.registered_psms[idx] &= !(1 << bit);
-            }
+    /// Register a PSM for listening.
+    fn register_psm(&mut self, psm: u16) {
+        if (1..=255).contains(&psm) {
+            let idx = psm as usize / 32;
+            let bit = psm as usize % 32;
+            self.registered_psms[idx] |= 1 << bit;
         }
     }
 
@@ -151,6 +127,10 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
 
     fn channel_mut(&self, index: ChannelIndex) -> RefMut<'_, ChannelStorage<P::Packet>> {
         RefMut::map(self.channels.borrow_mut(), |x| &mut x[index.0 as usize])
+    }
+
+    pub(crate) fn register_psm(&self, psm: u16) {
+        self.state.borrow_mut().register_psm(psm);
     }
 
     fn next_request_id(&self) -> u8 {
@@ -271,34 +251,15 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         Ok(ChannelIndex(idx as u8))
     }
 
-    pub(crate) async fn accept<T: Controller>(
-        &'d self,
-        conn: ConnHandle,
-        psm: &[u16],
-        config: &L2capChannelConfig,
-        ble: &BleHost<'d, T, P>,
-    ) -> Result<L2capChannel<'d, P>, BleHostError<T::Error>> {
-        let pending = self.listen(conn, psm, &ble.connections).await?;
-        let index = pending.into_index();
-        self.accept_pending(index, config, ble).await
-    }
-
-    /// Wait for an incoming L2CAP connection request matching the connection and PSM list.
+    /// Wait for an incoming L2CAP connection request on the given connection.
     ///
     /// Returns a [`L2capPendingConnection`] that can be inspected and then accepted or rejected.
-    /// Returns `Err(Error::AlreadyInUse)` if any of the requested PSMs already have a listener.
-    pub(crate) async fn listen(
+    /// PSMs must be registered globally via [`StackBuilder::register_l2cap_psm`].
+    pub(crate) async fn next_pending(
         &'d self,
         conn: ConnHandle,
-        psm: &[u16],
         connections: &ConnectionManager<'_, P>,
     ) -> Result<L2capPendingConnection<'d, P>, Error> {
-        self.state.borrow_mut().register_psms(psm)?;
-
-        let _guard = OnDrop::new(|| {
-            self.state.borrow_mut().unregister_psms(psm);
-        });
-
         poll_fn(|cx| {
             let mut state = self.state.borrow_mut();
             state.accept_waker.register(cx.waker());
@@ -307,7 +268,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
             let mut channels = self.channels.borrow_mut();
             for (idx, chan) in channels.iter_mut().enumerate() {
                 match chan.state {
-                    ChannelState::PeerConnecting(_) if chan.conn == Some(conn) && psm.contains(&chan.psm) => {
+                    ChannelState::PeerConnecting(_) if chan.conn == Some(conn) => {
                         if chan.refcount != 0 {
                             log_status(&channels, true);
                             panic!("unexpected refcount");
@@ -325,6 +286,31 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
             Poll::Pending
         })
         .await
+    }
+
+    /// Reject all pending L2CAP connections on the given connection that have not yet been
+    /// returned by `next_pending` (refcount == 0). Sends a `NoResources` rejection response
+    /// for each, then closes the channel slot.
+    pub(crate) fn reject_all_pending(&self, conn: ConnHandle, manager: &ConnectionManager<'_, P>) {
+        let mut channels = self.channels.borrow_mut();
+        for chan in channels.iter_mut() {
+            if chan.conn == Some(conn) && chan.refcount == 0 {
+                if let ChannelState::PeerConnecting(identifier) = chan.state {
+                    if let Err(e) = Self::try_send_signal(
+                        conn,
+                        identifier,
+                        &LeCreditConnRes::reject(LeCreditConnResultCode::NoResources),
+                        manager,
+                    ) {
+                        warn!(
+                            "[l2cap] error rejecting pending channel connect request {:?}: {:?}",
+                            identifier, e
+                        );
+                    }
+                    chan.close();
+                }
+            }
+        }
     }
 
     /// Accept a pending L2CAP connection: negotiate parameters, transition to Connected, send success response.
@@ -758,6 +744,8 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
             let mut state = self.state.borrow_mut();
             if !state.is_psm_registered(req.psm) {
                 Err(LeCreditConnResultCode::SpsmNotSupported)
+            } else if !manager.is_l2cap_listening(conn) {
+                Err(LeCreditConnResultCode::NoResources)
             } else {
                 match self.alloc(conn, Some(req.scid), |storage| {
                     storage.conn = Some(conn);

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -8,6 +8,7 @@ use bt_hci::{FromHciBytes, WriteHci};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::waitqueue::WakerRegistration;
+use embassy_time::with_timeout;
 
 use crate::connection_manager::ConnectionManager;
 use crate::cursor::WriteCursor;
@@ -25,6 +26,9 @@ use crate::types::l2cap::{
 use crate::{config, BleHostError, Error, PacketPool};
 
 const BASE_ID: u16 = 0x40;
+
+/// BT Core Spec Vol 3, Part A, Section 6.2.1: RTX signaling timeout.
+const L2CAP_RTX_TIMEOUT: embassy_time::Duration = embassy_time::Duration::from_secs(30);
 
 struct State {
     next_req_id: u8,
@@ -458,9 +462,17 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         let ondrop = OnDrop::new(|| self.channel_mut(idx).close());
 
         // Wait until a response is accepted.
-        let result = poll_fn(|cx| self.poll_created(conn, idx, ble, Some(cx))).await;
+        let result = with_timeout(
+            L2CAP_RTX_TIMEOUT,
+            poll_fn(|cx| self.poll_created(conn, idx, ble, Some(cx))),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            warn!("[l2cap] RTX timeout waiting for LE Credit Based Connection Response");
+            Err(BleHostError::BleHost(Error::Timeout))
+        })?;
         ondrop.defuse();
-        result
+        Ok(result)
     }
 
     fn poll_created<T: Controller>(

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -504,6 +504,10 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         self.manager.get_att_mtu(self.index)
     }
 
+    pub(crate) fn set_l2cap_listening(&self, listening: bool) {
+        self.manager.set_l2cap_listening(self.index, listening);
+    }
+
     pub(crate) async fn send(&self, pdu: Pdu<P::Packet>) {
         self.manager.send(self.index, pdu).await
     }

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -276,6 +276,10 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         self.connection_mut(index).att_mtu = mtu;
     }
 
+    pub(crate) fn set_l2cap_listening(&self, index: u8, listening: bool) {
+        self.connection_mut(index).l2cap_listening = listening;
+    }
+
     pub(crate) fn request_disconnect(&self, index: u8, reason: DisconnectReason) {
         let entry = &mut self.connection_mut(index);
         if entry.state == ConnectionState::Connected {
@@ -372,6 +376,11 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         self.with_connected_handle(h, |_storage| Ok(())).is_ok()
     }
 
+    pub(crate) fn is_l2cap_listening(&self, h: ConnHandle) -> bool {
+        self.with_connected_handle(h, |storage| Ok(storage.l2cap_listening))
+            .unwrap_or(false)
+    }
+
     pub(crate) fn reassembly<F: FnOnce(&mut PacketReassembly<P::Packet>) -> Result<R, Error>, R>(
         &self,
         h: ConnHandle,
@@ -403,6 +412,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 }
                 #[cfg(feature = "att-queued-writes")]
                 storage.prepare_write.clear();
+                storage.l2cap_listening = false;
                 return Ok(());
             }
         }
@@ -1068,6 +1078,7 @@ pub struct ConnectionStorage<P> {
     pub resolvable_addrs: ResolvablePrivateAddrs,
     #[cfg(feature = "legacy-pairing")]
     pub encryption_key_len: u8,
+    pub l2cap_listening: bool,
     pub events: EventChannel,
     pub reassembly: PacketReassembly<P>,
     #[cfg(feature = "gatt")]
@@ -1166,6 +1177,7 @@ impl<P> ConnectionStorage<P> {
             resolvable_addrs: ResolvablePrivateAddrs::none(),
             #[cfg(feature = "legacy-pairing")]
             encryption_key_len: 0,
+            l2cap_listening: false,
             events: EventChannel::new(),
             #[cfg(feature = "gatt")]
             gatt: GattChannel::new(),

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -110,9 +110,9 @@ impl<'d, P: PacketPool> L2capPendingConnection<'d, P> {
         self.index.take().unwrap()
     }
 
-    /// Get the PSM of the incoming connection request.
-    pub fn psm(&self) -> u16 {
-        self.manager.psm(self.index.unwrap())
+    /// Get the SPSM of the incoming connection request.
+    pub fn spsm(&self) -> u16 {
+        self.manager.spsm(self.index.unwrap())
     }
 
     /// Get the peer's requested MTU.
@@ -173,9 +173,9 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         self.manager.disconnect(self.index);
     }
 
-    /// Get the PSM for this channel.
-    pub fn psm(&self) -> u16 {
-        self.manager.psm(self.index)
+    /// Get the SPSM for this channel.
+    pub fn spsm(&self) -> u16 {
+        self.manager.spsm(self.index)
     }
 
     /// Get the negotiated MTU for this channel.
@@ -264,7 +264,7 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
 
     /// Start listening for incoming L2CAP connection requests on the given connection.
     ///
-    /// PSMs must be registered globally via [`StackBuilder::register_l2cap_psm`].
+    /// SPSMs must be registered globally via [`StackBuilder::register_l2cap_spsm`].
     ///
     /// Returns `Err(Error::AlreadyInUse)` if this connection already has an active listener.
     pub fn listen<T: Controller>(
@@ -278,17 +278,17 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         }
     }
 
-    /// Create a new connection request with the provided PSM.
+    /// Create a new connection request with the provided SPSM.
     pub async fn create<T: Controller>(
         stack: &'d Stack<'_, T, P>,
         connection: &Connection<'_, P>,
-        psm: u16,
+        spsm: u16,
         config: &L2capChannelConfig,
     ) -> Result<Self, BleHostError<T::Error>> {
         stack
             .host
             .channels
-            .create(connection.handle(), psm, config, stack.host)
+            .create(connection.handle(), spsm, config, stack.host)
             .await
     }
 

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -7,6 +7,7 @@ pub use crate::channel_manager::CreditFlowPolicy;
 pub use crate::channel_manager::Metrics as ChannelMetrics;
 use crate::channel_manager::{ChannelIndex, ChannelManager};
 use crate::connection::Connection;
+use crate::host::BleHost;
 use crate::pdu::Sdu;
 pub use crate::types::l2cap::LeCreditConnResultCode;
 use crate::{BleHostError, Error, PacketPool, Stack};
@@ -261,31 +262,20 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         self.manager.metrics(self.index, f)
     }
 
-    /// Listen for an incoming connection request matching the list of PSM.
+    /// Start listening for incoming L2CAP connection requests on the given connection.
     ///
-    /// Returns a [`L2capPendingConnection`] that can be inspected, then accepted or rejected.
-    /// Returns `Err(Error::AlreadyInUse)` if any of the requested PSMs already have a listener.
-    pub async fn listen(
-        stack: &'d Stack<'_, impl Controller, P>,
-        connection: &Connection<'_, P>,
-        psm: &[u16],
-    ) -> Result<L2capPendingConnection<'d, P>, Error> {
-        stack
-            .host
-            .channels
-            .listen(connection.handle(), psm, &stack.host.connections)
-            .await
-    }
-
-    /// Await an incoming connection request matching the list of PSM and accept it.
-    pub async fn accept<T: Controller>(
+    /// PSMs must be registered globally via [`StackBuilder::register_l2cap_psm`].
+    ///
+    /// Returns `Err(Error::AlreadyInUse)` if this connection already has an active listener.
+    pub fn listen<T: Controller>(
         stack: &'d Stack<'_, T, P>,
-        connection: &Connection<'_, P>,
-        psm: &[u16],
-        config: &L2capChannelConfig,
-    ) -> Result<Self, BleHostError<T::Error>> {
-        let handle = connection.handle();
-        stack.host.channels.accept(handle, psm, config, stack.host).await
+        connection: &Connection<'d, P>,
+    ) -> L2capChannelListener<'d, T, P> {
+        connection.set_l2cap_listening(true);
+        L2capChannelListener {
+            conn: connection.clone(),
+            host: stack.host,
+        }
     }
 
     /// Create a new connection request with the provided PSM.
@@ -462,5 +452,51 @@ impl<'d, P: PacketPool> L2capChannelWriter<'d, P> {
             index: self.index,
             manager: self.manager,
         }
+    }
+}
+
+/// A listener for incoming L2CAP connection requests on a specific connection.
+///
+/// Created by [`L2capChannel::listen`]. When dropped, clears the listening flag
+/// on the connection and rejects any pending connection requests that have not
+/// yet been returned by [`next`](Self::next) or [`accept`](Self::accept).
+pub struct L2capChannelListener<'d, T: Controller, P: PacketPool> {
+    conn: Connection<'d, P>,
+    host: &'d BleHost<'d, T, P>,
+}
+
+impl<'d, T: Controller, P: PacketPool> L2capChannelListener<'d, T, P> {
+    /// Wait for the next incoming L2CAP connection request.
+    ///
+    /// Returns a [`L2capPendingConnection`] that can be inspected, then accepted or rejected.
+    pub async fn next(&self) -> Result<L2capPendingConnection<'d, P>, Error> {
+        self.host
+            .channels
+            .next_pending(self.conn.handle(), &self.host.connections)
+            .await
+    }
+
+    /// Wait for the next incoming L2CAP connection request and accept it.
+    ///
+    /// This is a convenience method equivalent to calling [`next`](Self::next) followed by
+    /// [`L2capPendingConnection::accept`].
+    pub async fn accept(&self, config: &L2capChannelConfig) -> Result<L2capChannel<'d, P>, BleHostError<T::Error>> {
+        let pending = self.next().await?;
+        let index = pending.into_index();
+        self.host.channels.accept_pending(index, config, self.host).await
+    }
+
+    /// Get a reference to the connection this listener is bound to.
+    pub fn connection(&self) -> &Connection<'d, P> {
+        &self.conn
+    }
+}
+
+impl<T: Controller, P: PacketPool> Drop for L2capChannelListener<'_, T, P> {
+    fn drop(&mut self) {
+        self.conn.set_l2cap_listening(false);
+        self.host
+            .channels
+            .reject_all_pending(self.conn.handle(), &self.host.connections);
     }
 }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -748,6 +748,12 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
         self.host.as_mut().unwrap()
     }
 
+    /// Register an L2CAP PSM (Protocol/Service Multiplexer) for accepting incoming connections.
+    pub fn register_l2cap_psm(mut self, psm: u16) -> Self {
+        self.host().channels.register_psm(psm);
+        self
+    }
+
     /// Set the random address used by this host.
     pub fn set_random_address(mut self, address: Address) -> Self {
         self.host().address.replace(address);

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -748,9 +748,9 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
         self.host.as_mut().unwrap()
     }
 
-    /// Register an L2CAP PSM (Protocol/Service Multiplexer) for accepting incoming connections.
-    pub fn register_l2cap_psm(mut self, psm: u16) -> Self {
-        self.host().channels.register_psm(psm);
+    /// Register an L2CAP SPSM (Simplified Protocol/Service Multiplexer) for accepting incoming connections.
+    pub fn register_l2cap_spsm(mut self, spsm: u16) -> Self {
+        self.host().channels.register_spsm(spsm);
         self
     }
 

--- a/host/src/types/l2cap.rs
+++ b/host/src/types/l2cap.rs
@@ -151,7 +151,7 @@ impl L2capSignalCode {
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct LeCreditConnReq {
-    pub psm: u16,
+    pub spsm: u16,
     pub scid: u16,
     pub mtu: u16,
     pub mps: u16,

--- a/host/tests/l2cap.rs
+++ b/host/tests/l2cap.rs
@@ -28,7 +28,7 @@ async fn l2cap_connection_oriented_channels() {
         let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
-            .register_l2cap_psm(0xf2)
+            .register_l2cap_spsm(0xf2)
             .build();
         let mut runner = stack.runner();
         let mut peripheral = stack.peripheral();

--- a/host/tests/l2cap.rs
+++ b/host/tests/l2cap.rs
@@ -28,6 +28,7 @@ async fn l2cap_connection_oriented_channels() {
         let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
+            .register_l2cap_psm(0xf2)
             .build();
         let mut runner = stack.runner();
         let mut peripheral = stack.peripheral();
@@ -59,7 +60,7 @@ async fn l2cap_connection_oriented_channels() {
                     let conn = acceptor.accept().await?;
                     println!("[peripheral] connected");
 
-                    let mut ch1 = L2capChannel::accept(&stack, &conn, &[0xf2], &Default::default()).await?;
+                    let mut ch1 = L2capChannel::listen(&stack, &conn).accept(&Default::default()).await?;
 
                     println!("[peripheral] channel created");
 

--- a/tester/app/src/btp/mod.rs
+++ b/tester/app/src/btp/mod.rs
@@ -220,7 +220,7 @@ impl<T> From<Result<T, BtpStatus>> for HandlerResult<T> {
 
 /// L2CAP listener configuration captured during the pre-server phase.
 pub(crate) struct L2capListenerConfig {
-    pub psm: u16,
+    pub spsm: u16,
     pub mtu: Option<u16>,
     pub response: LeCreditConnResultCode,
 }
@@ -308,7 +308,7 @@ pub(crate) async fn run_pre_server<'a, R: Read, W: Write>(
                 L2capCommand::Listen(listen) => {
                     let mtu = if listen.mtu > 0 { Some(listen.mtu) } else { None };
                     l2cap_listener = Some(L2capListenerConfig {
-                        psm: listen.psm,
+                        spsm: listen.psm,
                         mtu,
                         response: listen.response,
                     });
@@ -716,7 +716,7 @@ fn convert_event<'a>(event: &'a Event, current_settings: &mut GapSettings) -> Bt
         }
         Event::L2capConnected {
             chan_id,
-            psm,
+            spsm,
             peer_mtu,
             peer_mps,
             our_mtu,
@@ -724,18 +724,18 @@ fn convert_event<'a>(event: &'a Event, current_settings: &mut GapSettings) -> Bt
             address,
         } => BtpEvent::L2cap(L2capEvent::Connected(protocol::l2cap::ConnectedEvent {
             chan_id: *chan_id,
-            psm: *psm,
+            psm: *spsm,
             peer_mtu: *peer_mtu,
             peer_mps: *peer_mps,
             our_mtu: *our_mtu,
             our_mps: *our_mps,
             address: *address,
         })),
-        Event::L2capDisconnected { chan_id, psm, address } => {
+        Event::L2capDisconnected { chan_id, spsm, address } => {
             BtpEvent::L2cap(L2capEvent::Disconnected(protocol::l2cap::DisconnectedEvent {
                 result: 0,
                 chan_id: *chan_id,
-                psm: *psm,
+                psm: *spsm,
                 address: *address,
             }))
         }
@@ -1350,7 +1350,7 @@ async fn handle_l2cap(cmd: L2capCommand<'_>, channels: &CommandChannels<'_>) -> 
                 .l2cap
                 .send(l2cap::Command::Connect {
                     address: connect.address,
-                    psm: connect.psm,
+                    spsm: connect.psm,
                     mtu: connect.mtu,
                     num: connect.num,
                 })

--- a/tester/app/src/btp/mod.rs
+++ b/tester/app/src/btp/mod.rs
@@ -218,10 +218,18 @@ impl<T> From<Result<T, BtpStatus>> for HandlerResult<T> {
     }
 }
 
+/// L2CAP listener configuration captured during the pre-server phase.
+pub(crate) struct L2capListenerConfig {
+    pub psm: u16,
+    pub mtu: Option<u16>,
+    pub response: LeCreditConnResultCode,
+}
+
 /// Result of the pre-server BTP phase.
 pub(crate) struct PreServerResult<'a, R, W> {
     pub transport: BtpTransport<R, W>,
     pub gap: GapState<'a, PreServerGap>,
+    pub l2cap_listener: Option<L2capListenerConfig>,
 }
 
 /// Run the pre-server BTP phase.
@@ -259,6 +267,8 @@ pub(crate) async fn run_pre_server<'a, R: Read, W: Write>(
         },
     };
 
+    let mut l2cap_listener: Option<L2capListenerConfig> = None;
+
     // Send IUT Ready event before entering the main loop
     info!("Sending IUT Ready event");
     BtpEvent::Core(CoreEvent::IutReady).write(&mut writer).await?;
@@ -295,6 +305,15 @@ pub(crate) async fn run_pre_server<'a, R: Read, W: Write>(
                 L2capCommand::ReadSupportedCommands => Ok(BtpResponse::L2cap(L2capResponse::SupportedCommands(
                     protocol::l2cap::SUPPORTED_COMMANDS,
                 ))),
+                L2capCommand::Listen(listen) => {
+                    let mtu = if listen.mtu > 0 { Some(listen.mtu) } else { None };
+                    l2cap_listener = Some(L2capListenerConfig {
+                        psm: listen.psm,
+                        mtu,
+                        response: listen.response,
+                    });
+                    Ok(BtpResponse::L2cap(L2capResponse::Empty))
+                }
                 _ => Err(BtpStatus::NotReady),
             },
         };
@@ -311,6 +330,7 @@ pub(crate) async fn run_pre_server<'a, R: Read, W: Write>(
                 return Ok(Some(PreServerResult {
                     transport: BtpTransport { reader, writer },
                     gap,
+                    l2cap_listener,
                 }));
             }
             Err(status) => {
@@ -511,7 +531,6 @@ where
                         command_channel::Response::L2cap(response) => {
                             use l2cap::Response as LR;
                             match response {
-                                LR::Listening => Ok(BtpResponse::L2cap(L2capResponse::Empty)),
                                 LR::Connecting(rsp) => Ok(BtpResponse::L2cap(L2capResponse::Connecting(rsp))),
                                 LR::Disconnected => Ok(BtpResponse::L2cap(L2capResponse::Empty)),
                                 LR::DataSent => Ok(BtpResponse::L2cap(L2capResponse::Empty)),
@@ -1322,16 +1341,9 @@ async fn handle_l2cap(cmd: L2capCommand<'_>, channels: &CommandChannels<'_>) -> 
         L2capCommand::ReadSupportedCommands => {
             HandlerResult::Ready(L2capResponse::SupportedCommands(SUPPORTED_COMMANDS))
         }
-        L2capCommand::Listen(listen) => {
-            channels
-                .l2cap
-                .send(l2cap::Command::Listen {
-                    psm: listen.psm,
-                    mtu: listen.mtu,
-                    response: listen.response,
-                })
-                .await;
-            HandlerResult::Forwarded
+        L2capCommand::Listen(_) => {
+            // Listen must be configured in the pre-server phase
+            HandlerResult::Error(BtpStatus::Fail)
         }
         L2capCommand::Connect(connect) => {
             channels

--- a/tester/app/src/l2cap.rs
+++ b/tester/app/src/l2cap.rs
@@ -21,7 +21,7 @@ use crate::command_channel::{self, CommandReceiver, HasResponse};
 pub enum Command {
     Connect {
         address: Address,
-        psm: u16,
+        spsm: u16,
         mtu: u16,
         num: u8,
     },
@@ -75,12 +75,12 @@ impl<P: PacketPool> ChannelSlot<'_, P> {
 enum ChannelOp<'stack, P: PacketPool> {
     Connect {
         conn: Connection<'stack, P>,
-        psm: u16,
+        spsm: u16,
         mtu: Option<u16>,
     },
     Accepted {
         reader: L2capChannelReader<'stack, P>,
-        psm: u16,
+        spsm: u16,
         address: Address,
     },
 }
@@ -97,7 +97,7 @@ enum ChannelNotification<'stack, P: PacketPool> {
     Accepted {
         writer: L2capChannelWriter<'stack, P>,
         reader: L2capChannelReader<'stack, P>,
-        psm: u16,
+        spsm: u16,
         our_mtu: u16,
         our_mps: u16,
         peer_mtu: u16,
@@ -105,7 +105,7 @@ enum ChannelNotification<'stack, P: PacketPool> {
         address: Address,
     },
     Rejected {
-        psm: u16,
+        spsm: u16,
         address: Address,
     },
 }
@@ -166,12 +166,12 @@ async fn listener_task<'stack, C: crate::Controller, P: PacketPool>(
     conn_rx: &mut watch::DynReceiver<'_, Connection<'stack, P>>,
     notify: &NotifyChannel<'stack, P>,
 ) {
-    let L2capListenerConfig { psm, mtu, response } = args;
+    let L2capListenerConfig { spsm, mtu, response } = args;
 
     loop {
         // Wait for a connection to become available
         let conn = conn_rx.changed().await;
-        info!("listener_task: connection available, listening on PSM {}", psm);
+        info!("listener_task: connection available, listening on SPSM {}", spsm);
 
         let listener = L2capChannel::listen(stack, &conn);
 
@@ -196,7 +196,7 @@ async fn listener_task<'stack, C: crate::Controller, P: PacketPool>(
                 if let Err(e) = pending.reject(stack, response).await {
                     error!("L2CAP reject failed: {:?}", e);
                 }
-                notify.send(ChannelNotification::Rejected { psm, address }).await;
+                notify.send(ChannelNotification::Rejected { spsm, address }).await;
             } else {
                 match pending.accept(stack, &config).await {
                     Ok(channel) => {
@@ -209,7 +209,7 @@ async fn listener_task<'stack, C: crate::Controller, P: PacketPool>(
                             .send(ChannelNotification::Accepted {
                                 writer,
                                 reader,
-                                psm,
+                                spsm,
                                 our_mtu,
                                 our_mps,
                                 peer_mtu,
@@ -220,7 +220,7 @@ async fn listener_task<'stack, C: crate::Controller, P: PacketPool>(
                     }
                     Err(e) => {
                         error!("L2CAP accept failed: {:?}", e);
-                        notify.send(ChannelNotification::Rejected { psm, address }).await;
+                        notify.send(ChannelNotification::Rejected { spsm, address }).await;
                     }
                 }
             }
@@ -236,8 +236,8 @@ async fn channel_task<'stack, C: crate::Controller, P: PacketPool>(
     notify: &NotifyChannel<'stack, P>,
     events: &DynamicSender<'_, Event>,
 ) {
-    let (mut reader, psm, address) = match op {
-        ChannelOp::Connect { conn, psm, mtu } => {
+    let (mut reader, spsm, address) = match op {
+        ChannelOp::Connect { conn, spsm, mtu } => {
             let config = L2capChannelConfig {
                 mtu,
                 mps: Some(64),
@@ -245,11 +245,11 @@ async fn channel_task<'stack, C: crate::Controller, P: PacketPool>(
             };
             let address = conn.peer_address();
 
-            let channel = match L2capChannel::create(stack, &conn, psm, &config).await {
+            let channel = match L2capChannel::create(stack, &conn, spsm, &config).await {
                 Ok(ch) => ch,
                 Err(e) => {
                     error!("L2CAP create failed: {:?}", e);
-                    events.send(Event::L2capDisconnected { chan_id, psm, address }).await;
+                    events.send(Event::L2capDisconnected { chan_id, spsm, address }).await;
                     notify.send(ChannelNotification::Done { chan_id }).await;
                     return;
                 }
@@ -266,7 +266,7 @@ async fn channel_task<'stack, C: crate::Controller, P: PacketPool>(
             events
                 .send(Event::L2capConnected {
                     chan_id,
-                    psm,
+                    spsm,
                     peer_mtu,
                     peer_mps,
                     our_mtu,
@@ -275,9 +275,9 @@ async fn channel_task<'stack, C: crate::Controller, P: PacketPool>(
                 })
                 .await;
 
-            (reader, psm, address)
+            (reader, spsm, address)
         }
-        ChannelOp::Accepted { reader, psm, address } => (reader, psm, address),
+        ChannelOp::Accepted { reader, spsm, address } => (reader, spsm, address),
     };
 
     let mut buf = [0u8; proto::MAX_DATA_SIZE];
@@ -299,7 +299,7 @@ async fn channel_task<'stack, C: crate::Controller, P: PacketPool>(
         }
     }
 
-    events.send(Event::L2capDisconnected { chan_id, psm, address }).await;
+    events.send(Event::L2capDisconnected { chan_id, spsm, address }).await;
     notify.send(ChannelNotification::Done { chan_id }).await;
 }
 
@@ -326,7 +326,12 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                 Either::First(cmd) => {
                     info!("l2cap command: {:?}", *cmd);
                     match &*cmd {
-                        Command::Connect { address, psm, mtu, num } => {
+                        Command::Connect {
+                            address,
+                            spsm,
+                            mtu,
+                            num,
+                        } => {
                             let conn = match stack.get_connection_by_peer_address(*address) {
                                 Some(conn) => conn,
                                 None => {
@@ -351,7 +356,7 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                                     .send((
                                         ChannelOp::Connect {
                                             conn: conn.clone(),
-                                            psm: *psm,
+                                            spsm: *spsm,
                                             mtu: mtu_opt,
                                         },
                                         free_idx as u8,
@@ -420,7 +425,7 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                     ChannelNotification::Accepted {
                         writer,
                         reader,
-                        psm,
+                        spsm,
                         our_mtu,
                         our_mps,
                         peer_mtu,
@@ -440,7 +445,7 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                         events
                             .send(Event::L2capConnected {
                                 chan_id,
-                                psm,
+                                spsm,
                                 peer_mtu,
                                 peer_mps,
                                 our_mtu,
@@ -450,14 +455,14 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                             .await;
 
                         args_tx
-                            .send((ChannelOp::Accepted { reader, psm, address }, chan_id))
+                            .send((ChannelOp::Accepted { reader, spsm, address }, chan_id))
                             .await;
                     }
-                    ChannelNotification::Rejected { psm, address } => {
+                    ChannelNotification::Rejected { spsm, address } => {
                         events
                             .send(Event::L2capDisconnected {
                                 chan_id: 0,
-                                psm,
+                                spsm,
                                 address,
                             })
                             .await;

--- a/tester/app/src/l2cap.rs
+++ b/tester/app/src/l2cap.rs
@@ -7,11 +7,11 @@ use embassy_futures::join::join3;
 use embassy_futures::select::{Either, select};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::{Channel, DynamicSender};
-use embassy_sync::signal::Signal;
 use embassy_sync::watch;
 use trouble_host::prelude::*;
 
 use crate::Event;
+pub(crate) use crate::btp::L2capListenerConfig;
 use crate::btp::protocol::l2cap::{self as proto, MAX_CHANNELS};
 use crate::command_channel::{self, CommandReceiver, HasResponse};
 
@@ -19,11 +19,6 @@ use crate::command_channel::{self, CommandReceiver, HasResponse};
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Command {
-    Listen {
-        psm: u16,
-        mtu: u16,
-        response: LeCreditConnResultCode,
-    },
     Connect {
         address: Address,
         psm: u16,
@@ -43,7 +38,6 @@ pub enum Command {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Response {
-    Listening,
     Connecting(proto::ConnectingResponse),
     Disconnected,
     DataSent,
@@ -75,13 +69,6 @@ impl<P: PacketPool> ChannelSlot<'_, P> {
     fn is_idle(&self) -> bool {
         matches!(self, Self::Idle)
     }
-}
-
-/// Arguments passed to the listener task via signal (one-time config, no connection).
-struct ListenerArgs {
-    psm: u16,
-    mtu: Option<u16>,
-    response: LeCreditConnResultCode,
 }
 
 /// Whether the channel task should create an outgoing channel or receive on an accepted one.
@@ -170,21 +157,23 @@ async fn poll_channels<'stack, C: crate::Controller, P: PacketPool>(
     .await
 }
 
-/// Listener task: waits for listen config, then loops over connections accepting/rejecting
-/// incoming L2CAP channels. When a connection disconnects, listen() returns an error and
-/// the inner loop breaks, waiting for the next connection.
+/// Listener task: loops over connections accepting/rejecting incoming L2CAP channels.
+/// When a connection disconnects, next() returns an error and the inner loop breaks,
+/// waiting for the next connection.
 async fn listener_task<'stack, C: crate::Controller, P: PacketPool>(
     stack: &'stack Stack<'_, C, P>,
-    listener_signal: &Signal<NoopRawMutex, ListenerArgs>,
+    args: L2capListenerConfig,
     conn_rx: &mut watch::DynReceiver<'_, Connection<'stack, P>>,
     notify: &NotifyChannel<'stack, P>,
 ) {
-    let ListenerArgs { psm, mtu, response } = listener_signal.wait().await;
+    let L2capListenerConfig { psm, mtu, response } = args;
 
     loop {
         // Wait for a connection to become available
         let conn = conn_rx.changed().await;
         info!("listener_task: connection available, listening on PSM {}", psm);
+
+        let listener = L2capChannel::listen(stack, &conn);
 
         // Listen on this connection until it disconnects
         loop {
@@ -194,9 +183,8 @@ async fn listener_task<'stack, C: crate::Controller, P: PacketPool>(
                 ..Default::default()
             };
             let address = conn.peer_address();
-            let psm_list = [psm];
 
-            let pending = match L2capChannel::listen(stack, &conn, &psm_list).await {
+            let pending = match listener.next().await {
                 Ok(pending) => pending,
                 Err(e) => {
                     info!("L2CAP listen ended (connection lost or error): {:?}", e);
@@ -323,12 +311,12 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
     commands: CommandReceiver<'_, Command>,
     events: DynamicSender<'_, Event>,
     conn_rx: &mut watch::DynReceiver<'_, Connection<'stack, P>>,
+    listener_config: Option<L2capListenerConfig>,
 ) -> ! {
     trace!("l2cap::run");
 
     let args_tx: Channel<NoopRawMutex, (ChannelOp<'stack, P>, u8), MAX_CHANNELS> = Channel::new();
     let notify_ch: NotifyChannel<'stack, P> = Channel::new();
-    let listener_signal: Signal<NoopRawMutex, ListenerArgs> = Signal::new();
 
     let command_loop = async {
         let mut slots: [ChannelSlot<'stack, P>; MAX_CHANNELS] = Default::default();
@@ -338,15 +326,6 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                 Either::First(cmd) => {
                     info!("l2cap command: {:?}", *cmd);
                     match &*cmd {
-                        Command::Listen { psm, mtu, response } => {
-                            let mtu_opt = if *mtu > 0 { Some(*mtu) } else { None };
-                            listener_signal.signal(ListenerArgs {
-                                psm: *psm,
-                                mtu: mtu_opt,
-                                response: *response,
-                            });
-                            cmd.reply(Response::Listening).await;
-                        }
                         Command::Connect { address, psm, mtu, num } => {
                             let conn = match stack.get_connection_by_peer_address(*address) {
                                 Some(conn) => conn,
@@ -488,9 +467,17 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
         }
     };
 
+    let listener_future = async {
+        if let Some(config) = listener_config {
+            listener_task(stack, config, conn_rx, &notify_ch).await;
+        } else {
+            core::future::pending::<()>().await;
+        }
+    };
+
     join3(
         poll_channels(stack, &args_tx, &notify_ch, &events),
-        listener_task(stack, &listener_signal, conn_rx, &notify_ch),
+        listener_future,
         command_loop,
     )
     .await;

--- a/tester/app/src/lib.rs
+++ b/tester/app/src/lib.rs
@@ -347,9 +347,14 @@ where
 
     // Build the stack, applying deferred GAP settings to the builder
     let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
-    let builder = trouble_host::new(controller, &mut resources)
+    let mut builder = trouble_host::new(controller, &mut resources)
         .set_random_address(config.address)
         .set_random_generator_seed(&mut random_generator);
+
+    if let Some(ref listener_config) = pre.l2cap_listener {
+        builder = builder.register_l2cap_psm(listener_config.psm);
+    }
+
     let builder = pre.gap.apply_to_builder(builder);
     let stack = builder.build();
     let runner = stack.runner();
@@ -388,6 +393,7 @@ where
             CommandReceiver::new(l2cap_command.receiver(), response.sender()),
             events.dyn_sender(),
             &mut l2cap_rx,
+            pre.l2cap_listener,
         ),
         select5(
             ble_task(runner, events.dyn_sender(), &scan_mode),

--- a/tester/app/src/lib.rs
+++ b/tester/app/src/lib.rs
@@ -205,7 +205,7 @@ pub(crate) enum Event {
     },
     L2capConnected {
         chan_id: u8,
-        psm: u16,
+        spsm: u16,
         peer_mtu: u16,
         peer_mps: u16,
         our_mtu: u16,
@@ -214,7 +214,7 @@ pub(crate) enum Event {
     },
     L2capDisconnected {
         chan_id: u8,
-        psm: u16,
+        spsm: u16,
         address: Address,
     },
     L2capDataReceived {
@@ -352,7 +352,7 @@ where
         .set_random_generator_seed(&mut random_generator);
 
     if let Some(ref listener_config) = pre.l2cap_listener {
-        builder = builder.register_l2cap_psm(listener_config.psm);
+        builder = builder.register_l2cap_spsm(listener_config.spsm);
     }
 
     let builder = pre.gap.apply_to_builder(builder);


### PR DESCRIPTION
Fixes #563 by adding a `L2capChannelListener` that manages a `l2cap_listening` flag on the `Connection`. Also makes L2CAP PSM registration global so we don't have to track which SPSMs are registered for each connection. If finer-grained control is needed, users can register all SPSMs that might be supported then use `L2capPendingConnection::reject(LeCreditConnResultCode::SpsmNotSupported)` on a case-by-case basis.

I've also done a refactoring to rename all uses of "PSM" to "SPSM" to make it clear that we are using Simplified Protocol/Service Multiplexer values rather than the old BR/EDR Protocol/Service Multiplexer values.

Finally, I implemented a timeout for L2CAP channel connection requests per the spec.