### PR TITLE
fix(connection): make DisconnectRequest::confirm idempotent

### DIFF
--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -1049,7 +1049,17 @@ impl<P> DisconnectRequest<'_, P> {
     }
 
     pub fn confirm(self) {
-        self.connections.borrow_mut()[self.index].state = ConnectionState::Disconnecting(self.reason);
+        let mut connections = self.connections.borrow_mut();
+        let storage = &mut connections[self.index];
+        // Only transition if still in DisconnectRequest. The HCI
+        // disconnect_complete handler (`disconnected()`) may race ahead and
+        // set state = Disconnected; in that case we must NOT overwrite it
+        // back to Disconnecting, or the slot becomes unreusable
+        // (`state == Disconnected && refcount == 0` is the reuse check).
+        if !matches!(storage.state, ConnectionState::DisconnectRequest(_)) {
+            return;
+        }
+        storage.state = ConnectionState::Disconnecting(self.reason);
     }
 }
 pub struct ConnectionStorage<P> {


### PR DESCRIPTION
`DisconnectRequest::confirm()` unconditionally writes `state = Disconnecting`, which races the HCI `DisconnectionComplete` handler. When the RX runner wins, the slot transitions `DisconnectRequest` -> `Disconnected` -> `Disconnecting` and gets stuck. Refcount eventually drops to 0 but state isn't `Disconnected`, so the slot fails the reuse check at `acquire()` (`state == Disconnected && refcount == 0`). The next inbound connection fails with `no available slot found for handle ConnHandle(1)`.

Caught it on an ESP32-S3 peripheral talking to a [bluer](https://github.com/bluez/bluer) central, in a stress harness driving repeated cancel-press-during-transfer cycles: central connects, opens GATT, begins a schedule transfer, peripheral cancels mid-stream via `connection.raw().disconnect()`, central reconnects. Pre-fix: 1 reproduction in 50 iterations, captured by an in-RAM flight recorder I added to a vendored copy. Post-fix: 75 iterations across two seeds, zero reproductions.

`confirm()` now early-returns if state has already moved past `DisconnectRequest`. The HCI `DisconnectionComplete` handler is the authoritative state-transition path; `confirm()` shouldn't overwrite it.

What this doesn't close: ABA on slot reuse. `DisconnectRequest` carries only the slot index, no generation token. Between `host.command(Disconnect).await` returning and `request.confirm()` running, the RX runner could process the disconnect, accept a new inbound connection on the same slot, and that new connection could itself reach `DisconnectRequest`, at which point the stale `confirm()` would match and write `Disconnecting` without HCI Disconnect having been sent for the new handle. The race window is sub-microsecond on the same task; the RX runner is a separate task. I never observed it post-fix and have no way to provoke it deterministically. A generation counter captured into `DisconnectRequest` at creation and checked in `confirm()` would close it, but that adds a field to `ConnectionStorage<P>`, and the shape is your call rather than mine.

Same pattern exists in `channel_manager::DisconnectRequest::confirm()` ([host/src/channel_manager.rs:1284](https://github.com/embassy-rs/trouble/blob/main/host/src/channel_manager.rs#L1284)) for L2CAP channel disconnects. I haven't patched it because I don't have an L2CAP CoC test setup.

The existing `controller_disconnects_before_host` test would have passed pre-fix. It doesn't drive `acquire` -> `disconnect` -> `confirm` -> `acquire` to prove slot reuse.