### PR TITLE
feat(gatt): Support arbitrary client-specific attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ host-macros/Cargo.lock
 bt-hci-linux/Cargo.lock
 bt-hci-usb/Cargo.lock
 examples/apps/Cargo.lock
+examples/tests/bins
 tester/app/Cargo.lock
 .idea
 /tests/

--- a/docs/pages/gatt.adoc
+++ b/docs/pages/gatt.adoc
@@ -94,7 +94,7 @@ loop {
             match &event {
                 GattEvent::Read(event) => {
                     if event.handle() == level.handle {
-                        let value = server.get(&level);
+                        let value = conn.get(&level);
                         info!("Read battery level: {:?}", value);
                     }
                 }

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -111,7 +111,7 @@ async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnect
                 match &event {
                     GattEvent::Read(event) => {
                         if event.handle() == level.handle {
-                            let value = server.get(&level);
+                            let value = conn.get(&level);
                             info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                         }
                     }

--- a/examples/apps/src/ble_bas_peripheral_auth.rs
+++ b/examples/apps/src/ble_bas_peripheral_auth.rs
@@ -148,7 +148,7 @@ where
                 let result = match &event {
                     GattEvent::Read(event) => {
                         if event.handle() == level.handle {
-                            let value = server.get(&level);
+                            let value = conn.get(&level);
                             info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                         }
                         #[cfg(feature = "security")]

--- a/examples/apps/src/ble_bas_peripheral_bonding.rs
+++ b/examples/apps/src/ble_bas_peripheral_bonding.rs
@@ -188,7 +188,7 @@ async fn gatt_events_task<S: NorFlash>(
                 match &event {
                     GattEvent::Read(event) => {
                         if event.handle() == level.handle {
-                            let value = server.get(&level);
+                            let value = conn.get(&level);
                             info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                         }
                     }

--- a/examples/apps/src/ble_bas_peripheral_pass_key.rs
+++ b/examples/apps/src/ble_bas_peripheral_pass_key.rs
@@ -127,7 +127,7 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
                 match &event {
                     GattEvent::Read(event) => {
                         if event.handle() == level.handle {
-                            let value = server.get(&level);
+                            let value = conn.get(&level);
                             info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                         }
                     }

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -128,7 +128,7 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
                 match &event {
                     GattEvent::Read(event) => {
                         if event.handle() == level.handle {
-                            let value = server.get(&level);
+                            let value = conn.get(&level);
                             info!("[gatt] Read Event to Level Characteristic: {:?}", value);
                         }
                     }

--- a/host-macros/src/server.rs
+++ b/host-macros/src/server.rs
@@ -15,7 +15,7 @@ pub(crate) struct ServerArgs {
     mutex_type: Option<syn::Type>,
     packet_type: Option<syn::Type>,
     attribute_table_size: Option<Expr>,
-    cccd_table_size: Option<Expr>,
+    client_att_table_size: Option<Expr>,
     connections_max: Option<Expr>,
 }
 
@@ -53,11 +53,11 @@ impl ServerArgs {
                 })?;
                 self.attribute_table_size = Some(buffer.parse()?);
             }
-            "cccd_table_size" => {
+            "client_att_table_size" => {
                 let buffer = meta.value().map_err(|_| {
-                    Error::custom("cccd_table_size must be followed by `= [size]`. e.g. cccd_table_size = 4".to_string())
+                    Error::custom("client_att_table_size must be followed by `= [size]`. e.g. client_att_table_size = 4".to_string())
                 })?;
-                self.cccd_table_size = Some(buffer.parse()?);
+                self.client_att_table_size = Some(buffer.parse()?);
             }
             "connections_max" => {
                 let buffer = meta.value().map_err(|_| {
@@ -66,7 +66,7 @@ impl ServerArgs {
                 self.connections_max = Some(buffer.parse()?);
             }
             other => return Err(meta.error(format!(
-                "Unsupported server property: '{other}'.\nSupported properties are: mutex_type, packet_type, attribute_table_size, cccd_table_size, connections_max"
+                "Unsupported server property: '{other}'.\nSupported properties are: mutex_type, packet_type, attribute_table_size, client_att_table_size, connections_max"
             ))),
         }
         Ok(())
@@ -135,10 +135,10 @@ impl ServerBuilder {
             parse_quote!(trouble_host::gap::GAP_SERVICE_ATTRIBUTE_COUNT #code_attribute_summation)
         };
 
-        let cccd_table_size = if let Some(value) = self.arguments.cccd_table_size {
+        let client_att_table_size = if let Some(value) = self.arguments.client_att_table_size {
             value
         } else {
-            parse_quote!(0 #code_cccd_summation)
+            parse_quote!(2 + 6 * (0 #code_cccd_summation))
         };
 
         let connections_max = if let Some(value) = self.arguments.connections_max {
@@ -153,12 +153,12 @@ impl ServerBuilder {
             const _: () = {
                 core::assert!(_ATTRIBUTE_TABLE_SIZE >= trouble_host::gap::GAP_SERVICE_ATTRIBUTE_COUNT #code_attribute_summation, "Specified attribute table size is insufficient. Please increase attribute_table_size or remove the argument entirely to allow automatic sizing of the attribute table.");
             };
-            const _CCCD_TABLE_SIZE: usize = #cccd_table_size;
+            const _CLIENT_ATT_TABLE_SIZE: usize = #client_att_table_size;
             const _CONNECTIONS_MAX: usize = #connections_max;
 
             #visibility struct #name<'values>
             {
-                pub server: trouble_host::prelude::AttributeServer<'values, #mutex_type, #packet_type, _ATTRIBUTE_TABLE_SIZE, _CCCD_TABLE_SIZE, _CONNECTIONS_MAX>,
+                pub server: trouble_host::prelude::AttributeServer<'values, #mutex_type, #packet_type, _ATTRIBUTE_TABLE_SIZE, _CLIENT_ATT_TABLE_SIZE, _CONNECTIONS_MAX>,
                 #code_service_definition
             }
 
@@ -220,18 +220,18 @@ impl ServerBuilder {
                     self.server.table().set(attribute_handle, input)
                 }
 
-                #visibility fn get_cccd_table(&self, connection: &trouble_host::connection::Connection<'_, #packet_type>) -> Option<trouble_host::prelude::CccdTable<_CCCD_TABLE_SIZE>> {
-                    self.server.get_cccd_table(connection)
+                #visibility fn get_client_att_table(&self, connection: &trouble_host::connection::Connection<'_, #packet_type>) -> Option<trouble_host::prelude::ClientAttTable<_CLIENT_ATT_TABLE_SIZE>> {
+                    self.server.get_client_att_table(connection)
                 }
 
-                #visibility fn set_cccd_table(&self, connection: &trouble_host::connection::Connection<'_, #packet_type>, table: trouble_host::prelude::CccdTable<_CCCD_TABLE_SIZE>) {
-                    self.server.set_cccd_table(connection, table);
+                #visibility fn set_client_att_table(&self, connection: &trouble_host::connection::Connection<'_, #packet_type>, table: &trouble_host::prelude::ClientAttTable<_CLIENT_ATT_TABLE_SIZE>) {
+                    self.server.set_client_att_table(connection, table);
                 }
             }
 
             impl<'values> core::ops::Deref for #name<'values>
             {
-                type Target = trouble_host::prelude::AttributeServer<'values, #mutex_type, #packet_type, _ATTRIBUTE_TABLE_SIZE, _CCCD_TABLE_SIZE, _CONNECTIONS_MAX>;
+                type Target = trouble_host::prelude::AttributeServer<'values, #mutex_type, #packet_type, _ATTRIBUTE_TABLE_SIZE, _CLIENT_ATT_TABLE_SIZE, _CONNECTIONS_MAX>;
 
                 fn deref(&self) -> &Self::Target {
                     &self.server

--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -172,7 +172,7 @@ impl ServiceBuilder {
             #(#cfg_attr)*
             let (#char_name, #(#named_descriptors),*) = {
                 #[allow(clippy::absurd_extreme_comparisons)]
-                let mut builder = if <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE <= 20 {
+                let mut builder = if <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE <= trouble_host::attribute::MAX_SMALL_DATA_SIZE {
                     service.add_characteristic_small(#uuid, [#(#properties),*], #default_value)
                 } else {
                     static #name_screaming: static_cell::StaticCell<[u8; <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE]> = static_cell::StaticCell::new();
@@ -361,7 +361,7 @@ impl ServiceBuilder {
                             #identifier_assignment {
                                 const #capacity_screaming: usize = #capacity;
                                 #[allow(clippy::absurd_extreme_comparisons)]
-                                if #capacity_screaming <= 20 {
+                                if #capacity_screaming <= trouble_host::attribute::MAX_SMALL_DATA_SIZE {
                                     builder.add_descriptor_small(
                                         #uuid,
                                         #permissions,

--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -172,7 +172,7 @@ impl ServiceBuilder {
             #(#cfg_attr)*
             let (#char_name, #(#named_descriptors),*) = {
                 #[allow(clippy::absurd_extreme_comparisons)]
-                let mut builder = if <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE <= 8 {
+                let mut builder = if <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE <= 20 {
                     service.add_characteristic_small(#uuid, [#(#properties),*], #default_value)
                 } else {
                     static #name_screaming: static_cell::StaticCell<[u8; <#ty as trouble_host::types::gatt_traits::AsGatt>::MAX_SIZE]> = static_cell::StaticCell::new();
@@ -361,7 +361,7 @@ impl ServiceBuilder {
                             #identifier_assignment {
                                 const #capacity_screaming: usize = #capacity;
                                 #[allow(clippy::absurd_extreme_comparisons)]
-                                if #capacity_screaming <= 8 {
+                                if #capacity_screaming <= 20 {
                                     builder.add_descriptor_small(
                                         #uuid,
                                         #permissions,

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -208,7 +208,10 @@ pub(crate) enum AttributeData<'d> {
         len: u8,
         value: [u8; MAX_SMALL_DATA_SIZE],
     },
-    ClientSpecific(u16),
+    ClientSpecific {
+        variable_len: bool,
+        capacity: u16,
+    },
 }
 
 impl From<Uuid> for AttributeData<'_> {
@@ -282,7 +285,7 @@ impl AttributeData<'_> {
             AttributeData::ReadOnlyData { value } => Some(value),
             AttributeData::Data { len, value, .. } => Some(&value[..*len as usize]),
             AttributeData::SmallData { len, value, .. } => Some(&value[..*len as usize]),
-            AttributeData::ClientSpecific(_) => None,
+            AttributeData::ClientSpecific { .. } => None,
         }
     }
 
@@ -311,7 +314,7 @@ impl AttributeData<'_> {
                 let value = &value[..*len as usize];
                 append(value, &mut offset, &mut data)
             }
-            Self::ClientSpecific(_) => return Err(AttErrorCode::UNLIKELY_ERROR),
+            Self::ClientSpecific { .. } => return Err(AttErrorCode::UNLIKELY_ERROR),
         };
 
         if offset > 0 {
@@ -814,7 +817,10 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
                         #[cfg(feature = "legacy-pairing")]
                         min_key_len: 0,
                     },
-                    AttributeData::ClientSpecific(2),
+                    AttributeData::ClientSpecific {
+                        variable_len: false,
+                        capacity: 2,
+                    },
                 ));
 
                 Some(handle)
@@ -1703,7 +1709,10 @@ mod tests {
         table.push(Attribute::new(
             CLIENT_CHARACTERISTIC_CONFIGURATION,
             cccd_perms,
-            AttributeData::ClientSpecific(2),
+            AttributeData::ClientSpecific {
+                variable_len: false,
+                capacity: 2,
+            },
         ));
 
         // Client supported features characteristic
@@ -1770,7 +1779,10 @@ mod tests {
         table.push(Attribute::new(
             CLIENT_CHARACTERISTIC_CONFIGURATION,
             cccd_perms,
-            AttributeData::ClientSpecific(2),
+            AttributeData::ClientSpecific {
+                variable_len: false,
+                capacity: 2,
+            },
         ));
 
         table.push(Attribute::new(

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -11,7 +11,7 @@ use heapless::Vec;
 
 use crate::att::{AttErrorCode, AttUns};
 use crate::attribute_server::AttributeServer;
-use crate::cursor::ReadCursor;
+use crate::cursor::{ReadCursor, WriteCursor};
 use crate::prelude::{AsGatt, FixedGattValue, FromGatt, GattConnection, SecurityLevel};
 use crate::types::gatt_traits::FromGattError;
 pub use crate::types::uuid::Uuid;
@@ -68,6 +68,15 @@ pub struct AttPermissions {
 }
 
 impl AttPermissions {
+    pub(crate) fn read_only() -> Self {
+        Self {
+            read: PermissionLevel::Allowed,
+            write: PermissionLevel::NotAllowed,
+            #[cfg(feature = "legacy-pairing")]
+            min_key_len: 0,
+        }
+    }
+
     pub(crate) fn can_read(
         &self,
         level: SecurityLevel,
@@ -119,9 +128,40 @@ impl AttPermissions {
     }
 }
 
+/// A GATT characteristic declaration value.
+pub(crate) struct CharacteristicDeclaration {
+    pub props: CharacteristicProps,
+    pub value_handle: u16,
+    pub uuid: Uuid,
+}
+
+impl CharacteristicDeclaration {
+    pub(crate) fn new<U: Into<Uuid>, P: Into<CharacteristicProps>>(props: P, value_handle: u16, uuid: U) -> Self {
+        Self {
+            props: props.into(),
+            value_handle,
+            uuid: uuid.into(),
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for CharacteristicDeclaration {
+    type Error = Error;
+
+    fn try_from(data: &'_ [u8]) -> Result<Self, Self::Error> {
+        let mut r = ReadCursor::new(data);
+        Ok(CharacteristicDeclaration {
+            props: CharacteristicProps(r.read()?),
+            value_handle: r.read()?,
+            uuid: Uuid::try_from(r.remaining())?,
+        })
+    }
+}
+
 /// Attribute metadata.
 pub struct Attribute<'a> {
     pub(crate) uuid: Uuid,
+    pub(crate) permissions: AttPermissions,
     pub(crate) data: AttributeData<'a>,
 }
 
@@ -137,79 +177,110 @@ impl<'a> Attribute<'a> {
     }
 
     pub(crate) fn permissions(&self) -> AttPermissions {
-        self.data.permissions()
+        self.permissions
+    }
+
+    pub(crate) fn readable(&self) -> bool {
+        self.permissions.read != PermissionLevel::NotAllowed
+    }
+
+    pub(crate) fn writable(&self) -> bool {
+        self.permissions.write != PermissionLevel::NotAllowed
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum AttributeData<'d> {
-    Service {
-        uuid: Uuid,
-        last_handle_in_group: u16,
-    },
-    IncludedService {
-        handle: u16,
-        last_handle_in_group: u16,
-        uuid: Option<[u8; 2]>,
-    },
     ReadOnlyData {
-        permissions: AttPermissions,
         value: &'d [u8],
     },
     Data {
-        permissions: AttPermissions,
         variable_len: bool,
         len: u16,
         value: &'d mut [u8],
     },
     SmallData {
-        permissions: AttPermissions,
         variable_len: bool,
         capacity: u8,
         len: u8,
-        value: [u8; 8],
+        value: [u8; 20],
     },
-    Declaration {
-        props: CharacteristicProps,
-        handle: u16,
-        uuid: Uuid,
-    },
-    Cccd {
-        notifications: bool,
-        indications: bool,
-        write_permission: PermissionLevel,
-    },
+    ClientSpecific,
+}
+
+impl From<Uuid> for AttributeData<'_> {
+    fn from(uuid: Uuid) -> Self {
+        let raw = uuid.as_raw();
+        let len = raw.len() as u8;
+        let mut value = [0u8; 20];
+        value[..raw.len()].copy_from_slice(raw);
+        AttributeData::SmallData {
+            variable_len: false,
+            capacity: len,
+            len,
+            value,
+        }
+    }
+}
+
+impl From<bt_hci::uuid::BluetoothUuid16> for AttributeData<'_> {
+    fn from(uuid: bt_hci::uuid::BluetoothUuid16) -> Self {
+        let raw = uuid.to_le_bytes();
+        let len = raw.len() as u8;
+        let mut value = [0u8; 20];
+        value[..raw.len()].copy_from_slice(&raw);
+        AttributeData::SmallData {
+            variable_len: false,
+            capacity: len,
+            len,
+            value,
+        }
+    }
+}
+
+impl From<bt_hci::uuid::BluetoothUuid128> for AttributeData<'_> {
+    fn from(uuid: bt_hci::uuid::BluetoothUuid128) -> Self {
+        let raw = uuid.to_le_bytes();
+        let len = raw.len() as u8;
+        let mut value = [0u8; 20];
+        value[..raw.len()].copy_from_slice(&raw);
+        AttributeData::SmallData {
+            variable_len: false,
+            capacity: len,
+            len,
+            value,
+        }
+    }
+}
+
+impl From<CharacteristicDeclaration> for AttributeData<'_> {
+    fn from(decl: CharacteristicDeclaration) -> Self {
+        let uuid_raw = decl.uuid.as_raw();
+        let total_len = 1 + 2 + uuid_raw.len(); // props + handle + uuid
+        debug_assert!(total_len <= 20);
+        let mut value = [0u8; 20];
+        value[0] = decl.props.0;
+        value[1..3].copy_from_slice(&decl.value_handle.to_le_bytes());
+        value[3..3 + uuid_raw.len()].copy_from_slice(uuid_raw);
+        let len = total_len as u8;
+        AttributeData::SmallData {
+            variable_len: false,
+            capacity: len,
+            len,
+            value,
+        }
+    }
 }
 
 impl AttributeData<'_> {
-    pub(crate) fn permissions(&self) -> AttPermissions {
+    /// Get the byte value of the attribute data.
+    pub(crate) fn value(&self) -> Option<&[u8]> {
         match self {
-            AttributeData::Service { .. }
-            | AttributeData::IncludedService { .. }
-            | AttributeData::Declaration { .. } => AttPermissions {
-                read: PermissionLevel::Allowed,
-                write: PermissionLevel::NotAllowed,
-                #[cfg(feature = "legacy-pairing")]
-                min_key_len: 0,
-            },
-            AttributeData::ReadOnlyData { permissions, .. }
-            | AttributeData::Data { permissions, .. }
-            | AttributeData::SmallData { permissions, .. } => *permissions,
-            AttributeData::Cccd { write_permission, .. } => AttPermissions {
-                read: PermissionLevel::Allowed,
-                write: *write_permission,
-                #[cfg(feature = "legacy-pairing")]
-                min_key_len: 0,
-            },
+            AttributeData::ReadOnlyData { value } => Some(value),
+            AttributeData::Data { len, value, .. } => Some(&value[..*len as usize]),
+            AttributeData::SmallData { len, value, .. } => Some(&value[..*len as usize]),
+            AttributeData::ClientSpecific => None,
         }
-    }
-
-    pub(crate) fn readable(&self) -> bool {
-        self.permissions().read != PermissionLevel::NotAllowed
-    }
-
-    pub(crate) fn writable(&self) -> bool {
-        self.permissions().write != PermissionLevel::NotAllowed
     }
 
     fn read(&self, mut offset: usize, mut data: &mut [u8]) -> Result<usize, AttErrorCode> {
@@ -228,7 +299,7 @@ impl AttributeData<'_> {
         }
 
         let written = match self {
-            Self::ReadOnlyData { value, .. } => append(value, &mut offset, &mut data),
+            Self::ReadOnlyData { value } => append(value, &mut offset, &mut data),
             Self::Data { len, value, .. } => {
                 let value = &value[..*len as usize];
                 append(value, &mut offset, &mut data)
@@ -237,44 +308,7 @@ impl AttributeData<'_> {
                 let value = &value[..*len as usize];
                 append(value, &mut offset, &mut data)
             }
-            Self::Service { uuid, .. } => {
-                let val = uuid.as_raw();
-                append(val, &mut offset, &mut data)
-            }
-            Self::IncludedService {
-                handle,
-                last_handle_in_group,
-                uuid,
-            } => {
-                let written = append(&handle.to_le_bytes(), &mut offset, &mut data)
-                    + append(&last_handle_in_group.to_le_bytes(), &mut offset, &mut data);
-                if let Some(uuid) = uuid {
-                    written + append(uuid, &mut offset, &mut data)
-                } else {
-                    written
-                }
-            }
-            Self::Cccd {
-                notifications,
-                indications,
-                ..
-            } => {
-                let mut v = 0u16;
-                if *notifications {
-                    v |= 0x01;
-                }
-
-                if *indications {
-                    v |= 0x02;
-                }
-                append(&v.to_le_bytes(), &mut offset, &mut data)
-            }
-            Self::Declaration { props, handle, uuid } => {
-                let val = uuid.as_raw();
-                append(&[props.0], &mut offset, &mut data)
-                    + append(&handle.to_le_bytes(), &mut offset, &mut data)
-                    + append(val, &mut offset, &mut data)
-            }
+            Self::ClientSpecific => return Err(AttErrorCode::UNLIKELY_ERROR),
         };
 
         if offset > 0 {
@@ -290,7 +324,6 @@ impl AttributeData<'_> {
                 value,
                 variable_len,
                 len,
-                ..
             } => {
                 if offset > value.len() {
                     Err(AttErrorCode::INVALID_OFFSET)
@@ -309,7 +342,6 @@ impl AttributeData<'_> {
                 capacity,
                 len,
                 value,
-                ..
             } => {
                 if offset > usize::from(*capacity) {
                     Err(AttErrorCode::INVALID_OFFSET)
@@ -323,34 +355,8 @@ impl AttributeData<'_> {
                     Ok(())
                 }
             }
-            Self::Cccd {
-                notifications,
-                indications,
-                ..
-            } => {
-                if offset > 0 {
-                    return Err(AttErrorCode::INVALID_OFFSET);
-                }
-
-                if data.is_empty() {
-                    return Err(AttErrorCode::UNLIKELY_ERROR);
-                }
-
-                *notifications = data[0] & 0x01 != 0;
-                *indications = data[0] & 0x02 != 0;
-                Ok(())
-            }
             _ => Err(AttErrorCode::WRITE_NOT_PERMITTED),
         }
-    }
-
-    pub(crate) fn decode_declaration(data: &[u8]) -> Result<Self, Error> {
-        let mut r = ReadCursor::new(data);
-        Ok(Self::Declaration {
-            props: CharacteristicProps(r.read()?),
-            handle: r.read()?,
-            uuid: Uuid::try_from(r.remaining())?,
-        })
     }
 }
 
@@ -358,8 +364,8 @@ impl fmt::Debug for Attribute<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Attribute")
             .field("uuid", &self.uuid)
-            .field("readable", &self.data.readable())
-            .field("writable", &self.data.writable())
+            .field("readable", &self.readable())
+            .field("writable", &self.writable())
             .finish()
     }
 }
@@ -372,8 +378,16 @@ impl<'a> defmt::Format for Attribute<'a> {
 }
 
 impl<'a> Attribute<'a> {
-    pub(crate) fn new(uuid: Uuid, data: AttributeData<'a>) -> Attribute<'a> {
-        Attribute { uuid, data }
+    pub(crate) fn new<U: Into<Uuid>, T: Into<AttributeData<'a>>>(
+        uuid: U,
+        permissions: AttPermissions,
+        data: T,
+    ) -> Attribute<'a> {
+        Attribute {
+            uuid: uuid.into(),
+            permissions,
+            data: data.into(),
+        }
     }
 }
 
@@ -391,6 +405,17 @@ impl<'d, const MAX: usize> InnerTable<'d, MAX> {
         let handle = self.next_handle();
         self.attributes.push(attribute).unwrap();
         handle
+    }
+
+    fn iterate_from(&self, pos: usize) -> AttributeIterator<'_, 'd> {
+        AttributeIterator {
+            attributes: &self.attributes,
+            pos,
+        }
+    }
+
+    fn service_group_end(&self, service_handle: u16) -> u16 {
+        self.iterate_from(usize::from(service_handle)).service_group_end()
     }
 
     fn next_handle(&self) -> u16 {
@@ -412,7 +437,14 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
         }
     }
 
-    pub(crate) fn with_inner<F: FnOnce(&mut InnerTable<'d, MAX>) -> R, R>(&self, f: F) -> R {
+    pub(crate) fn with_inner<F: FnOnce(&InnerTable<'d, MAX>) -> R, R>(&self, f: F) -> R {
+        self.inner.lock(|inner| {
+            let table = inner.borrow();
+            f(&table)
+        })
+    }
+
+    pub(crate) fn with_inner_mut<F: FnOnce(&mut InnerTable<'d, MAX>) -> R, R>(&self, f: F) -> R {
         self.inner.lock(|inner| {
             let mut table = inner.borrow_mut();
             f(&mut table)
@@ -420,87 +452,65 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
     }
 
     pub(crate) fn iterate<F: FnOnce(AttributeIterator<'_, 'd>) -> R, R>(&self, f: F) -> R {
-        self.with_inner(|table| {
-            let it = AttributeIterator {
-                attributes: table.attributes.as_mut_slice(),
-                pos: 0,
-            };
-            f(it)
-        })
+        self.with_inner(|table| f(table.iterate_from(0)))
     }
 
-    pub(crate) fn with_attribute<F: FnOnce(&mut Attribute<'d>) -> R, R>(&self, handle: u16, f: F) -> Option<R> {
+    pub(crate) fn with_attribute<F: FnOnce(&Attribute<'d>) -> R, R>(&self, handle: u16, f: F) -> Option<R> {
         if handle == 0 {
             return None;
         }
 
         self.with_inner(|table| {
             let i = usize::from(handle) - 1;
+            table.attributes.get(i).map(f)
+        })
+    }
+
+    pub(crate) fn with_attribute_mut<F: FnOnce(&mut Attribute<'d>) -> R, R>(&self, handle: u16, f: F) -> Option<R> {
+        if handle == 0 {
+            return None;
+        }
+
+        self.with_inner_mut(|table| {
+            let i = usize::from(handle) - 1;
             table.attributes.get_mut(i).map(f)
         })
     }
 
     pub(crate) fn iterate_from<F: FnOnce(AttributeIterator<'_, 'd>) -> R, R>(&self, start: u16, f: F) -> R {
-        self.with_inner(|table| {
-            let it = AttributeIterator {
-                attributes: &mut table.attributes[..],
-                pos: usize::from(start).saturating_sub(1),
-            };
-            f(it)
-        })
+        let i = usize::from(start).saturating_sub(1);
+        self.with_inner(|table| f(table.iterate_from(i)))
     }
 
     fn push(&mut self, attribute: Attribute<'d>) -> u16 {
-        self.with_inner(|table| table.push(attribute))
+        self.with_inner_mut(|table| table.push(attribute))
     }
 
     /// Add a service to the attribute table (group of characteristics)
     pub fn add_service(&mut self, service: Service) -> ServiceBuilder<'_, 'd, M, MAX> {
-        self.close_last_service_group();
-        let handle = self.push(Attribute {
-            uuid: PRIMARY_SERVICE.into(),
-            data: AttributeData::Service {
-                uuid: service.uuid,
-                last_handle_in_group: u16::MAX,
-            },
-        });
+        let handle = self.push(Attribute::new(
+            PRIMARY_SERVICE,
+            AttPermissions::read_only(),
+            service.uuid,
+        ));
         ServiceBuilder { handle, table: self }
     }
 
     /// Add a service to the attribute table (group of characteristics)
     pub fn add_secondary_service(&mut self, service: Service) -> ServiceBuilder<'_, 'd, M, MAX> {
-        self.close_last_service_group();
-        let handle = self.push(Attribute {
-            uuid: SECONDARY_SERVICE.into(),
-            data: AttributeData::Service {
-                uuid: service.uuid,
-                last_handle_in_group: u16::MAX,
-            },
-        });
+        let handle = self.push(Attribute::new(
+            SECONDARY_SERVICE,
+            AttPermissions::read_only(),
+            service.uuid,
+        ));
         ServiceBuilder { handle, table: self }
-    }
-
-    /// Update the last service's `last_handle_in_group` to the current last handle in the table.
-    fn close_last_service_group(&mut self) {
-        self.with_inner(|inner| {
-            let last_handle = inner.next_handle() - 1;
-            for attr in inner.attributes.iter_mut().rev() {
-                if let AttributeData::Service {
-                    last_handle_in_group, ..
-                } = &mut attr.data
-                {
-                    *last_handle_in_group = last_handle;
-                    break;
-                }
-            }
-        });
     }
 
     /// Get the permissions for the attribute
     ///
     /// Returns `None` if the attribute handle is invalid.
     pub fn permissions(&self, attribute: u16) -> Option<AttPermissions> {
-        self.with_attribute(attribute, |att| att.data.permissions())
+        self.with_attribute(attribute, |att| att.permissions())
     }
 
     /// Get the UUID of the attribute type
@@ -511,7 +521,7 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
     }
 
     pub(crate) fn set_ro(&self, attribute: u16, new_value: &'d [u8]) -> Result<(), Error> {
-        self.with_attribute(attribute, |att| match &mut att.data {
+        self.with_attribute_mut(attribute, |att| match &mut att.data {
             AttributeData::ReadOnlyData { value, .. } => {
                 *value = new_value;
                 Ok(())
@@ -538,12 +548,12 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
     /// If the attribute is fixed length, the range `offset..(offset + data.len())` will be
     /// overwritten.
     pub fn write(&self, attribute: u16, offset: usize, data: &[u8]) -> Result<(), Error> {
-        self.with_attribute(attribute, |att| att.write(offset, data).map_err(Into::into))
+        self.with_attribute_mut(attribute, |att| att.write(offset, data).map_err(Into::into))
             .unwrap_or(Err(Error::NotFound))
     }
 
     pub(crate) fn set_raw(&self, attribute: u16, input: &[u8]) -> Result<(), Error> {
-        self.with_attribute(attribute, |att| match &mut att.data {
+        self.with_attribute_mut(attribute, |att| match &mut att.data {
             AttributeData::Data {
                 value,
                 variable_len,
@@ -626,13 +636,7 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
     /// If the characteristic for the handle cannot be found, an error is returned.
     pub fn get<T: AttributeHandle<Value = V>, V: FromGatt>(&self, attribute_handle: &T) -> Result<T::Value, Error> {
         self.with_attribute(attribute_handle.handle(), |att| {
-            let value_slice = match &mut att.data {
-                AttributeData::Data { value, len, .. } => &value[..*len as usize],
-                AttributeData::ReadOnlyData { value, .. } => value,
-                AttributeData::SmallData { len, value, .. } => &value[..usize::from(*len)],
-                _ => return Err(Error::NotSupported),
-            };
-
+            let value_slice = att.data.value().ok_or(Error::NotSupported)?;
             T::Value::from_gatt(value_slice).map_err(|_| {
                 let mut invalid_data = [0u8; MAX_INVALID_DATA_LEN];
                 let len_to_copy = value_slice.len().min(MAX_INVALID_DATA_LEN);
@@ -654,25 +658,15 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
 
         self.iterate_from(handle - 1, |mut it| {
             if let Some((_, att)) = it.next() {
-                if let AttributeData::Declaration { props, uuid, .. } = &att.data {
-                    let props = *props;
-                    let uuid = *uuid;
+                if att.uuid == CHARACTERISTIC.into() {
+                    let decl = CharacteristicDeclaration::try_from(att.data.value().unwrap())?;
+                    let props = decl.props;
+                    let uuid = decl.uuid;
                     if it.next().is_some() {
-                        let cccd_handle = it
-                            .next()
-                            .and_then(|(handle, att)| matches!(att.data, AttributeData::Cccd { .. }).then_some(handle));
-
-                        // Scan forward to find the end of this characteristic's handles
-                        let mut end_handle = cccd_handle.unwrap_or(handle);
-                        while let Some((h, att)) = it.next() {
-                            if matches!(
-                                att.data,
-                                AttributeData::Declaration { .. } | AttributeData::Service { .. }
-                            ) {
-                                break;
-                            }
-                            end_handle = h;
-                        }
+                        let end_handle = it.characteristic_group_end();
+                        let cccd_handle = it.next().and_then(|(handle, att)| {
+                            matches!(att.data, AttributeData::ClientSpecific).then_some(handle)
+                        });
 
                         return Ok(Characteristic {
                             handle,
@@ -718,8 +712,8 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
 
         let mut mac = AesCmac::db_hash();
 
-        self.iterate(|mut it| {
-            while let Some((handle, att)) = it.next() {
+        self.iterate(|it| {
+            for (handle, att) in it {
                 match att.uuid {
                     PRIMARY_SERVICE
                     | SECONDARY_SERVICE
@@ -727,21 +721,8 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
                     | CHARACTERISTIC
                     | CHARACTERISTIC_EXTENDED_PROPERTIES => {
                         mac.update(handle.to_le_bytes()).update(att.uuid.as_raw());
-                        match &att.data {
-                            AttributeData::ReadOnlyData { value, .. } => {
-                                mac.update(value);
-                            }
-                            AttributeData::Data { len, value, .. } => {
-                                mac.update(&value[..usize::from(*len)]);
-                            }
-                            AttributeData::Service { uuid, .. } => {
-                                mac.update(uuid.as_raw());
-                            }
-                            AttributeData::Declaration { props, handle, uuid } => {
-                                mac.update([props.0]).update(handle.to_le_bytes()).update(uuid.as_raw());
-                            }
-                            _ => unreachable!(),
-                        }
+                        let value = att.data.value().unwrap_or(&[]);
+                        mac.update(value);
                     }
                     CHARACTERISTIC_USER_DESCRIPTION
                     | CLIENT_CHARACTERISTIC_CONFIGURATION
@@ -806,35 +787,32 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
         &mut self,
         uuid: Uuid,
         props: CharacteristicProps,
+        permissions: AttPermissions,
         data: AttributeData<'d>,
     ) -> CharacteristicBuilder<'_, 'd, T, M, MAX> {
         let chrc_uuid = uuid;
         // First the characteristic declaration
-        let (handle, cccd_handle) = self.table.with_inner(|table| {
+        let (handle, cccd_handle) = self.table.with_inner_mut(|table| {
             let value_handle = table.next_handle() + 1;
-            table.push(Attribute {
-                uuid: CHARACTERISTIC.into(),
-                data: AttributeData::Declaration {
-                    props,
-                    handle: value_handle,
-                    uuid,
-                },
-            });
+            let declaration = CharacteristicDeclaration::new(props, value_handle, uuid);
+            table.push(Attribute::new(CHARACTERISTIC, AttPermissions::read_only(), declaration));
 
             // Then the value declaration
-            let h = table.push(Attribute { uuid, data });
+            let h = table.push(Attribute::new(uuid, permissions, data));
             debug_assert!(h == value_handle);
 
             // Add optional CCCD handle
             let cccd_handle = if props.has_cccd() {
-                let handle = table.push(Attribute {
-                    uuid: CLIENT_CHARACTERISTIC_CONFIGURATION.into(),
-                    data: AttributeData::Cccd {
-                        notifications: false,
-                        indications: false,
-                        write_permission: PermissionLevel::Allowed,
+                let handle = table.push(Attribute::new(
+                    CLIENT_CHARACTERISTIC_CONFIGURATION,
+                    AttPermissions {
+                        read: PermissionLevel::Allowed,
+                        write: PermissionLevel::Allowed,
+                        #[cfg(feature = "legacy-pairing")]
+                        min_key_len: 0,
                     },
-                });
+                    AttributeData::ClientSpecific,
+                ));
 
                 Some(handle)
             } else {
@@ -875,8 +853,8 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
         self.add_characteristic_internal(
             uuid.into(),
             props,
+            permissions,
             AttributeData::Data {
-                permissions,
                 value: store,
                 variable_len,
                 len,
@@ -884,29 +862,29 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
         )
     }
 
-    /// Add a characteristic to this service using inline storage. The characteristic value must be 8 bytes or less.
+    /// Add a characteristic to this service using inline storage. The characteristic value must be 20 bytes or less.
     pub fn add_characteristic_small<T: AsGatt, U: Into<Uuid>, P: Into<CharacteristicProps>>(
         &mut self,
         uuid: U,
         props: P,
         value: T,
     ) -> CharacteristicBuilder<'_, 'd, T, M, MAX> {
-        assert!(T::MIN_SIZE <= 8);
+        assert!(T::MIN_SIZE <= 20);
 
         let props: CharacteristicProps = props.into();
         let permissions = props.default_permissions();
         let bytes = value.as_gatt();
-        assert!(bytes.len() <= 8);
-        let mut value = [0; 8];
+        assert!(bytes.len() <= 20);
+        let mut value = [0; 20];
         value[..bytes.len()].copy_from_slice(bytes);
         let variable_len = T::MAX_SIZE != T::MIN_SIZE;
-        let capacity = T::MAX_SIZE.min(8) as u8;
+        let capacity = T::MAX_SIZE.min(20) as u8;
         let len = bytes.len() as u8;
         self.add_characteristic_internal(
             uuid.into(),
             props,
+            permissions,
             AttributeData::SmallData {
-                permissions,
                 variable_len,
                 capacity,
                 len,
@@ -926,37 +904,44 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
         self.add_characteristic_internal(
             uuid.into(),
             props,
-            AttributeData::ReadOnlyData {
-                permissions,
-                value: value.as_gatt(),
-            },
+            permissions,
+            AttributeData::ReadOnlyData { value: value.as_gatt() },
         )
     }
 
     /// Add an included service to this service
     pub fn add_included_service(&mut self, handle: u16) -> Result<u16, InvalidHandle> {
-        self.table.with_inner(|table| {
+        self.table.with_inner_mut(|table| {
             if handle > 0 && table.attributes.len() >= usize::from(handle) {
-                if let AttributeData::Service {
-                    uuid,
-                    last_handle_in_group,
-                } = &table.attributes[usize::from(handle) - 1].data
-                {
-                    // Included service values only include 16-bit UUIDs per the Bluetooth spec
-                    let uuid = match uuid {
-                        Uuid::Uuid16(uuid) => Some(*uuid),
-                        Uuid::Uuid32(_) => None,
-                        Uuid::Uuid128(_) => None,
-                    };
+                let i = usize::from(handle - 1);
+                let att = &table.attributes[i];
+                let service_uuid = att.uuid;
+                if service_uuid == Uuid::from(PRIMARY_SERVICE) || service_uuid == Uuid::from(SECONDARY_SERVICE) {
+                    let last_handle_in_group = table.service_group_end(handle);
 
-                    Ok(table.push(Attribute {
-                        uuid: INCLUDE.into(),
-                        data: AttributeData::IncludedService {
-                            handle,
-                            last_handle_in_group: *last_handle_in_group,
-                            uuid,
+                    // Included service values only include 16-bit UUIDs per the Bluetooth spec
+                    let uuid = att.data.value().and_then(|val| (val.len() == 2).then_some(val));
+
+                    // Encode: handle_LE(2) + last_handle_in_group_LE(2) + optional_uuid(0 or 2)
+                    let mut value = [0u8; 20];
+                    let mut w = WriteCursor::new(&mut value);
+                    w.write(handle).unwrap();
+                    w.write(last_handle_in_group).unwrap();
+                    if let Some(uuid) = uuid {
+                        w.append(uuid).unwrap();
+                    }
+                    let len = w.len() as u8;
+
+                    Ok(table.push(Attribute::new(
+                        INCLUDE,
+                        AttPermissions::read_only(),
+                        AttributeData::SmallData {
+                            variable_len: false,
+                            capacity: len,
+                            len,
+                            value,
                         },
-                    }))
+                    )))
                 } else {
                     Err(InvalidHandle)
                 }
@@ -1150,8 +1135,13 @@ pub struct CharacteristicBuilder<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const 
 }
 
 impl<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const MAX: usize> CharacteristicBuilder<'r, 'd, T, M, MAX> {
-    fn add_descriptor_internal<DT: AsGatt + ?Sized>(&mut self, uuid: Uuid, data: AttributeData<'d>) -> Descriptor<DT> {
-        let handle = self.table.push(Attribute { uuid, data });
+    fn add_descriptor_internal<DT: AsGatt + ?Sized>(
+        &mut self,
+        uuid: Uuid,
+        permissions: AttPermissions,
+        data: AttributeData<'d>,
+    ) -> Descriptor<DT> {
+        let handle = self.table.push(Attribute::new(uuid, permissions, data));
 
         Descriptor {
             handle,
@@ -1174,8 +1164,8 @@ impl<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const MAX: usize> CharacteristicBu
         let len = bytes.len() as u16;
         self.add_descriptor_internal(
             uuid.into(),
+            permissions,
             AttributeData::Data {
-                permissions,
                 value: store,
                 variable_len,
                 len,
@@ -1183,26 +1173,26 @@ impl<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const MAX: usize> CharacteristicBu
         )
     }
 
-    /// Add a characteristic to this service using inline storage. The descriptor value must be 8 bytes or less.
+    /// Add a characteristic to this service using inline storage. The descriptor value must be 20 bytes or less.
     pub fn add_descriptor_small<DT: AsGatt, U: Into<Uuid>>(
         &mut self,
         uuid: U,
         permissions: AttPermissions,
         value: DT,
     ) -> Descriptor<DT> {
-        assert!(DT::MIN_SIZE <= 8);
+        assert!(DT::MIN_SIZE <= 20);
 
         let bytes = value.as_gatt();
-        assert!(bytes.len() <= 8);
-        let mut value = [0; 8];
+        assert!(bytes.len() <= 20);
+        let mut value = [0; 20];
         value[..bytes.len()].copy_from_slice(bytes);
         let variable_len = DT::MAX_SIZE != DT::MIN_SIZE;
-        let capacity = DT::MAX_SIZE.min(8) as u8;
+        let capacity = DT::MAX_SIZE.min(20) as u8;
         let len = bytes.len() as u8;
         self.add_descriptor_internal(
             uuid.into(),
+            permissions,
             AttributeData::SmallData {
-                permissions,
                 variable_len,
                 capacity,
                 len,
@@ -1226,42 +1216,22 @@ impl<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const MAX: usize> CharacteristicBu
         };
         self.add_descriptor_internal(
             uuid.into(),
-            AttributeData::ReadOnlyData {
-                permissions,
-                value: data.as_gatt(),
-            },
+            permissions,
+            AttributeData::ReadOnlyData { value: data.as_gatt() },
         )
     }
 
     /// Set the read permission for this characteristic
     pub fn read_permission(self, read: PermissionLevel) -> Self {
-        self.table.with_attribute(self.handle.handle, |att| {
-            let permissions = match &mut att.data {
-                AttributeData::Data { permissions, .. }
-                | AttributeData::SmallData { permissions, .. }
-                | AttributeData::ReadOnlyData { permissions, .. } => permissions,
-                _ => unreachable!(),
-            };
-
-            permissions.read = read;
-        });
-
+        self.table
+            .with_attribute_mut(self.handle.handle, |att| att.permissions.read = read);
         self
     }
 
     /// Set the write permission for this characteristic
     pub fn write_permission(self, write: PermissionLevel) -> Self {
-        self.table.with_attribute(self.handle.handle, |att| {
-            let permissions = match &mut att.data {
-                AttributeData::Data { permissions, .. }
-                | AttributeData::SmallData { permissions, .. }
-                | AttributeData::ReadOnlyData { permissions, .. } => permissions,
-                _ => unreachable!(),
-            };
-
-            permissions.write = write;
-        });
-
+        self.table
+            .with_attribute_mut(self.handle.handle, |att| att.permissions.write = write);
         self
     }
 
@@ -1273,32 +1243,16 @@ impl<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const MAX: usize> CharacteristicBu
             panic!("Can't set CCCD permission on characteristics without notify or indicate properties.");
         };
 
-        self.table.with_attribute(handle, |att| {
-            let permission = match &mut att.data {
-                AttributeData::Cccd { write_permission, .. } => write_permission,
-                _ => unreachable!(),
-            };
-
-            *permission = write;
-        });
-
+        self.table
+            .with_attribute_mut(handle, |att| att.permissions.write = write);
         self
     }
 
     /// Set the minimum encryption key length required for this characteristic
     #[cfg(feature = "legacy-pairing")]
     pub fn min_key_len(self, len: u8) -> Self {
-        self.table.with_attribute(self.handle.handle, |att| {
-            let permissions = match &mut att.data {
-                AttributeData::Data { permissions, .. }
-                | AttributeData::SmallData { permissions, .. }
-                | AttributeData::ReadOnlyData { permissions, .. } => permissions,
-                _ => unreachable!(),
-            };
-
-            permissions.min_key_len = len;
-        });
-
+        self.table
+            .with_attribute_mut(self.handle.handle, |att| att.permissions.min_key_len = len);
         self
     }
 
@@ -1372,21 +1326,56 @@ impl<T: AsGatt + ?Sized> Descriptor<T> {
 
 /// Iterator over attributes.
 pub struct AttributeIterator<'a, 'd> {
-    attributes: &'a mut [Attribute<'d>],
+    attributes: &'a [Attribute<'d>],
     pos: usize,
 }
 
-impl<'d> AttributeIterator<'_, 'd> {
-    /// Return next attribute in iterator.
-    pub fn next<'m>(&'m mut self) -> Option<(u16, &'m mut Attribute<'d>)> {
+impl<'a, 'd> Iterator for AttributeIterator<'a, 'd> {
+    type Item = (u16, &'a Attribute<'d>);
+
+    fn next(&mut self) -> Option<Self::Item> {
         if self.pos < self.attributes.len() {
-            let att = &mut self.attributes[self.pos];
+            let att = &self.attributes[self.pos];
             self.pos += 1;
             let handle = self.pos as u16;
             Some((handle, att))
         } else {
             None
         }
+    }
+}
+
+impl<'a, 'd> AttributeIterator<'a, 'd> {
+    /// Find the handle of the last attribute in the current GATT service.
+    ///
+    /// Returns `u16::MAX` for the last service in the table.
+    pub fn service_group_end(&self) -> u16 {
+        // We return the 0-based index of the next service definition. When interpretted as a 1-based handle,
+        // this represents the handle of the last attribute before the next service definition.
+        self.attributes
+            .iter()
+            .enumerate()
+            .skip(self.pos)
+            .find(|(_, attr)| attr.uuid == PRIMARY_SERVICE.into() || attr.uuid == SECONDARY_SERVICE.into())
+            .map(|(i, _)| i as u16)
+            .unwrap_or(u16::MAX)
+    }
+
+    /// Find the handle of the last attribute in the current GATT characteristic.
+    pub fn characteristic_group_end(&self) -> u16 {
+        // We return the 0-based index of the next characteristic or service definition. When interpretted as a 1-based handle,
+        // this represents the handle of the last attribute before the next characteristic or service definition.
+        self.attributes
+            .iter()
+            .enumerate()
+            .skip(self.pos)
+            .find(|(_, attr)| {
+                attr.uuid == PRIMARY_SERVICE.into()
+                    || attr.uuid == SECONDARY_SERVICE.into()
+                    || attr.uuid == CHARACTERISTIC.into()
+            })
+            .map(|(i, _)| i as u16)
+            .unwrap_or(self.attributes.len() as u16)
     }
 }
 
@@ -1639,14 +1628,16 @@ mod tests {
 
         let mut table: AttributeTable<'static, NoopRawMutex, 20> = AttributeTable::new();
 
+        let ro = AttPermissions::read_only();
+        let cccd_perms = AttPermissions {
+            read: PermissionLevel::Allowed,
+            write: PermissionLevel::Allowed,
+            #[cfg(feature = "legacy-pairing")]
+            min_key_len: 0,
+        };
+
         // GAP service (handles 0x001 - 0x005)
-        table.push(Attribute::new(
-            PRIMARY_SERVICE.into(),
-            AttributeData::Service {
-                uuid: GAP.into(),
-                last_handle_in_group: 0x05,
-            },
-        ));
+        table.push(Attribute::new(PRIMARY_SERVICE, ro, GAP));
 
         let expected = 0xd4cdec10804db3f147b4d7d10baa0120;
         let actual = table.hash();
@@ -1658,48 +1649,28 @@ mod tests {
 
         // Device name characteristic
         table.push(Attribute::new(
-            CHARACTERISTIC.into(),
-            AttributeData::Declaration {
-                props: [CharacteristicProp::Read].as_slice().into(),
-                handle: 0x0003,
-                uuid: DEVICE_NAME.into(),
-            },
+            CHARACTERISTIC,
+            ro,
+            CharacteristicDeclaration::new([CharacteristicProp::Read], 0x0003, DEVICE_NAME),
         ));
 
         table.push(Attribute::new(
-            DEVICE_NAME.into(),
-            AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
-                value: b"",
-            },
+            DEVICE_NAME,
+            ro,
+            AttributeData::ReadOnlyData { value: b"" },
         ));
 
         // Appearance characteristic
         table.push(Attribute::new(
-            CHARACTERISTIC.into(),
-            AttributeData::Declaration {
-                props: [CharacteristicProp::Read].as_slice().into(),
-                handle: 0x0005,
-                uuid: APPEARANCE.into(),
-            },
+            CHARACTERISTIC,
+            ro,
+            CharacteristicDeclaration::new([CharacteristicProp::Read], 0x0005, APPEARANCE),
         ));
 
         table.push(Attribute::new(
-            APPEARANCE.into(),
-            AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
-                value: b"",
-            },
+            APPEARANCE,
+            ro,
+            AttributeData::ReadOnlyData { value: b"" },
         ));
 
         let expected = 0x6c329e3f1d52c03f174980f6b4704875;
@@ -1711,90 +1682,55 @@ mod tests {
         );
 
         // GATT service (handles 0x006 - 0x000d)
-        table.push(Attribute::new(
-            PRIMARY_SERVICE.into(),
-            AttributeData::Service {
-                uuid: GATT.into(),
-                last_handle_in_group: 0x0d,
-            },
-        ));
+        table.push(Attribute::new(PRIMARY_SERVICE, ro, GATT));
 
         // Service changed characteristic
         table.push(Attribute::new(
-            CHARACTERISTIC.into(),
-            AttributeData::Declaration {
-                props: [CharacteristicProp::Indicate].as_slice().into(),
-                handle: 0x0008,
-                uuid: SERVICE_CHANGED.into(),
-            },
+            CHARACTERISTIC,
+            ro,
+            CharacteristicDeclaration::new([CharacteristicProp::Indicate], 0x0008, SERVICE_CHANGED),
         ));
 
         table.push(Attribute::new(
-            SERVICE_CHANGED.into(),
-            AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
-                value: b"",
-            },
+            SERVICE_CHANGED,
+            ro,
+            AttributeData::ReadOnlyData { value: b"" },
         ));
 
         table.push(Attribute::new(
-            CLIENT_CHARACTERISTIC_CONFIGURATION.into(),
-            AttributeData::Cccd {
-                notifications: false,
-                indications: false,
-                write_permission: PermissionLevel::Allowed,
-            },
+            CLIENT_CHARACTERISTIC_CONFIGURATION,
+            cccd_perms,
+            AttributeData::ClientSpecific,
         ));
 
         // Client supported features characteristic
         table.push(Attribute::new(
-            CHARACTERISTIC.into(),
-            AttributeData::Declaration {
-                props: [CharacteristicProp::Read, CharacteristicProp::Write].as_slice().into(),
-                handle: 0x000b,
-                uuid: CLIENT_SUPPORTED_FEATURES.into(),
-            },
+            CHARACTERISTIC,
+            ro,
+            CharacteristicDeclaration::new(
+                [CharacteristicProp::Read, CharacteristicProp::Write],
+                0x000b,
+                CLIENT_SUPPORTED_FEATURES,
+            ),
         ));
 
         table.push(Attribute::new(
-            CLIENT_SUPPORTED_FEATURES.into(),
-            AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
-                value: b"",
-            },
+            CLIENT_SUPPORTED_FEATURES,
+            ro,
+            AttributeData::ReadOnlyData { value: b"" },
         ));
 
         // Database hash characteristic
         table.push(Attribute::new(
-            CHARACTERISTIC.into(),
-            AttributeData::Declaration {
-                props: [CharacteristicProp::Read].as_slice().into(),
-                handle: 0x000d,
-                uuid: DATABASE_HASH.into(),
-            },
+            CHARACTERISTIC,
+            ro,
+            CharacteristicDeclaration::new([CharacteristicProp::Read], 0x000d, DATABASE_HASH),
         ));
 
         table.push(Attribute::new(
-            DATABASE_HASH.into(),
-            AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
-                value: b"",
-            },
+            DATABASE_HASH,
+            ro,
+            AttributeData::ReadOnlyData { value: b"" },
         ));
 
         let expected = 0x16ce756326c5062bf74022f845c2b21f;
@@ -1809,68 +1745,43 @@ mod tests {
         const CUSTOM_CHARACTERISTIC: u128 = 0x12345678_12345678_12345678_9abcdef1;
 
         // Custom service (handles 0x00e - 0x0013)
-        table.push(Attribute::new(
-            PRIMARY_SERVICE.into(),
-            AttributeData::Service {
-                uuid: CUSTOM_SERVICE.into(),
-                last_handle_in_group: 0x13,
-            },
-        ));
+        table.push(Attribute::new(PRIMARY_SERVICE, ro, Uuid::from(CUSTOM_SERVICE)));
 
         // Custom characteristic
         table.push(Attribute::new(
-            CHARACTERISTIC.into(),
-            AttributeData::Declaration {
-                props: [CharacteristicProp::Notify, CharacteristicProp::Read].as_slice().into(),
-                handle: 0x0010,
-                uuid: CUSTOM_CHARACTERISTIC.into(),
-            },
+            CHARACTERISTIC,
+            ro,
+            CharacteristicDeclaration::new(
+                [CharacteristicProp::Notify, CharacteristicProp::Read],
+                0x0010,
+                CUSTOM_CHARACTERISTIC,
+            ),
         ));
 
         table.push(Attribute::new(
-            CUSTOM_CHARACTERISTIC.into(),
+            CUSTOM_CHARACTERISTIC,
+            ro,
+            AttributeData::ReadOnlyData { value: b"" },
+        ));
+
+        table.push(Attribute::new(
+            CLIENT_CHARACTERISTIC_CONFIGURATION,
+            cccd_perms,
+            AttributeData::ClientSpecific,
+        ));
+
+        table.push(Attribute::new(
+            CHARACTERISTIC_USER_DESCRIPTION,
+            ro,
             AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
-                value: b"",
-            },
-        ));
-
-        table.push(Attribute::new(
-            CLIENT_CHARACTERISTIC_CONFIGURATION.into(),
-            AttributeData::Cccd {
-                notifications: false,
-                indications: false,
-                write_permission: PermissionLevel::Allowed,
-            },
-        ));
-
-        table.push(Attribute::new(
-            CHARACTERISTIC_USER_DESCRIPTION.into(),
-            AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
                 value: b"Custom Characteristic",
             },
         ));
 
         table.push(Attribute::new(
-            CHARACTERISTIC_PRESENTATION_FORMAT.into(),
+            CHARACTERISTIC_PRESENTATION_FORMAT,
+            ro,
             AttributeData::ReadOnlyData {
-                permissions: AttPermissions {
-                    read: PermissionLevel::Allowed,
-                    write: PermissionLevel::NotAllowed,
-                    #[cfg(feature = "legacy-pairing")]
-                    min_key_len: 0,
-                },
                 value: &[4, 0, 0, 0x27, 1, 0, 0],
             },
         ));

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -349,7 +349,7 @@ impl AttributeData<'_> {
                 variable_len,
                 len,
             } => {
-                if offset > value.len() {
+                if offset > usize::from(*len) {
                     Err(AttErrorCode::INVALID_OFFSET)
                 } else if offset + data.len() > value.len() {
                     Err(AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH)
@@ -367,7 +367,7 @@ impl AttributeData<'_> {
                 len,
                 value,
             } => {
-                if offset > usize::from(*capacity) {
+                if offset > usize::from(*len) {
                     Err(AttErrorCode::INVALID_OFFSET)
                 } else if offset + data.len() > usize::from(*capacity) {
                     Err(AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH)
@@ -896,6 +896,27 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
         )
     }
 
+    /// Add a client-specific characteristic to this service.
+    pub fn add_characteristic_client<T: AsGatt, U: Into<Uuid>, P: Into<CharacteristicProps>>(
+        &mut self,
+        uuid: U,
+        props: P,
+    ) -> CharacteristicBuilder<'_, 'd, T, M, MAX> {
+        assert!(T::MAX_SIZE <= 512);
+        let props: CharacteristicProps = props.into();
+        let permissions = props.default_permissions();
+        let variable_len = T::MAX_SIZE != T::MIN_SIZE;
+        self.add_characteristic_internal(
+            uuid.into(),
+            props,
+            permissions,
+            AttributeData::ClientSpecific {
+                variable_len,
+                capacity: T::MAX_SIZE as u16,
+            },
+        )
+    }
+
     /// Add an included service to this service
     pub fn add_included_service(&mut self, handle: u16) -> Result<u16, InvalidHandle> {
         self.table.with_inner_mut(|table| {
@@ -1203,6 +1224,24 @@ impl<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const MAX: usize> CharacteristicBu
             uuid.into(),
             permissions,
             AttributeData::ReadOnlyData { value: data.as_gatt() },
+        )
+    }
+
+    /// Add a client-specific descriptor to this service.
+    pub fn add_descriptor_client<DT: AsGatt, U: Into<Uuid>>(
+        &mut self,
+        uuid: U,
+        permissions: AttPermissions,
+    ) -> Descriptor<DT> {
+        assert!(DT::MAX_SIZE <= 512);
+        let variable_len = DT::MAX_SIZE != DT::MIN_SIZE;
+        self.add_descriptor_internal(
+            uuid.into(),
+            permissions,
+            AttributeData::ClientSpecific {
+                variable_len,
+                capacity: DT::MAX_SIZE as u16,
+            },
         )
     }
 

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -208,7 +208,7 @@ pub(crate) enum AttributeData<'d> {
         len: u8,
         value: [u8; MAX_SMALL_DATA_SIZE],
     },
-    ClientSpecific,
+    ClientSpecific(u16),
 }
 
 impl From<Uuid> for AttributeData<'_> {
@@ -282,7 +282,7 @@ impl AttributeData<'_> {
             AttributeData::ReadOnlyData { value } => Some(value),
             AttributeData::Data { len, value, .. } => Some(&value[..*len as usize]),
             AttributeData::SmallData { len, value, .. } => Some(&value[..*len as usize]),
-            AttributeData::ClientSpecific => None,
+            AttributeData::ClientSpecific(_) => None,
         }
     }
 
@@ -311,7 +311,7 @@ impl AttributeData<'_> {
                 let value = &value[..*len as usize];
                 append(value, &mut offset, &mut data)
             }
-            Self::ClientSpecific => return Err(AttErrorCode::UNLIKELY_ERROR),
+            Self::ClientSpecific(_) => return Err(AttErrorCode::UNLIKELY_ERROR),
         };
 
         if offset > 0 {
@@ -668,7 +668,7 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
                     if it.next().is_some() {
                         let end_handle = it.characteristic_group_end();
                         let cccd_handle = it.next().and_then(|(handle, att)| {
-                            matches!(att.data, AttributeData::ClientSpecific).then_some(handle)
+                            (att.uuid == CLIENT_CHARACTERISTIC_CONFIGURATION.into()).then_some(handle)
                         });
 
                         return Ok(Characteristic {
@@ -814,7 +814,7 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
                         #[cfg(feature = "legacy-pairing")]
                         min_key_len: 0,
                     },
-                    AttributeData::ClientSpecific,
+                    AttributeData::ClientSpecific(2),
                 ));
 
                 Some(handle)
@@ -1703,7 +1703,7 @@ mod tests {
         table.push(Attribute::new(
             CLIENT_CHARACTERISTIC_CONFIGURATION,
             cccd_perms,
-            AttributeData::ClientSpecific,
+            AttributeData::ClientSpecific(2),
         ));
 
         // Client supported features characteristic
@@ -1770,7 +1770,7 @@ mod tests {
         table.push(Attribute::new(
             CLIENT_CHARACTERISTIC_CONFIGURATION,
             cccd_perms,
-            AttributeData::ClientSpecific,
+            AttributeData::ClientSpecific(2),
         ));
 
         table.push(Attribute::new(

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -289,7 +289,25 @@ impl AttributeData<'_> {
         }
     }
 
-    fn read(&self, mut offset: usize, mut data: &mut [u8]) -> Result<usize, AttErrorCode> {
+    pub(crate) fn is_variable_len(&self) -> bool {
+        match self {
+            AttributeData::Data { variable_len, .. }
+            | AttributeData::SmallData { variable_len, .. }
+            | AttributeData::ClientSpecific { variable_len, .. } => *variable_len,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        match self {
+            AttributeData::ReadOnlyData { value, .. } => value.len(),
+            AttributeData::Data { value, .. } => value.len(),
+            AttributeData::SmallData { capacity, .. } => usize::from(*capacity),
+            AttributeData::ClientSpecific { capacity, .. } => usize::from(*capacity),
+        }
+    }
+
+    pub(crate) fn read(&self, mut offset: usize, mut data: &mut [u8]) -> Result<usize, AttErrorCode> {
         fn append(src: &[u8], offset: &mut usize, dest: &mut &mut [u8]) -> usize {
             if *offset >= src.len() {
                 *offset -= src.len();
@@ -324,7 +342,7 @@ impl AttributeData<'_> {
         }
     }
 
-    fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), AttErrorCode> {
+    pub(crate) fn write(&mut self, offset: usize, data: &[u8]) -> Result<(), AttErrorCode> {
         match self {
             Self::Data {
                 value,
@@ -559,55 +577,15 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
     }
 
     pub(crate) fn set_raw(&self, attribute: u16, input: &[u8]) -> Result<(), Error> {
-        self.with_attribute_mut(attribute, |att| match &mut att.data {
-            AttributeData::Data {
-                value,
-                variable_len,
-                len,
-                ..
-            } => {
-                let expected_len = value.len();
-                let actual_len = input.len();
-
-                if *variable_len && actual_len <= expected_len {
-                    value[..input.len()].copy_from_slice(input);
-                    *len = input.len() as u16;
-                    Ok(())
-                } else if expected_len == actual_len {
-                    value.copy_from_slice(input);
-                    Ok(())
-                } else {
-                    Err(Error::UnexpectedDataLength {
-                        expected: expected_len,
-                        actual: actual_len,
-                    })
-                }
+        self.with_attribute_mut(attribute, |att| {
+            if !att.data.is_variable_len() && att.data.capacity() != input.len() {
+                Err(Error::UnexpectedDataLength {
+                    expected: att.data.capacity(),
+                    actual: input.len(),
+                })
+            } else {
+                att.write(0, input).map_err(Into::into)
             }
-            AttributeData::SmallData {
-                variable_len,
-                capacity,
-                len,
-                value,
-                ..
-            } => {
-                let expected_len = usize::from(*capacity);
-                let actual_len = input.len();
-
-                if *variable_len && actual_len <= expected_len {
-                    value[..input.len()].copy_from_slice(input);
-                    *len = input.len() as u8;
-                    Ok(())
-                } else if expected_len == actual_len {
-                    value[..expected_len].copy_from_slice(input);
-                    Ok(())
-                } else {
-                    Err(Error::UnexpectedDataLength {
-                        expected: expected_len,
-                        actual: actual_len,
-                    })
-                }
-            }
-            _ => Err(Error::NotSupported),
         })
         .unwrap_or(Err(Error::NotFound))
     }
@@ -749,13 +727,13 @@ impl<'d, M: RawMutex, const MAX: usize> AttributeTable<'d, M, MAX> {
 /// A type which holds a handle to an attribute in the attribute table
 pub trait AttributeHandle {
     /// The data type which the attribute contains
-    type Value: AsGatt;
+    type Value: AsGatt + ?Sized;
 
     /// Returns the attribute's handle
     fn handle(&self) -> u16;
 }
 
-impl<T: AsGatt> AttributeHandle for Characteristic<T> {
+impl<T: AsGatt + ?Sized> AttributeHandle for Characteristic<T> {
     type Value = T;
 
     fn handle(&self) -> u16 {
@@ -990,9 +968,8 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
     ///
     /// If the characteristic does not support notifications, an error is returned.
     pub async fn notify<P: PacketPool>(&self, connection: &GattConnection<'_, '_, P>, value: &T) -> Result<(), Error> {
-        let value = value.as_gatt();
         let server = connection.server;
-        server.set(self.handle, value)?;
+        connection.set(self, value)?;
 
         let cccd_handle = self.cccd_handle.ok_or(Error::NotFound)?;
         let conn = connection.raw();
@@ -1005,7 +982,7 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
 
         let uns = AttUns::Notify {
             handle: self.handle,
-            data: value,
+            data: value.as_gatt(),
         };
         let pdu = gatt::assemble(conn, crate::att::AttServer::Unsolicited(uns))?;
         conn.send(pdu).await;
@@ -1025,9 +1002,8 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
         connection: &GattConnection<'_, '_, P>,
         value: &T,
     ) -> Result<(), Error> {
-        let value = value.as_gatt();
         let server = connection.server;
-        server.set(self.handle, value)?;
+        connection.set(self, value)?;
 
         let cccd_handle = self.cccd_handle.ok_or(Error::NotFound)?;
         let conn = connection.raw();
@@ -1040,7 +1016,7 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
 
         let uns = AttUns::Indicate {
             handle: self.handle,
-            data: value,
+            data: value.as_gatt(),
         };
         let pdu = gatt::assemble(conn, crate::att::AttServer::Unsolicited(uns))?;
         conn.send(pdu).await;
@@ -1288,7 +1264,7 @@ pub struct Descriptor<T: AsGatt + ?Sized> {
     pub(crate) phantom: PhantomData<T>,
 }
 
-impl<T: AsGatt> AttributeHandle for Descriptor<T> {
+impl<T: AsGatt + ?Sized> AttributeHandle for Descriptor<T> {
     type Value = T;
 
     fn handle(&self) -> u16 {

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -17,6 +17,9 @@ use crate::types::gatt_traits::FromGattError;
 pub use crate::types::uuid::Uuid;
 use crate::{gatt, Error, PacketPool, MAX_INVALID_DATA_LEN};
 
+/// The maximum size in bytes of an attribute using inline small data storage.
+pub const MAX_SMALL_DATA_SIZE: usize = 20;
+
 /// Characteristic properties
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
@@ -203,7 +206,7 @@ pub(crate) enum AttributeData<'d> {
         variable_len: bool,
         capacity: u8,
         len: u8,
-        value: [u8; 20],
+        value: [u8; MAX_SMALL_DATA_SIZE],
     },
     ClientSpecific,
 }
@@ -212,7 +215,7 @@ impl From<Uuid> for AttributeData<'_> {
     fn from(uuid: Uuid) -> Self {
         let raw = uuid.as_raw();
         let len = raw.len() as u8;
-        let mut value = [0u8; 20];
+        let mut value = [0u8; MAX_SMALL_DATA_SIZE];
         value[..raw.len()].copy_from_slice(raw);
         AttributeData::SmallData {
             variable_len: false,
@@ -227,7 +230,7 @@ impl From<bt_hci::uuid::BluetoothUuid16> for AttributeData<'_> {
     fn from(uuid: bt_hci::uuid::BluetoothUuid16) -> Self {
         let raw = uuid.to_le_bytes();
         let len = raw.len() as u8;
-        let mut value = [0u8; 20];
+        let mut value = [0u8; MAX_SMALL_DATA_SIZE];
         value[..raw.len()].copy_from_slice(&raw);
         AttributeData::SmallData {
             variable_len: false,
@@ -242,7 +245,7 @@ impl From<bt_hci::uuid::BluetoothUuid128> for AttributeData<'_> {
     fn from(uuid: bt_hci::uuid::BluetoothUuid128) -> Self {
         let raw = uuid.to_le_bytes();
         let len = raw.len() as u8;
-        let mut value = [0u8; 20];
+        let mut value = [0u8; MAX_SMALL_DATA_SIZE];
         value[..raw.len()].copy_from_slice(&raw);
         AttributeData::SmallData {
             variable_len: false,
@@ -257,8 +260,8 @@ impl From<CharacteristicDeclaration> for AttributeData<'_> {
     fn from(decl: CharacteristicDeclaration) -> Self {
         let uuid_raw = decl.uuid.as_raw();
         let total_len = 1 + 2 + uuid_raw.len(); // props + handle + uuid
-        debug_assert!(total_len <= 20);
-        let mut value = [0u8; 20];
+        debug_assert!(total_len <= MAX_SMALL_DATA_SIZE);
+        let mut value = [0u8; MAX_SMALL_DATA_SIZE];
         value[0] = decl.props.0;
         value[1..3].copy_from_slice(&decl.value_handle.to_le_bytes());
         value[3..3 + uuid_raw.len()].copy_from_slice(uuid_raw);
@@ -862,23 +865,23 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
         )
     }
 
-    /// Add a characteristic to this service using inline storage. The characteristic value must be 20 bytes or less.
+    /// Add a characteristic to this service using inline storage. The characteristic value must be [`MAX_SMALL_DATA_SIZE`] bytes or less.
     pub fn add_characteristic_small<T: AsGatt, U: Into<Uuid>, P: Into<CharacteristicProps>>(
         &mut self,
         uuid: U,
         props: P,
         value: T,
     ) -> CharacteristicBuilder<'_, 'd, T, M, MAX> {
-        assert!(T::MIN_SIZE <= 20);
+        assert!(T::MIN_SIZE <= MAX_SMALL_DATA_SIZE);
 
         let props: CharacteristicProps = props.into();
         let permissions = props.default_permissions();
         let bytes = value.as_gatt();
-        assert!(bytes.len() <= 20);
-        let mut value = [0; 20];
+        assert!(bytes.len() <= MAX_SMALL_DATA_SIZE);
+        let mut value = [0; MAX_SMALL_DATA_SIZE];
         value[..bytes.len()].copy_from_slice(bytes);
         let variable_len = T::MAX_SIZE != T::MIN_SIZE;
-        let capacity = T::MAX_SIZE.min(20) as u8;
+        let capacity = T::MAX_SIZE.min(MAX_SMALL_DATA_SIZE) as u8;
         let len = bytes.len() as u8;
         self.add_characteristic_internal(
             uuid.into(),
@@ -923,7 +926,7 @@ impl<'d, M: RawMutex, const MAX: usize> ServiceBuilder<'_, 'd, M, MAX> {
                     let uuid = att.data.value().and_then(|val| (val.len() == 2).then_some(val));
 
                     // Encode: handle_LE(2) + last_handle_in_group_LE(2) + optional_uuid(0 or 2)
-                    let mut value = [0u8; 20];
+                    let mut value = [0u8; MAX_SMALL_DATA_SIZE];
                     let mut w = WriteCursor::new(&mut value);
                     w.write(handle).unwrap();
                     w.write(last_handle_in_group).unwrap();
@@ -1173,21 +1176,21 @@ impl<'r, 'd, T: AsGatt + ?Sized, M: RawMutex, const MAX: usize> CharacteristicBu
         )
     }
 
-    /// Add a characteristic to this service using inline storage. The descriptor value must be 20 bytes or less.
+    /// Add a characteristic to this service using inline storage. The descriptor value must be [`MAX_SMALL_DATA_SIZE`] bytes or less.
     pub fn add_descriptor_small<DT: AsGatt, U: Into<Uuid>>(
         &mut self,
         uuid: U,
         permissions: AttPermissions,
         value: DT,
     ) -> Descriptor<DT> {
-        assert!(DT::MIN_SIZE <= 20);
+        assert!(DT::MIN_SIZE <= MAX_SMALL_DATA_SIZE);
 
         let bytes = value.as_gatt();
-        assert!(bytes.len() <= 20);
-        let mut value = [0; 20];
+        assert!(bytes.len() <= MAX_SMALL_DATA_SIZE);
+        let mut value = [0; MAX_SMALL_DATA_SIZE];
         value[..bytes.len()].copy_from_slice(bytes);
         let variable_len = DT::MAX_SIZE != DT::MIN_SIZE;
-        let capacity = DT::MAX_SIZE.min(20) as u8;
+        let capacity = DT::MAX_SIZE.min(MAX_SMALL_DATA_SIZE) as u8;
         let len = bytes.len() as u8;
         self.add_descriptor_internal(
             uuid.into(),

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -551,7 +551,8 @@ pub(crate) mod sealed {
         ) -> Result<Option<usize>, Error>;
         fn should_notify(&self, connection: &Connection<'_, P>, cccd_handle: u16) -> bool;
         fn should_indicate(&self, connection: &Connection<'_, P>, cccd_handle: u16) -> bool;
-        fn set(&self, characteristic: u16, input: &[u8]) -> Result<(), Error>;
+        fn set(&self, connection: &Connection<'_, P>, att_handle: u16, input: &[u8]) -> Result<(), Error>;
+        fn get(&self, connection: &Connection<'_, P>, att_handle: u16, buf: &mut [u8]) -> Result<usize, Error>;
         fn update_identity(&self, identity: Identity) -> Result<(), Error>;
 
         fn can_read(&self, connection: &Connection<'_, P>, handle: u16) -> Result<(), AttErrorCode>;
@@ -599,8 +600,37 @@ impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CLIENT_ATT_BYTES: u
         AttributeServer::should_indicate(self, connection, cccd_handle)
     }
 
-    fn set(&self, characteristic: u16, input: &[u8]) -> Result<(), Error> {
-        self.att_table.set_raw(characteristic, input)
+    fn get(&self, connection: &Connection<'_, P>, att_handle: u16, buf: &mut [u8]) -> Result<usize, Error> {
+        self.att_table
+            .with_attribute(att_handle, |att| {
+                if matches!(att.data, AttributeData::ClientSpecific { .. }) {
+                    self.client_att_tables
+                        .read(&connection.peer_identity(), att_handle, 0, buf)
+                } else {
+                    att.read(0, buf)
+                }
+                .map_err(Into::into)
+            })
+            .unwrap_or(Err(Error::NotFound))
+    }
+
+    fn set(&self, connection: &Connection<'_, P>, att_handle: u16, input: &[u8]) -> Result<(), Error> {
+        self.att_table
+            .with_attribute_mut(att_handle, |att| {
+                if !att.data.is_variable_len() && att.data.capacity() != input.len() {
+                    Err(Error::UnexpectedDataLength {
+                        expected: att.data.capacity(),
+                        actual: input.len(),
+                    })
+                } else if matches!(att.data, AttributeData::ClientSpecific { .. }) {
+                    self.client_att_tables
+                        .write(&connection.peer_identity(), att_handle, 0, input)
+                        .map_err(Into::into)
+                } else {
+                    att.write(0, input).map_err(Into::into)
+                }
+            })
+            .unwrap_or(Err(Error::NotFound))
     }
 
     fn update_identity(&self, identity: Identity) -> Result<(), Error> {

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -23,115 +23,279 @@ impl Client {
     }
 }
 
-/// A table of CCCD values.
+/// A compact, fixed-size map of client-specific attribute values (e.g. CCCDs).
+///
+/// Entries are stored in a flat byte buffer with a sorted index for binary-search lookups.
+/// The `BYTES` const generic determines the total storage available for both the index and values.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Clone, Debug)]
-pub struct CccdTable<const ENTRIES: usize> {
-    inner: [(u16, CCCD); ENTRIES],
+pub struct ClientAttTable<const BYTES: usize> {
+    buf: [u8; BYTES],
 }
 
-impl<const ENTRIES: usize> Default for CccdTable<ENTRIES> {
-    fn default() -> Self {
-        Self {
-            inner: [(0, CCCD(0)); ENTRIES],
+impl<const BYTES: usize> ClientAttTable<BYTES> {
+    const HEADER_SIZE: usize = 2;
+    const ENTRY_SIZE: usize = 4;
+
+    /// Creates a new [`ClientAttTableBuilder`] for constructing a `ClientAttTable`.
+    pub const fn builder() -> ClientAttTableBuilder<BYTES> {
+        const { core::assert!(BYTES >= 2 && BYTES <= u16::MAX as usize) };
+
+        ClientAttTableBuilder {
+            buf: [0; BYTES],
+            values_len: 0,
         }
+    }
+
+    /// Returns the number of entries in the map.
+    pub const fn len(&self) -> usize {
+        u16::from_le_bytes([self.buf[0], self.buf[1]]) as usize
+    }
+
+    /// Returns `true` if the map contains no entries.
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    const fn values_base(&self) -> usize {
+        Self::HEADER_SIZE + self.len() * Self::ENTRY_SIZE
+    }
+
+    fn values_len(&self) -> usize {
+        if let Some(i) = self.find(u16::MAX) {
+            Self::entry_offset(&self.index()[i])
+        } else {
+            BYTES - self.values_base()
+        }
+    }
+
+    fn index(&self) -> &[[u8; 4]] {
+        self.buf[Self::HEADER_SIZE..self.values_base()].as_chunks::<4>().0
+    }
+
+    const fn entry_key(entry: &[u8; 4]) -> u16 {
+        u16::from_le_bytes([entry[0], entry[1]])
+    }
+
+    const fn entry_offset(entry: &[u8; 4]) -> usize {
+        u16::from_le_bytes([entry[2], entry[3]]) as usize
+    }
+
+    fn value_range(&self, i: usize) -> core::ops::Range<usize> {
+        let index = self.index();
+        let start = Self::entry_offset(&index[i]) + self.values_base();
+        let end = index
+            .get(i + 1)
+            .map(|entry| self.values_base() + Self::entry_offset(entry))
+            .unwrap_or(BYTES);
+        start..end
+    }
+
+    fn find(&self, key: u16) -> Option<usize> {
+        self.index().binary_search_by_key(&key, Self::entry_key).ok()
+    }
+
+    /// Returns a reference to the value associated with the given attribute handle, or `None` if not found.
+    pub fn get(&self, key: u16) -> Option<&[u8]> {
+        let range = self.value_range(self.find(key)?);
+        Some(&self.buf[range])
+    }
+
+    /// Returns a mutable reference to the value associated with the given attribute handle, or `None` if not found.
+    pub fn get_mut(&mut self, key: u16) -> Option<&mut [u8]> {
+        let range = self.value_range(self.find(key)?);
+        Some(&mut self.buf[range])
+    }
+
+    /// Returns the raw byte representation of the map, suitable for serialization or storage.
+    pub fn raw(&self) -> &[u8] {
+        let end = self.values_base() + self.values_len();
+        &self.buf[..end]
+    }
+
+    /// Constructs a `ClientAttTable` from a raw byte slice previously obtained via [`raw()`](Self::raw).
+    ///
+    /// Returns an error if the data is too large for the buffer, or if the index is malformed.
+    pub fn try_from_raw(data: &[u8]) -> Result<Self, Error> {
+        if data.len() > BYTES {
+            return Err(Error::InsufficientSpace);
+        } else if data.len() < 2 {
+            return Err(Error::InvalidValue);
+        }
+
+        let mut buf = [0; BYTES];
+        buf[..data.len()].copy_from_slice(data);
+        let map = Self { buf };
+
+        if map.values_base() > data.len() {
+            return Err(Error::InvalidValue);
+        }
+
+        let mut last_key = 0;
+        let mut last_offset = 0;
+        for e in map.index().iter() {
+            let key = Self::entry_key(e);
+            let offset = Self::entry_offset(e);
+            if key <= core::mem::replace(&mut last_key, key)
+                || offset < core::mem::replace(&mut last_offset, offset)
+                || map.values_base() + offset > data.len()
+            {
+                return Err(Error::InvalidValue);
+            }
+        }
+
+        Ok(map)
+    }
+
+    /// Copies values from `src` into this map for all matching keys.
+    ///
+    /// Keys present in this map but not in `src` are zeroed. If value sizes differ,
+    /// only the smaller length is copied and the remainder is zeroed.
+    pub fn set_values<const N: usize>(&mut self, src: &ClientAttTable<N>) {
+        for i in 0..self.len() {
+            let key = Self::entry_key(&self.index()[i]);
+            let range = self.value_range(i);
+            let dest = &mut self.buf[range];
+            match src.get(key) {
+                Some(src) => {
+                    let copy_len = dest.len().min(src.len());
+                    dest[..copy_len].copy_from_slice(&src[..copy_len]);
+                    dest[copy_len..].fill(0);
+                }
+                None => {
+                    dest.fill(0);
+                }
+            }
+        }
+    }
+
+    /// Zeros all values in the map, leaving the index structure intact.
+    pub fn clear(&mut self) {
+        let values_base = self.values_base();
+        let values_end = values_base + self.values_len();
+        self.buf[values_base..values_end].fill(0);
     }
 }
 
-impl<const ENTRIES: usize> CccdTable<ENTRIES> {
-    /// Create a new CCCD table from an array of (handle, cccd) pairs.
-    pub fn new(cccd_values: [(u16, CCCD); ENTRIES]) -> Self {
-        Self { inner: cccd_values }
-    }
+/// A builder for [`ClientAttTable`].
+///
+/// Entries must be pushed in ascending key order. Use [`build()`](Self::build) to finalize.
+#[derive(Debug, Clone)]
+pub struct ClientAttTableBuilder<const BYTES: usize> {
+    buf: [u8; BYTES],
+    values_len: u16,
+}
 
-    /// Get the inner array of (handle, cccd) pairs.
-    pub fn inner(&self) -> &[(u16, CCCD); ENTRIES] {
-        &self.inner
-    }
+impl<const BYTES: usize> ClientAttTableBuilder<BYTES> {
+    const HEADER_SIZE: usize = ClientAttTable::<BYTES>::HEADER_SIZE;
+    const ENTRY_SIZE: usize = ClientAttTable::<BYTES>::ENTRY_SIZE;
 
-    fn add_handle(&mut self, cccd_handle: u16) {
-        for (handle, _) in self.inner.iter_mut() {
-            if *handle == 0 {
-                *handle = cccd_handle;
-                break;
+    /// Adds an entry with the given attribute handle and value size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `key` is not greater than the previously pushed key, or if there is insufficient space.
+    pub fn push(&mut self, key: u16, value_len: u16) {
+        let old_len = self.len();
+        self.set_len(old_len + 1);
+        let offset = self.values_len;
+        self.values_len = self
+            .values_len
+            .checked_add(value_len)
+            .expect("ClientAttTable buffer overflow");
+
+        // If we overflow, just keep tracking the total needed size so we can report it in build()
+        if self.end() <= BYTES {
+            let index = self.index_mut();
+            if old_len > 0 {
+                let last_key = ClientAttTable::<BYTES>::entry_key(&index[old_len - 1]);
+                assert!(key > last_key, "keys must be inserted in ascending order");
             }
+            Self::set_entry(&mut index[old_len], key, offset);
         }
     }
 
-    fn disable_all(&mut self) {
-        for (_, value) in self.inner.iter_mut() {
-            value.disable();
+    /// Consumes the builder and returns the completed [`ClientAttTable`].
+    pub fn build(mut self) -> ClientAttTable<BYTES> {
+        let end = self.end();
+        if end < BYTES {
+            let len = self.len();
+            if len > 0 {
+                let index = self.index_mut();
+                let last_key = ClientAttTable::<BYTES>::entry_key(&index[len - 1]);
+                assert!(last_key < u16::MAX);
+            }
+
+            // Add a dummy value to define the length of the last attribute value
+            self.push(u16::MAX, 0)
         }
+
+        if self.end() > BYTES {
+            panic!(
+                "ClientAttTable<{}> buffer overflow. Need {} bytes for exact size",
+                BYTES, end
+            );
+        } else if end < BYTES {
+            warn!(
+                "ClientAttTable<{}> buffer oversized. Only need {} bytes for exact size",
+                BYTES, end
+            );
+        }
+
+        ClientAttTable { buf: self.buf }
     }
 
-    fn get_raw(&self, cccd_handle: u16) -> Option<[u8; 2]> {
-        for (handle, value) in self.inner.iter() {
-            if *handle == cccd_handle {
-                return Some(value.raw().to_le_bytes());
-            }
-        }
-        None
+    const fn len(&self) -> usize {
+        u16::from_le_bytes([self.buf[0], self.buf[1]]) as usize
     }
 
-    fn set_notify(&mut self, cccd_handle: u16, is_enabled: bool) {
-        for (handle, value) in self.inner.iter_mut() {
-            if *handle == cccd_handle {
-                trace!("[cccd] set_notify({}) = {}", cccd_handle, is_enabled);
-                value.set_notify(is_enabled);
-                break;
-            }
-        }
+    fn set_len(&mut self, len: usize) {
+        assert!(len <= u16::MAX as usize);
+        let [b0, b1] = (len as u16).to_le_bytes();
+        self.buf[0] = b0;
+        self.buf[1] = b1;
     }
 
-    fn should_notify(&self, cccd_handle: u16) -> bool {
-        for (handle, value) in self.inner.iter() {
-            if *handle == cccd_handle {
-                return value.should_notify();
-            }
-        }
-        false
+    const fn index_mut(&mut self) -> &mut [[u8; 4]] {
+        let end = self.len() * Self::ENTRY_SIZE;
+        let (_, slice) = self.buf.split_at_mut(Self::HEADER_SIZE);
+        let (slice, _) = slice.split_at_mut(end);
+        slice.as_chunks_mut::<4>().0
     }
 
-    fn set_indicate(&mut self, cccd_handle: u16, is_enabled: bool) {
-        for (handle, value) in self.inner.iter_mut() {
-            if *handle == cccd_handle {
-                trace!("\n\n\n[cccd] set_indicate({}) = {}", cccd_handle, is_enabled);
-                value.set_indicate(is_enabled);
-                break;
-            }
-        }
+    const fn set_entry(entry: &mut [u8; 4], key: u16, offset: u16) {
+        let key = key.to_le_bytes();
+        let offset = offset.to_le_bytes();
+        *entry = [key[0], key[1], offset[0], offset[1]];
     }
-    fn should_indicate(&self, cccd_handle: u16) -> bool {
-        for (handle, value) in self.inner.iter() {
-            if *handle == cccd_handle {
-                return value.should_indicate();
-            }
-        }
-        false
+
+    const fn values_base(&self) -> usize {
+        Self::HEADER_SIZE + self.len() * Self::ENTRY_SIZE
+    }
+
+    const fn end(&self) -> usize {
+        self.values_base() + self.values_len as usize
     }
 }
 
 /// A table of CCCD values for each connected client.
-struct CccdTables<M: RawMutex, const CCCD_MAX: usize, const CONN_MAX: usize> {
-    state: Mutex<M, RefCell<[(Client, CccdTable<CCCD_MAX>); CONN_MAX]>>,
+struct ClientAttTables<M: RawMutex, const BYTES: usize, const CONN_MAX: usize> {
+    state: Mutex<M, RefCell<[(Client, ClientAttTable<BYTES>); CONN_MAX]>>,
 }
 
-impl<M: RawMutex, const CCCD_MAX: usize, const CONN_MAX: usize> CccdTables<M, CCCD_MAX, CONN_MAX> {
+impl<M: RawMutex, const BYTES: usize, const CONN_MAX: usize> ClientAttTables<M, BYTES, CONN_MAX> {
     fn new<const ATT_MAX: usize>(att_table: &AttributeTable<'_, M, ATT_MAX>) -> Self {
-        let mut values: [(Client, CccdTable<CCCD_MAX>); CONN_MAX] =
-            core::array::from_fn(|_| (Client::default(), CccdTable::default()));
-        let mut base_cccd_table = CccdTable::default();
+        let mut builder = ClientAttTable::builder();
         att_table.iterate(|at| {
             for (handle, att) in at {
-                if matches!(att.data, AttributeData::ClientSpecific) {
-                    base_cccd_table.add_handle(handle);
+                if let AttributeData::ClientSpecific(len) = att.data {
+                    builder.push(handle, len);
                 }
             }
         });
-        // add the base CCCD table for each potential connected client
-        for (_, table) in values.iter_mut() {
-            *table = base_cccd_table.clone();
-        }
+        let base = builder.build();
+        let values: [(Client, ClientAttTable<BYTES>); CONN_MAX] =
+            core::array::from_fn(|_| (Client::default(), base.clone()));
         Self {
             state: Mutex::new(RefCell::new(values)),
         }
@@ -162,13 +326,13 @@ impl<M: RawMutex, const CCCD_MAX: usize, const CONN_MAX: usize> CccdTables<M, CC
                     client.is_connected = true;
                     client.set_identity(*peer_identity);
                     // erase the previous client's config
-                    table.disable_all();
+                    table.clear();
                     return Ok(());
                 }
             }
             // Should be unreachable if the max connections (CONN_MAX) matches that defined
             // in HostResources...
-            warn!("[server] unable to obtain CCCD slot");
+            warn!("[server] unable to obtain client attributes slot");
             Err(Error::ConnectionLimitReached)
         })
     }
@@ -180,7 +344,7 @@ impl<M: RawMutex, const CCCD_MAX: usize, const CONN_MAX: usize> CccdTables<M, CC
                 if client.identity.match_identity(peer_identity) {
                     if !bonded {
                         *client = Client::default();
-                        table.disable_all();
+                        table.clear();
                     } else {
                         client.is_connected = false;
                     }
@@ -190,67 +354,64 @@ impl<M: RawMutex, const CCCD_MAX: usize, const CONN_MAX: usize> CccdTables<M, CC
         })
     }
 
-    fn get_value(&self, peer_identity: &Identity, cccd_handle: u16) -> Option<[u8; 2]> {
+    fn with_value<R>(&self, peer_identity: &Identity, att_handle: u16, f: impl FnOnce(&[u8]) -> R) -> Option<R> {
         self.state.lock(|n| {
             let n = n.borrow();
             for (client, table) in n.iter() {
                 if client.identity.match_identity(peer_identity) {
-                    return table.get_raw(cccd_handle);
+                    return table.get(att_handle).map(f);
                 }
             }
             None
         })
     }
 
-    fn set_notify(&self, peer_identity: &Identity, cccd_handle: u16, is_enabled: bool) {
-        self.state.lock(|n| {
-            let mut n = n.borrow_mut();
-            for (client, table) in n.iter_mut() {
-                if client.identity.match_identity(peer_identity) {
-                    table.set_notify(cccd_handle, is_enabled);
-                    break;
-                }
-            }
-        })
-    }
-
-    fn should_notify(&self, peer_identity: &Identity, cccd_handle: u16) -> bool {
+    fn read(
+        &self,
+        peer_identity: &Identity,
+        att_handle: u16,
+        offset: usize,
+        data: &mut [u8],
+    ) -> Result<usize, AttErrorCode> {
         self.state.lock(|n| {
             let n = n.borrow();
             for (client, table) in n.iter() {
                 if client.identity.match_identity(peer_identity) {
-                    return table.should_notify(cccd_handle);
+                    let value = table.get(att_handle).ok_or(AttErrorCode::ATTRIBUTE_NOT_FOUND)?;
+                    if offset > value.len() {
+                        return Err(AttErrorCode::INVALID_OFFSET);
+                    }
+                    let value = &value[offset..];
+                    let len = value.len().min(data.len());
+                    data[..len].copy_from_slice(value);
+                    return Ok(len);
                 }
             }
-            false
+            Err(AttErrorCode::ATTRIBUTE_NOT_FOUND)
         })
     }
 
-    fn set_indicate(&self, peer_identity: &Identity, cccd_handle: u16, is_enabled: bool) {
+    fn write(&self, peer_identity: &Identity, att_handle: u16, offset: usize, data: &[u8]) -> Result<(), AttErrorCode> {
         self.state.lock(|n| {
             let mut n = n.borrow_mut();
             for (client, table) in n.iter_mut() {
                 if client.identity.match_identity(peer_identity) {
-                    table.set_indicate(cccd_handle, is_enabled);
-                    break;
+                    let value = table.get_mut(att_handle).ok_or(AttErrorCode::ATTRIBUTE_NOT_FOUND)?;
+                    if offset > value.len() {
+                        return Err(AttErrorCode::INVALID_OFFSET);
+                    } else if offset + data.len() > value.len() {
+                        return Err(AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH);
+                    } else {
+                        value[offset..offset + data.len()].copy_from_slice(data);
+                        return Ok(());
+                    }
                 }
             }
+            Err(AttErrorCode::ATTRIBUTE_NOT_FOUND)
         })
     }
 
-    fn should_indicate(&self, peer_identity: &Identity, cccd_handle: u16) -> bool {
-        self.state.lock(|n| {
-            let n = n.borrow();
-            for (client, table) in n.iter() {
-                if client.identity.match_identity(peer_identity) {
-                    return table.should_indicate(cccd_handle);
-                }
-            }
-            false
-        })
-    }
-
-    fn get_cccd_table(&self, peer_identity: &Identity) -> Option<CccdTable<CCCD_MAX>> {
+    fn get_client_att_table(&self, peer_identity: &Identity) -> Option<ClientAttTable<BYTES>> {
         self.state.lock(|n| {
             let n = n.borrow();
             for (client, table) in n.iter() {
@@ -262,13 +423,13 @@ impl<M: RawMutex, const CCCD_MAX: usize, const CONN_MAX: usize> CccdTables<M, CC
         })
     }
 
-    fn set_cccd_table(&self, peer_identity: &Identity, table: CccdTable<CCCD_MAX>) {
+    fn set_client_att_table(&self, peer_identity: &Identity, table: &ClientAttTable<BYTES>) {
         self.state.lock(|n| {
             let mut n = n.borrow_mut();
             for (client, t) in n.iter_mut() {
                 if client.identity.match_identity(peer_identity) {
-                    trace!("Setting cccd table {:?} for {:?}", table, peer_identity);
-                    *t = table;
+                    trace!("Setting client attribute table {:?} for {:?}", table, peer_identity);
+                    t.set_values(table);
                     break;
                 }
             }
@@ -295,11 +456,11 @@ pub struct AttributeServer<
     M: RawMutex,
     P: PacketPool,
     const ATT_MAX: usize,
-    const CCCD_MAX: usize,
+    const CLIENT_ATT_BYTES: usize,
     const CONN_MAX: usize,
 > {
     att_table: AttributeTable<'values, M, ATT_MAX>,
-    cccd_tables: CccdTables<M, CCCD_MAX, CONN_MAX>,
+    client_att_tables: ClientAttTables<M, CLIENT_ATT_BYTES, CONN_MAX>,
     _p: PhantomData<P>,
 }
 
@@ -328,12 +489,12 @@ pub(crate) mod sealed {
 /// Type erased attribute server
 pub trait DynamicAttributeServer<P: PacketPool>: sealed::DynamicAttributeServer<P> {}
 
-impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: usize, const CONN_MAX: usize>
-    DynamicAttributeServer<P> for AttributeServer<'_, M, P, ATT_MAX, CCCD_MAX, CONN_MAX>
+impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CLIENT_ATT_BYTES: usize, const CONN_MAX: usize>
+    DynamicAttributeServer<P> for AttributeServer<'_, M, P, ATT_MAX, CLIENT_ATT_BYTES, CONN_MAX>
 {
 }
-impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: usize, const CONN_MAX: usize>
-    sealed::DynamicAttributeServer<P> for AttributeServer<'_, M, P, ATT_MAX, CCCD_MAX, CONN_MAX>
+impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CLIENT_ATT_BYTES: usize, const CONN_MAX: usize>
+    sealed::DynamicAttributeServer<P> for AttributeServer<'_, M, P, ATT_MAX, CLIENT_ATT_BYTES, CONN_MAX>
 {
     fn connect(&self, connection: &Connection<'_, P>) -> Result<(), Error> {
         AttributeServer::connect(self, connection)
@@ -345,7 +506,7 @@ impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: usize, co
         #[cfg(not(feature = "security"))]
         let bonded = false;
 
-        self.cccd_tables.disconnect(&connection.peer_identity(), bonded);
+        self.client_att_tables.disconnect(&connection.peer_identity(), bonded);
     }
 
     fn process(
@@ -370,7 +531,7 @@ impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: usize, co
     }
 
     fn update_identity(&self, identity: Identity) -> Result<(), Error> {
-        self.cccd_tables.update_identity(identity)
+        self.client_att_tables.update_identity(identity)
     }
 
     fn can_read(&self, connection: &Connection<'_, P>, handle: u16) -> Result<(), AttErrorCode> {
@@ -386,17 +547,23 @@ impl<M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: usize, co
     }
 }
 
-impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: usize, const CONN_MAX: usize>
-    AttributeServer<'values, M, P, ATT_MAX, CCCD_MAX, CONN_MAX>
+impl<
+        'values,
+        M: RawMutex,
+        P: PacketPool,
+        const ATT_MAX: usize,
+        const CLIENT_ATT_BYTES: usize,
+        const CONN_MAX: usize,
+    > AttributeServer<'values, M, P, ATT_MAX, CLIENT_ATT_BYTES, CONN_MAX>
 {
     /// Create a new instance of the AttributeServer
     pub fn new(
         att_table: AttributeTable<'values, M, ATT_MAX>,
-    ) -> AttributeServer<'values, M, P, ATT_MAX, CCCD_MAX, CONN_MAX> {
-        let cccd_tables = CccdTables::new(&att_table);
+    ) -> AttributeServer<'values, M, P, ATT_MAX, CLIENT_ATT_BYTES, CONN_MAX> {
+        let cccd_tables = ClientAttTables::new(&att_table);
         AttributeServer {
             att_table,
-            cccd_tables,
+            client_att_tables: cccd_tables,
             _p: PhantomData,
         }
     }
@@ -417,16 +584,31 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
     }
 
     pub(crate) fn connect(&self, connection: &Connection<'_, P>) -> Result<(), Error> {
-        self.cccd_tables.connect(&connection.peer_identity())
+        self.client_att_tables.connect(&connection.peer_identity())
     }
 
     pub(crate) fn should_notify(&self, connection: &Connection<'_, P>, cccd_handle: u16) -> bool {
-        self.cccd_tables.should_notify(&connection.peer_identity(), cccd_handle)
+        self.client_att_tables
+            .with_value(&connection.peer_identity(), cccd_handle, |value| {
+                if let Ok(value) = value.try_into() {
+                    CCCD(u16::from_le_bytes(value)).should_notify()
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(false)
     }
 
     pub(crate) fn should_indicate(&self, connection: &Connection<'_, P>, cccd_handle: u16) -> bool {
-        self.cccd_tables
-            .should_indicate(&connection.peer_identity(), cccd_handle)
+        self.client_att_tables
+            .with_value(&connection.peer_identity(), cccd_handle, |value| {
+                if let Ok(value) = value.try_into() {
+                    CCCD(u16::from_le_bytes(value)).should_indicate()
+                } else {
+                    false
+                }
+            })
+            .unwrap_or(false)
     }
 
     fn can_read(&self, connection: &Connection<'_, P>, att: &Attribute<'_>) -> Result<(), AttErrorCode> {
@@ -460,23 +642,10 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         data: &mut [u8],
     ) -> Result<usize, AttErrorCode> {
         self.can_read(connection, att)?;
-        if matches!(att.data, AttributeData::ClientSpecific) {
-            // CCCD values are per-connection; read directly from the CCCD table
-            let value = self
-                .cccd_tables
-                .get_value(&connection.peer_identity(), handle)
-                .unwrap_or_default();
-            let bytes = value.as_slice();
-            if offset >= bytes.len() {
-                return if offset == 0 {
-                    Ok(0)
-                } else {
-                    Err(AttErrorCode::INVALID_OFFSET)
-                };
-            }
-            let n = data.len().min(bytes.len() - offset);
-            data[..n].copy_from_slice(&bytes[offset..offset + n]);
-            return Ok(n);
+        if matches!(att.data, AttributeData::ClientSpecific(_)) {
+            return self
+                .client_att_tables
+                .read(&connection.peer_identity(), handle, offset, data);
         }
         att.read(offset, data)
     }
@@ -490,20 +659,10 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         data: &[u8],
     ) -> Result<(), AttErrorCode> {
         self.can_write(connection, att)?;
-        if matches!(att.data, AttributeData::ClientSpecific) {
-            if offset > 0 {
-                return Err(AttErrorCode::INVALID_OFFSET);
-            }
-            if data.is_empty() {
-                return Err(AttErrorCode::UNLIKELY_ERROR);
-            }
-            let notifications = data[0] & 0x01 != 0;
-            let indications = data[0] & 0x02 != 0;
-            self.cccd_tables
-                .set_notify(&connection.peer_identity(), handle, notifications);
-            self.cccd_tables
-                .set_indicate(&connection.peer_identity(), handle, indications);
-            return Ok(());
+        if matches!(att.data, AttributeData::ClientSpecific(_)) {
+            return self
+                .client_att_tables
+                .write(&connection.peer_identity(), handle, offset, data);
         }
         att.write(offset, data)
     }
@@ -1070,14 +1229,15 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         Ok(())
     }
 
-    /// Get the CCCD table for a connection
-    pub fn get_cccd_table(&self, connection: &Connection<'_, P>) -> Option<CccdTable<CCCD_MAX>> {
-        self.cccd_tables.get_cccd_table(&connection.peer_identity())
+    /// Get the client-specific attribute table for a connection
+    pub fn get_client_att_table(&self, connection: &Connection<'_, P>) -> Option<ClientAttTable<CLIENT_ATT_BYTES>> {
+        self.client_att_tables.get_client_att_table(&connection.peer_identity())
     }
 
-    /// Set the CCCD table for a connection
-    pub fn set_cccd_table(&self, connection: &Connection<'_, P>, table: CccdTable<CCCD_MAX>) {
-        self.cccd_tables.set_cccd_table(&connection.peer_identity(), table);
+    /// Set the client-specific attribute table for a connection
+    pub fn set_client_att_table(&self, connection: &Connection<'_, P>, table: &ClientAttTable<CLIENT_ATT_BYTES>) {
+        self.client_att_tables
+            .set_client_att_table(&connection.peer_identity(), table);
     }
 }
 
@@ -1122,7 +1282,7 @@ mod tests {
         let _ = env_logger::try_init();
         const MAX_ATTRIBUTES: usize = 1024;
         const CONNECTIONS_MAX: usize = 3;
-        const CCCD_MAX: usize = 1024;
+        const CLIENT_ATT_BYTES: usize = 1024;
         const L2CAP_CHANNELS_MAX: usize = 5;
         type FacadeDummyType = [u8; 0];
 
@@ -1173,7 +1333,8 @@ mod tests {
             });
 
             // Create a server.
-            let server = AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CCCD_MAX, CONNECTIONS_MAX>::new(table);
+            let server =
+                AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CLIENT_ATT_BYTES, CONNECTIONS_MAX>::new(table);
 
             // Create the connection manager.
             let mgr = setup();

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -36,10 +36,11 @@ pub struct ClientAttTable<const BYTES: usize> {
 impl<const BYTES: usize> ClientAttTable<BYTES> {
     const HEADER_SIZE: usize = 2;
     const ENTRY_SIZE: usize = 4;
+    const END_OF_VALUES: u16 = 0x8000;
 
     /// Creates a new [`ClientAttTableBuilder`] for constructing a `ClientAttTable`.
     pub const fn builder() -> ClientAttTableBuilder<BYTES> {
-        const { core::assert!(BYTES >= 2 && BYTES <= u16::MAX as usize) };
+        const { core::assert!(BYTES >= Self::HEADER_SIZE && BYTES <= u16::MAX as usize) };
 
         ClientAttTableBuilder {
             buf: [0; BYTES],
@@ -47,26 +48,22 @@ impl<const BYTES: usize> ClientAttTable<BYTES> {
         }
     }
 
-    /// Returns the number of entries in the map.
-    pub const fn len(&self) -> usize {
+    const fn att_count(&self) -> usize {
         u16::from_le_bytes([self.buf[0], self.buf[1]]) as usize
     }
 
-    /// Returns `true` if the map contains no entries.
-    pub const fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     const fn values_base(&self) -> usize {
-        Self::HEADER_SIZE + self.len() * Self::ENTRY_SIZE
+        Self::HEADER_SIZE + self.att_count() * Self::ENTRY_SIZE
     }
 
     fn values_len(&self) -> usize {
-        if let Some(i) = self.find(u16::MAX) {
-            Self::entry_offset(&self.index()[i])
-        } else {
-            BYTES - self.values_base()
+        if let Some(entry) = self.index().last() {
+            if Self::entry_key(entry) == Self::END_OF_VALUES {
+                return Self::entry_offset(entry);
+            }
         }
+
+        BYTES - self.values_base()
     }
 
     fn index(&self) -> &[[u8; 4]] {
@@ -74,21 +71,67 @@ impl<const BYTES: usize> ClientAttTable<BYTES> {
     }
 
     const fn entry_key(entry: &[u8; 4]) -> u16 {
-        u16::from_le_bytes([entry[0], entry[1]])
+        let key = u16::from_le_bytes([entry[0], entry[1]]);
+        if key == Self::END_OF_VALUES {
+            key
+        } else {
+            key & 0x7fff
+        }
     }
 
     const fn entry_offset(entry: &[u8; 4]) -> usize {
         u16::from_le_bytes([entry[2], entry[3]]) as usize
     }
 
-    fn value_range(&self, i: usize) -> core::ops::Range<usize> {
-        let index = self.index();
-        let start = Self::entry_offset(&index[i]) + self.values_base();
-        let end = index
+    const fn is_variable_len(entry: &[u8; 4]) -> bool {
+        let key = u16::from_le_bytes([entry[0], entry[1]]);
+        key != Self::END_OF_VALUES && (key & 0x8000) != 0
+    }
+
+    fn raw_value_start(&self, i: usize) -> usize {
+        let entry = self.index()[i];
+        Self::entry_offset(&entry) + self.values_base()
+    }
+
+    fn value_start(&self, i: usize) -> usize {
+        let entry = self.index()[i];
+        let start = Self::entry_offset(&entry) + self.values_base();
+        if Self::is_variable_len(&entry) {
+            start + 2
+        } else {
+            start
+        }
+    }
+
+    fn value_end(&self, i: usize) -> usize {
+        self.index()
             .get(i + 1)
-            .map(|entry| self.values_base() + Self::entry_offset(entry))
-            .unwrap_or(BYTES);
-        start..end
+            .map(Self::entry_offset)
+            .unwrap_or(self.values_len())
+            + self.values_base()
+    }
+
+    fn value_capacity(&self, i: usize) -> usize {
+        self.value_end(i).saturating_sub(self.value_start(i))
+    }
+
+    fn value_len(&self, i: usize) -> usize {
+        let index = self.index();
+        if Self::is_variable_len(&index[i]) {
+            let start = self.raw_value_start(i);
+            u16::from_le_bytes([self.buf[start], self.buf[start + 1]]) as usize
+        } else {
+            self.value_capacity(i)
+        }
+    }
+
+    // If `i` is a variable length attribute, set its length to `len`. For fixed length attributes, do nothing.
+    fn set_variable_len(&mut self, i: usize, len: u16) {
+        assert!(len as usize <= self.value_capacity(i));
+        if Self::is_variable_len(&self.index()[i]) {
+            let start = self.raw_value_start(i);
+            self.buf[start..][..2].copy_from_slice(&len.to_le_bytes());
+        }
     }
 
     fn find(&self, key: u16) -> Option<usize> {
@@ -97,14 +140,34 @@ impl<const BYTES: usize> ClientAttTable<BYTES> {
 
     /// Returns a reference to the value associated with the given attribute handle, or `None` if not found.
     pub fn get(&self, key: u16) -> Option<&[u8]> {
-        let range = self.value_range(self.find(key)?);
-        Some(&self.buf[range])
+        if key >= Self::END_OF_VALUES {
+            None
+        } else {
+            let i = self.find(key)?;
+            Some(&self.buf[self.value_start(i)..][..self.value_len(i)])
+        }
     }
 
-    /// Returns a mutable reference to the value associated with the given attribute handle, or `None` if not found.
-    pub fn get_mut(&mut self, key: u16) -> Option<&mut [u8]> {
-        let range = self.value_range(self.find(key)?);
-        Some(&mut self.buf[range])
+    /// Writes `data` to `key` starting at `offset`.
+    pub fn write(&mut self, key: u16, offset: usize, data: &[u8]) -> Result<(), AttErrorCode> {
+        if key >= Self::END_OF_VALUES {
+            return Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
+        }
+
+        let i = self.find(key).ok_or(AttErrorCode::ATTRIBUTE_NOT_FOUND)?;
+        if offset > self.value_len(i) {
+            Err(AttErrorCode::INVALID_OFFSET)
+        } else if offset + data.len() > self.value_capacity(i) {
+            Err(AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH)
+        } else {
+            let start = self.value_start(i) + offset;
+            let end = start + data.len();
+            self.buf[start..end].copy_from_slice(data);
+
+            self.set_variable_len(i, (offset + data.len()) as u16);
+
+            Ok(())
+        }
     }
 
     /// Returns the raw byte representation of the map, suitable for serialization or storage.
@@ -131,6 +194,7 @@ impl<const BYTES: usize> ClientAttTable<BYTES> {
             return Err(Error::InvalidValue);
         }
 
+        // Validate the index
         let mut last_key = 0;
         let mut last_offset = 0;
         for e in map.index().iter() {
@@ -144,6 +208,13 @@ impl<const BYTES: usize> ClientAttTable<BYTES> {
             }
         }
 
+        // Validate variable length attributes
+        for i in 0..map.att_count() {
+            if map.value_end(i) < map.value_start(i) || map.value_len(i) > map.value_capacity(i) {
+                return Err(Error::InvalidValue);
+            }
+        }
+
         Ok(map)
     }
 
@@ -152,18 +223,25 @@ impl<const BYTES: usize> ClientAttTable<BYTES> {
     /// Keys present in this map but not in `src` are zeroed. If value sizes differ,
     /// only the smaller length is copied and the remainder is zeroed.
     pub fn set_values<const N: usize>(&mut self, src: &ClientAttTable<N>) {
-        for i in 0..self.len() {
-            let key = Self::entry_key(&self.index()[i]);
-            let range = self.value_range(i);
-            let dest = &mut self.buf[range];
+        for i in 0..self.att_count() {
+            let entry = self.index()[i];
+            let key = Self::entry_key(&entry);
             match src.get(key) {
                 Some(src) => {
+                    let start = self.value_start(i);
+                    let capacity = self.value_capacity(i);
+                    let dest = &mut self.buf[start..][..capacity];
+
                     let copy_len = dest.len().min(src.len());
                     dest[..copy_len].copy_from_slice(&src[..copy_len]);
                     dest[copy_len..].fill(0);
+
+                    self.set_variable_len(i, copy_len as u16);
                 }
                 None => {
-                    dest.fill(0);
+                    let start = self.raw_value_start(i);
+                    let end = self.value_end(i);
+                    self.buf[start..end].fill(0);
                 }
             }
         }
@@ -194,11 +272,23 @@ impl<const BYTES: usize> ClientAttTableBuilder<BYTES> {
     ///
     /// # Panics
     ///
-    /// Panics if `key` is not greater than the previously pushed key, or if there is insufficient space.
-    pub fn push(&mut self, key: u16, value_len: u16) {
-        let old_len = self.len();
-        self.set_len(old_len + 1);
+    /// Panics if `key` is not greater than the previously pushed keys.
+    pub fn push(&mut self, key: u16, value_len: u16, variable_len: bool) {
+        assert!(value_len <= 512, "Bluetooth attributes must be at most 512 bytes");
+        assert!(key > 0, "Bluetooth handles must be greater than 0");
+        assert!(key <= 0x7fff, "Handle values above 0x7fff are reserved");
+        self.push_inner(key, value_len, variable_len);
+    }
+
+    fn push_inner(&mut self, key: u16, mut value_len: u16, variable_len: bool) {
+        let old_att_count = self.att_count();
+        self.set_att_count(old_att_count + 1);
         let offset = self.values_len;
+
+        if variable_len {
+            value_len += 2;
+        }
+
         self.values_len = self
             .values_len
             .checked_add(value_len)
@@ -207,11 +297,11 @@ impl<const BYTES: usize> ClientAttTableBuilder<BYTES> {
         // If we overflow, just keep tracking the total needed size so we can report it in build()
         if self.end() <= BYTES {
             let index = self.index_mut();
-            if old_len > 0 {
-                let last_key = ClientAttTable::<BYTES>::entry_key(&index[old_len - 1]);
+            if old_att_count > 0 {
+                let last_key = ClientAttTable::<BYTES>::entry_key(&index[old_att_count - 1]);
                 assert!(key > last_key, "keys must be inserted in ascending order");
             }
-            Self::set_entry(&mut index[old_len], key, offset);
+            Self::set_entry(&mut index[old_att_count], key, offset, variable_len);
         }
     }
 
@@ -219,15 +309,8 @@ impl<const BYTES: usize> ClientAttTableBuilder<BYTES> {
     pub fn build(mut self) -> ClientAttTable<BYTES> {
         let end = self.end();
         if end < BYTES {
-            let len = self.len();
-            if len > 0 {
-                let index = self.index_mut();
-                let last_key = ClientAttTable::<BYTES>::entry_key(&index[len - 1]);
-                assert!(last_key < u16::MAX);
-            }
-
             // Add a dummy value to define the length of the last attribute value
-            self.push(u16::MAX, 0)
+            self.push_inner(ClientAttTable::<BYTES>::END_OF_VALUES, 0, false)
         }
 
         if self.end() > BYTES {
@@ -245,32 +328,30 @@ impl<const BYTES: usize> ClientAttTableBuilder<BYTES> {
         ClientAttTable { buf: self.buf }
     }
 
-    const fn len(&self) -> usize {
+    const fn att_count(&self) -> usize {
         u16::from_le_bytes([self.buf[0], self.buf[1]]) as usize
     }
 
-    fn set_len(&mut self, len: usize) {
-        assert!(len <= u16::MAX as usize);
-        let [b0, b1] = (len as u16).to_le_bytes();
-        self.buf[0] = b0;
-        self.buf[1] = b1;
+    fn set_att_count(&mut self, len: usize) {
+        self.buf[..2].copy_from_slice(&(len as u16).to_le_bytes())
     }
 
     const fn index_mut(&mut self) -> &mut [[u8; 4]] {
-        let end = self.len() * Self::ENTRY_SIZE;
+        let end = self.att_count() * Self::ENTRY_SIZE;
         let (_, slice) = self.buf.split_at_mut(Self::HEADER_SIZE);
         let (slice, _) = slice.split_at_mut(end);
         slice.as_chunks_mut::<4>().0
     }
 
-    const fn set_entry(entry: &mut [u8; 4], key: u16, offset: u16) {
-        let key = key.to_le_bytes();
+    const fn set_entry(entry: &mut [u8; 4], key: u16, offset: u16, variable_len: bool) {
+        let flag = if variable_len { 0x8000 } else { 0 };
+        let key = (key | flag).to_le_bytes();
         let offset = offset.to_le_bytes();
         *entry = [key[0], key[1], offset[0], offset[1]];
     }
 
     const fn values_base(&self) -> usize {
-        Self::HEADER_SIZE + self.len() * Self::ENTRY_SIZE
+        Self::HEADER_SIZE + self.att_count() * Self::ENTRY_SIZE
     }
 
     const fn end(&self) -> usize {
@@ -288,8 +369,8 @@ impl<M: RawMutex, const BYTES: usize, const CONN_MAX: usize> ClientAttTables<M, 
         let mut builder = ClientAttTable::builder();
         att_table.iterate(|at| {
             for (handle, att) in at {
-                if let AttributeData::ClientSpecific(len) = att.data {
-                    builder.push(handle, len);
+                if let AttributeData::ClientSpecific { variable_len, capacity } = att.data {
+                    builder.push(handle, capacity, variable_len);
                 }
             }
         });
@@ -396,15 +477,7 @@ impl<M: RawMutex, const BYTES: usize, const CONN_MAX: usize> ClientAttTables<M, 
             let mut n = n.borrow_mut();
             for (client, table) in n.iter_mut() {
                 if client.identity.match_identity(peer_identity) {
-                    let value = table.get_mut(att_handle).ok_or(AttErrorCode::ATTRIBUTE_NOT_FOUND)?;
-                    if offset > value.len() {
-                        return Err(AttErrorCode::INVALID_OFFSET);
-                    } else if offset + data.len() > value.len() {
-                        return Err(AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH);
-                    } else {
-                        value[offset..offset + data.len()].copy_from_slice(data);
-                        return Ok(());
-                    }
+                    return table.write(att_handle, offset, data);
                 }
             }
             Err(AttErrorCode::ATTRIBUTE_NOT_FOUND)
@@ -642,7 +715,7 @@ impl<
         data: &mut [u8],
     ) -> Result<usize, AttErrorCode> {
         self.can_read(connection, att)?;
-        if matches!(att.data, AttributeData::ClientSpecific(_)) {
+        if matches!(att.data, AttributeData::ClientSpecific { .. }) {
             return self
                 .client_att_tables
                 .read(&connection.peer_identity(), handle, offset, data);
@@ -659,7 +732,7 @@ impl<
         data: &[u8],
     ) -> Result<(), AttErrorCode> {
         self.can_write(connection, att)?;
-        if matches!(att.data, AttributeData::ClientSpecific(_)) {
+        if matches!(att.data, AttributeData::ClientSpecific { .. }) {
             return self
                 .client_att_tables
                 .write(&connection.peer_identity(), handle, offset, data);

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -121,9 +121,9 @@ impl<M: RawMutex, const CCCD_MAX: usize, const CONN_MAX: usize> CccdTables<M, CC
         let mut values: [(Client, CccdTable<CCCD_MAX>); CONN_MAX] =
             core::array::from_fn(|_| (Client::default(), CccdTable::default()));
         let mut base_cccd_table = CccdTable::default();
-        att_table.iterate(|mut at| {
-            while let Some((handle, att)) = at.next() {
-                if let AttributeData::Cccd { .. } = att.data {
+        att_table.iterate(|at| {
+            for (handle, att) in at {
+                if matches!(att.data, AttributeData::ClientSpecific) {
                     base_cccd_table.add_handle(handle);
                 }
             }
@@ -456,17 +456,27 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         connection: &Connection<'_, P>,
         handle: u16,
         offset: usize,
-        att: &mut Attribute<'values>,
+        att: &Attribute<'values>,
         data: &mut [u8],
     ) -> Result<usize, AttErrorCode> {
         self.can_read(connection, att)?;
-        if let AttributeData::Cccd { .. } = att.data {
-            // CCCD values for each connected client are held in the CCCD tables:
-            // the value is written back into att.data so att.read() has the final
-            // say when parsing at the requested offset.
-            if let Some(value) = self.cccd_tables.get_value(&connection.peer_identity(), handle) {
-                let _ = att.write(0, value.as_slice());
+        if matches!(att.data, AttributeData::ClientSpecific) {
+            // CCCD values are per-connection; read directly from the CCCD table
+            let value = self
+                .cccd_tables
+                .get_value(&connection.peer_identity(), handle)
+                .unwrap_or_default();
+            let bytes = value.as_slice();
+            if offset >= bytes.len() {
+                return if offset == 0 {
+                    Ok(0)
+                } else {
+                    Err(AttErrorCode::INVALID_OFFSET)
+                };
             }
+            let n = data.len().min(bytes.len() - offset);
+            data[..n].copy_from_slice(&bytes[offset..offset + n]);
+            return Ok(n);
         }
         att.read(offset, data)
     }
@@ -480,21 +490,22 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         data: &[u8],
     ) -> Result<(), AttErrorCode> {
         self.can_write(connection, att)?;
-        let err = att.write(offset, data);
-        if err.is_ok() {
-            if let AttributeData::Cccd {
-                notifications,
-                indications,
-                ..
-            } = att.data
-            {
-                self.cccd_tables
-                    .set_notify(&connection.peer_identity(), handle, notifications);
-                self.cccd_tables
-                    .set_indicate(&connection.peer_identity(), handle, indications);
+        if matches!(att.data, AttributeData::ClientSpecific) {
+            if offset > 0 {
+                return Err(AttErrorCode::INVALID_OFFSET);
             }
+            if data.is_empty() {
+                return Err(AttErrorCode::UNLIKELY_ERROR);
+            }
+            let notifications = data[0] & 0x01 != 0;
+            let indications = data[0] & 0x02 != 0;
+            self.cccd_tables
+                .set_notify(&connection.peer_identity(), handle, notifications);
+            self.cccd_tables
+                .set_indicate(&connection.peer_identity(), handle, indications);
+            return Ok(());
         }
-        err
+        att.write(offset, data)
     }
 
     fn handle_read_by_type_req(
@@ -513,9 +524,9 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         }
 
         let (mut header, mut body) = data.split(2)?;
-        let err = self.att_table.iterate_from(start, |mut it| {
+        let err = self.att_table.iterate_from(start, |it| {
             let mut ret = Err(AttErrorCode::ATTRIBUTE_NOT_FOUND);
-            while let Some((att_handle, att)) = it.next() {
+            for (att_handle, att) in it {
                 // trace!("[read_by_type] Check attribute {:?} {}", att.uuid, att.handle);
                 if &att.uuid == attribute_type && att_handle <= end {
                     body.write(att_handle)?;
@@ -603,14 +614,7 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
                 if &att.uuid == group_type && att_handle <= end {
                     // debug!("[read_by_group] found! {:x?} handle: {}", att.uuid, att.handle);
                     handle = att_handle;
-
-                    let AttributeData::Service {
-                        last_handle_in_group, ..
-                    } = att.data
-                    else {
-                        ret = Err(AttErrorCode::UNSUPPORTED_GROUP_TYPE);
-                        break;
-                    };
+                    let last_handle_in_group = it.service_group_end();
 
                     body.write(att_handle)?;
                     body.write(last_handle_in_group)?;
@@ -703,7 +707,7 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         handle: u16,
         data: &[u8],
     ) -> Result<usize, codec::Error> {
-        self.att_table.with_attribute(handle, |att| {
+        self.att_table.with_attribute_mut(handle, |att| {
             // Write commands can't respond with an error.
             let _ = self.write_attribute_data(connection, handle, 0, att, data);
         });
@@ -719,7 +723,7 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
     ) -> Result<usize, codec::Error> {
         let err = self
             .att_table
-            .with_attribute(handle, |att| {
+            .with_attribute_mut(handle, |att| {
                 self.write_attribute_data(connection, handle, 0, att, data)
             })
             .unwrap_or(Err(AttErrorCode::ATTRIBUTE_NOT_FOUND));
@@ -753,18 +757,13 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         self.att_table.iterate_from(start, |mut it| {
             while let Some((handle, att)) = it.next() {
                 if handle <= end && att.uuid == attr_type {
-                    if let AttributeData::Service {
-                        uuid,
-                        last_handle_in_group,
-                    } = &att.data
-                    {
-                        if uuid.as_raw() == attr_value {
-                            if w.available() < 4 {
-                                break;
-                            }
-                            w.write(handle)?;
-                            w.write(*last_handle_in_group)?;
+                    let value = att.data.value();
+                    if value == Some(attr_value) {
+                        if w.available() < 4 {
+                            break;
                         }
+                        w.write(handle)?;
+                        w.write(it.service_group_end())?;
                     }
                 }
             }
@@ -794,8 +793,8 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
         header.write(att::ATT_FIND_INFORMATION_RSP)?;
         let mut t = 0;
 
-        self.att_table.iterate_from(start, |mut it| {
-            while let Some((handle, att)) = it.next() {
+        self.att_table.iterate_from(start, |it| {
+            for (handle, att) in it {
                 if handle <= end {
                     if t == 0 {
                         t = att.uuid.get_type();
@@ -891,7 +890,9 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CCCD_MAX: 
                 }
                 let data = &pw.buf[..pw.len as usize];
                 self.att_table
-                    .with_attribute(pw.handle, |att| att.write(pw.offset as usize, data))
+                    .with_attribute_mut(pw.handle, |att| {
+                        self.write_attribute_data(connection, pw.handle, pw.offset as usize, att, data)
+                    })
                     .unwrap_or(Err(AttErrorCode::ATTRIBUTE_NOT_FOUND))
             });
             connection.clear_prepare_write();
@@ -1085,6 +1086,7 @@ mod tests {
     use core::task::Poll;
 
     use bt_hci::param::{AddrKind, BdAddr, ConnHandle, LeConnRole};
+    use bt_hci::uuid::declarations::{PRIMARY_SERVICE, SECONDARY_SERVICE};
     use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 
     use super::*;
@@ -1159,20 +1161,11 @@ mod tests {
             }
 
             // Print the table for debugging.
-            table.iterate(|mut it| {
-                while let Some((handle, att)) = it.next() {
+            table.iterate(|it| {
+                for (handle, att) in it {
                     let uuid = &att.uuid;
-                    if let AttributeData::Service {
-                        uuid,
-                        last_handle_in_group,
-                    } = &att.data
-                    {
-                        trace!(
-                            "last_handle_in_group for 0x{:0>4x?}, 0x{:0>2x?} 0x{:0>2x?}",
-                            handle,
-                            uuid,
-                            last_handle_in_group
-                        );
+                    if *uuid == PRIMARY_SERVICE.into() || *uuid == SECONDARY_SERVICE.into() {
+                        trace!("service 0x{:0>4x?}, 0x{:0>2x?}", handle, uuid,);
                     } else {
                         trace!("  0x{:0>4x?}, 0x{:0>2x?}", handle, uuid,);
                     }

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -910,11 +910,11 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         'server,
         M: RawMutex,
         const ATT_MAX: usize,
-        const CCCD_MAX: usize,
+        const CLIENT_ATT_BYTES: usize,
         const CONN_MAX: usize,
     >(
         self,
-        server: &'server AttributeServer<'values, M, P, ATT_MAX, CCCD_MAX, CONN_MAX>,
+        server: &'server AttributeServer<'values, M, P, ATT_MAX, CLIENT_ATT_BYTES, CONN_MAX>,
     ) -> Result<GattConnection<'stack, 'server, P>, Error> {
         GattConnection::try_new(self, server)
     }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -19,7 +19,7 @@ use crate::att::{
     self, Att, AttCfm, AttClient, AttCmd, AttErrorCode, AttReq, AttRsp, AttServer, AttUns, ATT_HANDLE_VALUE_IND,
     ATT_HANDLE_VALUE_NTF,
 };
-use crate::attribute::{Characteristic, CharacteristicProps, Descriptor, Uuid};
+use crate::attribute::{AttributeHandle, Characteristic, CharacteristicProps, Descriptor, Uuid};
 use crate::attribute_server::{AttributeServer, DynamicAttributeServer};
 use crate::connection::Connection;
 #[cfg(feature = "security")]
@@ -33,7 +33,7 @@ use crate::types::gatt_traits::{AsGatt, FromGatt, FromGattError};
 use crate::types::l2cap::L2capHeader;
 #[cfg(feature = "security")]
 use crate::BondInformation;
-use crate::{config, BleHostError, Error, PacketPool, Stack};
+use crate::{config, BleHostError, Error, PacketPool, Stack, MAX_INVALID_DATA_LEN};
 
 /// A GATT connection event.
 pub enum GattConnectionEvent<'stack, 'server, P: PacketPool> {
@@ -270,6 +270,29 @@ impl<'stack, 'server, P: PacketPool> GattConnection<'stack, 'server, P> {
     /// Get a reference to the underlying BLE connection.
     pub fn raw(&self) -> &Connection<'stack, P> {
         &self.connection
+    }
+
+    /// Set the value of an attribute on the local GATT server for this connection.
+    pub fn set<T: AttributeHandle>(&self, attribute_handle: &T, input: &T::Value) -> Result<(), Error> {
+        let gatt_value = input.as_gatt();
+        self.server.set(&self.connection, attribute_handle.handle(), gatt_value)
+    }
+
+    /// Get the value of an attribute from the local GATT server for this connection.
+    pub fn get<T: AttributeHandle>(&self, attribute_handle: &T) -> Result<T::Value, Error>
+    where
+        T::Value: FromGatt,
+    {
+        let mut buf = [0; 512];
+        let len = self.server.get(&self.connection, attribute_handle.handle(), &mut buf)?;
+        let value_slice = &buf[..len];
+        T::Value::from_gatt(value_slice).map_err(|_| {
+            let mut invalid_data = [0u8; MAX_INVALID_DATA_LEN];
+            let len_to_copy = value_slice.len().min(MAX_INVALID_DATA_LEN);
+            invalid_data[..len_to_copy].copy_from_slice(&value_slice[..len_to_copy]);
+
+            Error::CannotConstructGattValue(invalid_data)
+        })
     }
 }
 

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -1801,7 +1801,7 @@ mod tests {
 
         const MAX_ATTRIBUTES: usize = 64;
         const CONNECTIONS_MAX: usize = 3;
-        const CCCD_MAX: usize = 64;
+        const CLIENT_ATT_BYTES: usize = 64;
         const NUM_CHARACTERISTICS: u8 = 9;
         const ATT_MTU: u16 = 185;
 
@@ -1828,7 +1828,8 @@ mod tests {
             }
         }
 
-        let server = AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CCCD_MAX, CONNECTIONS_MAX>::new(table);
+        let server =
+            AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CLIENT_ATT_BYTES, CONNECTIONS_MAX>::new(table);
 
         // Set up a connection with ATT MTU = 185 (typical iOS value)
         let mgr = setup();
@@ -1904,7 +1905,7 @@ mod tests {
 
         const MAX_ATTRIBUTES: usize = 16;
         const CONNECTIONS_MAX: usize = 3;
-        const CCCD_MAX: usize = 16;
+        const CLIENT_ATT_BYTES: usize = 16;
 
         let mut table: AttributeTable<'_, NoopRawMutex, MAX_ATTRIBUTES> = AttributeTable::new();
         let mut storage = [0u8; 1];
@@ -1914,12 +1915,13 @@ mod tests {
             })
             .add_characteristic(
                 Uuid::new_long([0x45; 16]),
-                &[CharacteristicProp::Read, CharacteristicProp::WriteWithoutResponse],
+                [CharacteristicProp::Read, CharacteristicProp::WriteWithoutResponse],
                 0u8,
                 &mut storage[..],
             )
             .build();
-        let server = AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CCCD_MAX, CONNECTIONS_MAX>::new(table);
+        let server =
+            AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CLIENT_ATT_BYTES, CONNECTIONS_MAX>::new(table);
 
         let mgr = setup();
         assert!(mgr.poll_accept(LeConnRole::Peripheral, &[], None).is_pending());

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -19,14 +19,14 @@ use crate::att::{
     self, Att, AttCfm, AttClient, AttCmd, AttErrorCode, AttReq, AttRsp, AttServer, AttUns, ATT_HANDLE_VALUE_IND,
     ATT_HANDLE_VALUE_NTF,
 };
-use crate::attribute::{AttributeData, Characteristic, CharacteristicProps, Descriptor, Uuid};
+use crate::attribute::{Characteristic, CharacteristicProps, Descriptor, Uuid};
 use crate::attribute_server::{AttributeServer, DynamicAttributeServer};
 use crate::connection::Connection;
 #[cfg(feature = "security")]
 use crate::connection::SecurityLevel;
 use crate::cursor::{ReadCursor, WriteCursor};
 use crate::pdu::Pdu;
-use crate::prelude::{ConnectionEvent, ConnectionParamsRequest};
+use crate::prelude::{CharacteristicDeclaration, ConnectionEvent, ConnectionParamsRequest};
 #[cfg(feature = "security")]
 use crate::security_manager::PassKey;
 use crate::types::gatt_traits::{AsGatt, FromGatt, FromGattError};
@@ -1147,19 +1147,15 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
                     return ControlFlow::Break(());
                 }
 
-                match AttributeData::decode_declaration(item) {
-                    Ok(AttributeData::Declaration {
-                        props,
-                        handle,
-                        uuid: decl_uuid,
-                    }) => {
+                match CharacteristicDeclaration::try_from(item) {
+                    Ok(decl) => {
                         if characteristics
                             .push(Characteristic {
-                                handle,
+                                handle: decl.value_handle,
                                 end_handle: 0,
-                                props,
+                                props: decl.props,
                                 cccd_handle: None,
-                                uuid: decl_uuid,
+                                uuid: decl.uuid,
                                 phantom: PhantomData,
                             })
                             .is_err()
@@ -1169,7 +1165,6 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
                         }
                         ControlFlow::Continue(())
                     }
-                    Ok(_) => unreachable!(),
                     Err(e) => {
                         err = Some(e.into());
                         ControlFlow::Break(())
@@ -1233,29 +1228,24 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
                         }));
                     }
 
-                    match AttributeData::decode_declaration(item) {
-                        Ok(AttributeData::Declaration {
-                            props,
-                            handle: value_handle,
-                            uuid: decl_uuid,
-                        }) => {
+                    match CharacteristicDeclaration::try_from(item) {
+                        Ok(decl) => {
                             if found.is_some() {
                                 // We already found our match; this is the next declaration,
                                 // so we can determine end_handle.
                                 return ControlFlow::Break(Ok(declaration_handle));
                             }
 
-                            if *uuid == decl_uuid {
-                                found = Some((value_handle, props));
+                            if *uuid == decl.uuid {
+                                found = Some((decl.value_handle, decl.props));
                             }
 
-                            if value_handle == 0xFFFF && found.is_some() {
+                            if decl.value_handle == 0xFFFF && found.is_some() {
                                 return ControlFlow::Break(Ok(declaration_handle));
                             }
 
                             ControlFlow::Continue(())
                         }
-                        Ok(_) => ControlFlow::Break(Err(Error::InvalidCharacteristicDeclarationData)),
                         Err(e) => ControlFlow::Break(Err(e)),
                     }
                 },

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -63,7 +63,7 @@ async fn gatt_client_server() {
                 &mut storage[..]
             ).build();
 
-        let server = AttributeServer::<NoopRawMutex, DefaultPacketPool, 10, 1, CONNECTIONS_MAX>::new(table);
+        let server = AttributeServer::<NoopRawMutex, DefaultPacketPool, 10, 8, CONNECTIONS_MAX>::new(table);
         select! {
             r = runner.run() => {
                 r

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -102,7 +102,7 @@ async fn gatt_client_server() {
                                 assert_eq!(characteristic.handle, event.handle());
                                 event.accept().unwrap().send().await;
 
-                                let value: u8 = server.table().get(&characteristic).unwrap();
+                                let value: u8 = conn.get(&characteristic).unwrap();
                                 println!("[peripheral] write value: {}", value);
                                 assert_eq!(expected, value);
                                 expected = expected.wrapping_add(1);

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -133,7 +133,7 @@ async fn gatt_client_server() {
                                     writes += 1;
                                 } else {
                                     let characteristic = server.table().find_characteristic_by_value_handle(event.handle()).unwrap();
-                                    let value: u8 = server.table().get(&characteristic).unwrap();
+                                    let value: u8 = conn.get(&characteristic).unwrap();
                                     assert_eq!(expected, value);
                                     expected = expected.wrapping_add(2);
                                     writes += 1;

--- a/tester/app/src/lib.rs
+++ b/tester/app/src/lib.rs
@@ -229,8 +229,8 @@ const CONNECTIONS_MAX: usize = 3;
 const L2CAP_CHANNELS_MAX: usize = 14;
 /// Maximum number of attributes in the GATT attribute table.
 const ATTRIBUTE_TABLE_SIZE: usize = 64;
-/// Maximum number of CCCD (Client Characteristic Configuration Descriptor) entries.
-const CCCD_TABLE_SIZE: usize = 10;
+/// Maximum total size of the client-specific attributes (e.g. CCCDs) tables.
+const CLIENT_ATT_BYTES: usize = 64;
 /// Number of attributes used by the GAP service (service + device name + appearance + central address resolution).
 const GAP_ATTRIBUTE_COUNT: usize = 7;
 /// Number of attributes used by the GATT service (service + service_changed + client_supported_features + database_hash).
@@ -238,7 +238,7 @@ const GATT_ATTRIBUTE_COUNT: usize = 8;
 
 /// Type alias for the GATT attribute server used throughout this crate.
 pub(crate) type Server<'a, P> =
-    AttributeServer<'a, NoopRawMutex, P, ATTRIBUTE_TABLE_SIZE, CCCD_TABLE_SIZE, CONNECTIONS_MAX>;
+    AttributeServer<'a, NoopRawMutex, P, ATTRIBUTE_TABLE_SIZE, CLIENT_ATT_BYTES, CONNECTIONS_MAX>;
 
 /// Errors from the BTP runner.
 #[derive(Debug)]


### PR DESCRIPTION
This adds support for client-specific attributes beyond the CCCD descriptors.

I have simplified the `AttributeData` enum as originally outlined [here](https://github.com/embassy-rs/trouble/pull/561#issuecomment-4077859834). The custom variants for things like characteristic declarations and service definitions have been removed in favor of variants that just hold the raw data. The `Cccd` variant has been replaced with a general `ClientSpecific` variant for attributes that should have values that are unique per client and persisted across bonded connections to that client. The main down side is that we no longer have cached values for the last handle in a service or characteristic group. Those have been replaced with methods on `AttributeIterator` to scan the table for the next service or characteristic handle. Since the number of handles in any given service should be quite small this should have minimal performance impact.

Arbitrary length attributes are supported with a `ClientAttTable` struct that uses a "bag of bytes" to hold an index for the attribute locations within the data followed by the attribute data itself. This makes it easy to serialize and deserialize the table for storing across bonded connections.

I looked at moving the `ClientAttTable` into `ConnectionStorage`. That turned out not to work because the connections are completely independent of the `AttributeServer` until you create a `GattConnection`. That means there's nothing preventing you from having multiple `AttributeServer`s and using different ones for different connections (or event different ones at different times for the same connection) so having a single `ClientAttTable` tied to the connection doesn't make sense.

API changes:
- The `CCCD_MAX` generic parameter to `AttributeServer` is now `CLIENT_ATT_BYTES`. If your only client-specific attributes are CCCD descriptors then `CLIENT_ATT_BYTES` should be `2 + 6 * cccd_count`. The `#[server]` macro calculates this for you.
- `GattConnection::get` and `GattConnection::set` methods are added to get/set GATT values including client-specific value. These should generally be preferred over the generated server get/set functions because they handle client-specific values properly.
- `ServiceBuilder::add_characteristic_client` and `CharacteristicBuilder::add_descriptor_client` are added to allow creating client-specific attributes.
- `AttributeServer::get_cccd_table` and `AttributeServer::set_cccd_table` are renamed to `AttributeServer::get_client_att_table` and `AttributeServer::set_client_att_table`
