### PR TITLE
Fix/sm bonded reconnect and late pdu

### DIFF
--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -261,6 +261,23 @@ impl Inner {
             handle,
             peer_identity,
         } = *cmd;
+        // Once the pairing FSM has finished (Success or Error), ignore any
+        // SMP frame that isn't a fresh PairingRequest. `is_idle()` returns
+        // true post-completion, so without this guard the block below
+        // would overwrite the completed `pairing_sm` with a brand-new one
+        // whenever the central followed up with key-distribution PDUs
+        // (IdentityInformation, IdentityAddressInformation, …) — entirely
+        // normal in LESC. The fresh SM then rejected the PDU with
+        // InvalidState and the error path fired PairingFailed at the
+        // central, corrupting its bond.
+        if self
+            .pairing_sm
+            .as_ref()
+            .is_some_and(|sm| sm.result().is_some())
+            && command != Command::PairingRequest
+        {
+            return Ok(());
+        }
         if self.is_idle() {
             let local_address = self.connection_local_address(storage)?;
             let peer_address = Self::connection_peer_address(peer_address, storage);

--- a/host/src/security_manager/pairing/peripheral.rs
+++ b/host/src/security_manager/pairing/peripheral.rs
@@ -196,6 +196,13 @@ impl Pairing {
                 current @ (Self::WaitingPairingRequest | Self::WaitingLinkEncrypted),
                 Input::Event(Event::LinkEncryptedResult(res)),
             ) => Self::handle_link_encrypted(current, res, pairing_data, ops),
+            // Bonded reconnect: the per-stack pairing_sm persists in
+            // `Success` after the previous session, so when a bonded peer
+            // reconnects and the controller emits Encryption Complete
+            // (LTK reuse, no fresh pairing) the FSM receives this event
+            // while sitting in Success. Treat as a no-op — the SM has
+            // nothing left to do.
+            (current @ Self::Success, Input::Event(Event::LinkEncryptedResult(_))) => Ok(current),
             (
                 Self::WaitingNumericComparisonResult {
                     phase_data,


### PR DESCRIPTION
Hey there!

I was trying to connect/reconnect after pairing on a board but (possibly my linux setup) was triggering errors left and right. Managed to catch the extra commands and after this I was able to successfully pair -> disconnect/reconnect/disconnect. 

Hope it helps