### PR TITLE
fix(host): use interval_max for max_connection_interval in LeRemoteConnectionParameterRequest handler

### DIFF
--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -1344,7 +1344,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                                 event.interval_min.as_micros(),
                                             ),
                                             max_connection_interval: Duration::from_micros(
-                                                event.interval_min.as_micros(),
+                                                event.interval_max.as_micros(),
                                             ),
                                             max_latency: event.max_latency,
                                             supervision_timeout: Duration::from_micros(event.timeout.as_micros()),


### PR DESCRIPTION
## Summary
- Fix copy-paste bug where `max_connection_interval` was incorrectly set from `event.interval_min` instead of `event.interval_max` in the `LeRemoteConnectionParameterRequest` handler (`host/src/host.rs:1348`).

This caused the host to always propose `min == max` connection intervals when handling remote connection parameter requests, ignoring the peer's actual requested range.