### PR TITLE
Fix variable-length attribute length when writing full capacity

### DIFF
--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -608,11 +608,12 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
 
     /// Set the value of a characteristic
     ///
-    /// The provided data must exactly match the size of the storage for the characteristic,
-    /// otherwise this function will panic.
+    /// For fixed-length values, the provided data must exactly match the storage size.
+    /// For variable-length values, any length up to the configured capacity is accepted.
     ///
-    /// If the characteristic for the handle cannot be found, or the shape of the data does not match the type of the characterstic,
-    /// an error is returned
+    /// Returns an error if the characteristic cannot be found, if the input length is
+    /// incompatible with the characteristic storage, or if the data shape does not
+    /// match the characteristic type.
     pub fn set<T: AttributeHandle>(&self, attribute_handle: &T, input: &T::Value) -> Result<(), Error> {
         let gatt_value = input.as_gatt();
         self.set_raw(attribute_handle.handle(), gatt_value)

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -553,12 +553,12 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
                 let expected_len = value.len();
                 let actual_len = input.len();
 
-                if expected_len == actual_len {
-                    value.copy_from_slice(input);
-                    Ok(())
-                } else if *variable_len && actual_len <= expected_len {
+                if *variable_len && actual_len <= expected_len {
                     value[..input.len()].copy_from_slice(input);
                     *len = input.len() as u16;
+                    Ok(())
+                } else if expected_len == actual_len {
+                    value.copy_from_slice(input);
                     Ok(())
                 } else {
                     Err(Error::UnexpectedDataLength {
@@ -577,12 +577,12 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
                 let expected_len = usize::from(*capacity);
                 let actual_len = input.len();
 
-                if expected_len == actual_len {
-                    value[..expected_len].copy_from_slice(input);
-                    Ok(())
-                } else if *variable_len && actual_len <= expected_len {
+                if *variable_len && actual_len <= expected_len {
                     value[..input.len()].copy_from_slice(input);
                     *len = input.len() as u8;
+                    Ok(())
+                } else if expected_len == actual_len {
+                    value[..expected_len].copy_from_slice(input);
                     Ok(())
                 } else {
                     Err(Error::UnexpectedDataLength {
@@ -1881,5 +1881,61 @@ mod tests {
             "\nexpected: {:#032x}\n  actual: {:#032x}",
             expected, actual
         );
+    }
+
+    #[test]
+    fn set_updates_variable_length_when_value_fills_backing_storage() {
+        use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+        use heapless::Vec;
+
+        use super::*;
+
+        let mut storage = [0u8; 4];
+        let mut table: AttributeTable<'_, NoopRawMutex, 4> = AttributeTable::new();
+        let initial = Vec::<u8, 4>::from_slice(b"ab").unwrap();
+        let characteristic = table
+            .add_service(Service {
+                uuid: Uuid::new_long([0x10; 16]),
+            })
+            .add_characteristic(
+                Uuid::new_long([0x11; 16]),
+                [CharacteristicProp::Read, CharacteristicProp::Write],
+                initial,
+                &mut storage,
+            )
+            .build();
+
+        let replacement = Vec::<u8, 4>::from_slice(b"wxyz").unwrap();
+        table.set(&characteristic, &replacement).unwrap();
+
+        let stored: Vec<u8, 4> = table.get(&characteristic).unwrap();
+        assert_eq!(stored.as_slice(), b"wxyz");
+    }
+
+    #[test]
+    fn set_updates_small_variable_length_when_value_reaches_capacity() {
+        use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+        use heapless::String;
+
+        use super::*;
+
+        let mut table: AttributeTable<'_, NoopRawMutex, 4> = AttributeTable::new();
+        let initial = String::<8>::try_from("hi").unwrap();
+        let characteristic = table
+            .add_service(Service {
+                uuid: Uuid::new_long([0x12; 16]),
+            })
+            .add_characteristic_small(
+                Uuid::new_long([0x13; 16]),
+                [CharacteristicProp::Read, CharacteristicProp::Write],
+                initial,
+            )
+            .build();
+
+        let replacement = String::<8>::try_from("12345678").unwrap();
+        table.set(&characteristic, &replacement).unwrap();
+
+        let stored: String<8> = table.get(&characteristic).unwrap();
+        assert_eq!(stored.as_str(), "12345678");
     }
 }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -1909,7 +1909,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_without_response_surfaces_gatt_write_event() {
+    fn test_write_command_surfaces_gatt_write_event_without_att_response() {
         let _ = env_logger::try_init();
 
         const MAX_ATTRIBUTES: usize = 16;
@@ -1956,11 +1956,11 @@ mod tests {
                 let reply = write.accept().unwrap();
                 assert!(
                     reply.att_payload().is_none(),
-                    "write without response must not generate an ATT response"
+                    "write command must not generate an ATT response"
                 );
                 core::mem::forget(reply);
             }
-            _ => panic!("expected write event for write_without_response"),
+            _ => panic!("expected write event for write command"),
         }
 
         let stored: u8 = server.table().get(&characteristic).unwrap();

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -1780,6 +1780,17 @@ mod tests {
         (packet, len)
     }
 
+    /// Build a Write Command ATT PDU (ATT payload only, no L2CAP header).
+    fn build_write_cmd_pdu(handle: u16, data: &[u8]) -> (<DefaultPacketPool as PacketPool>::Packet, usize) {
+        let att = Att::Client(AttClient::Command(AttCmd::Write { handle, data }));
+
+        let mut packet = DefaultPacketPool::allocate().unwrap();
+        let mut w = WriteCursor::new(packet.as_mut());
+        w.write(att).unwrap();
+        let len = w.len();
+        (packet, len)
+    }
+
     /// Regression test: process_accept must not produce ReadByType responses
     /// with partial entries when the ATT MTU is smaller than the packet pool
     /// buffer.
@@ -1895,5 +1906,64 @@ mod tests {
             "should discover all {} characteristics",
             NUM_CHARACTERISTICS,
         );
+    }
+
+    #[test]
+    fn test_write_without_response_surfaces_gatt_write_event() {
+        let _ = env_logger::try_init();
+
+        const MAX_ATTRIBUTES: usize = 16;
+        const CONNECTIONS_MAX: usize = 3;
+        const CCCD_MAX: usize = 16;
+
+        let mut table: AttributeTable<'_, NoopRawMutex, MAX_ATTRIBUTES> = AttributeTable::new();
+        let mut storage = [0u8; 1];
+        let characteristic: Characteristic<u8> = table
+            .add_service(Service {
+                uuid: Uuid::new_long([0x44; 16]),
+            })
+            .add_characteristic(
+                Uuid::new_long([0x45; 16]),
+                &[CharacteristicProp::Read, CharacteristicProp::WriteWithoutResponse],
+                0u8,
+                &mut storage[..],
+            )
+            .build();
+        let server = AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CCCD_MAX, CONNECTIONS_MAX>::new(table);
+
+        let mgr = setup();
+        assert!(mgr.poll_accept(LeConnRole::Peripheral, &[], None).is_pending());
+        unwrap!(mgr.connect(
+            ConnHandle::new(0),
+            AddrKind::RANDOM,
+            BdAddr::new(ADDR_1),
+            LeConnRole::Peripheral,
+            ConnParams::new(),
+        ));
+        let Poll::Ready(conn) = mgr.poll_accept(LeConnRole::Peripheral, &[], None) else {
+            panic!("expected connection to be accepted");
+        };
+
+        let payload = [0x2a];
+        let (packet, len) = build_write_cmd_pdu(characteristic.handle, &payload);
+        let pdu = Pdu::new(packet, len);
+
+        let event = GattEvent::new(GattData::new(pdu, conn.clone()), &server);
+        match event {
+            GattEvent::Write(write) => {
+                assert_eq!(write.handle(), characteristic.handle);
+                assert_eq!(write.data(), &payload);
+                let reply = write.accept().unwrap();
+                assert!(
+                    reply.att_payload().is_none(),
+                    "write without response must not generate an ATT response"
+                );
+                core::mem::forget(reply);
+            }
+            _ => panic!("expected write event for write_without_response"),
+        }
+
+        let stored: u8 = server.table().get(&characteristic).unwrap();
+        assert_eq!(stored, payload[0]);
     }
 }


### PR DESCRIPTION
First of all, thanks for working on this crate! I can't believe how well the first attempt went with trouble + nrf-sdc on nRF54L15.

In order to support my use case, this change was required. I hit this while using variable-length characteristic values for a streaming use case, where values could grow up to the configured capacity.

Tests added:
- regression test for variable-length backing storage reaching capacity
- regression test for small variable-length inline storage reaching capacity

I also added a small GATT test covering the write-command/no-response path, although that coverage is not specific to the `set()` fix itself.
