### PR TITLE
feat(gatt): User managed atts

### DIFF
--- a/docs/pages/gatt.adoc
+++ b/docs/pages/gatt.adoc
@@ -137,10 +137,10 @@ Send updates to connected clients that have subscribed:
 let level = server.battery_service.level;
 
 // Notification (no confirmation from client)
-level.notify(&conn, &new_value).await?;
+level.notify(&conn, &new_value, true).await?;
 
 // Indication (waits for client confirmation)
-level.indicate(&conn, &new_value).await?;
+level.indicate(&conn, &new_value, true).await?;
 ----
 
 NOTE: Notifications/indications will only be delivered if the client has enabled them by writing to the characteristic's CCCD (Client Characteristic Configuration Descriptor). The `notify` and `indicate` calls return an error if the client hasn't subscribed.
@@ -291,7 +291,7 @@ pub async fn run<C: Controller>(controller: C) {
                         let mut tick: u8 = 0;
                         loop {
                             tick = tick.wrapping_add(1);
-                            let _ = level.notify(&conn, &tick).await;
+                            let _ = level.notify(&conn, &tick, true).await;
                             Timer::after_secs(2).await;
                         }
                     },

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -117,7 +117,9 @@ async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnect
                     }
                     GattEvent::Write(event) => {
                         if event.handle() == level.handle {
-                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
+                            event.with_data(|offset, data| {
+                                info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data)
+                            });
                         }
                     }
                     _ => {}

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -206,7 +206,7 @@ async fn custom_task<C: Controller, P: PacketPool>(
     loop {
         tick = tick.wrapping_add(1);
         info!("[custom_task] notifying connection of tick {}", tick);
-        if level.notify(conn, &tick).await.is_err() {
+        if level.notify(conn, &tick, true).await.is_err() {
             info!("[custom_task] error notifying connection");
             break;
         };

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -24,7 +24,7 @@ struct BatteryService {
     #[characteristic(uuid = characteristic::BATTERY_LEVEL, read, notify, value = 10)]
     level: u8,
     #[characteristic(uuid = "408813df-5dd4-1f87-ec11-cdb001100000", write, read, notify)]
-    status: bool,
+    status: (),
 }
 
 /// Run the BLE stack.
@@ -104,15 +104,22 @@ async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
 /// This is how we interact with read and write requests.
 async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnection<'_, '_, P>) -> Result<(), Error> {
     let level = server.battery_service.level;
+    let status_handle = server.battery_service.status.handle;
+    let mut status = false;
     let reason = loop {
         match conn.next().await {
             GattConnectionEvent::Disconnected { reason } => break reason,
             GattConnectionEvent::Gatt { event } => {
-                match &event {
+                let reply = match event {
                     GattEvent::Read(event) => {
                         if event.handle() == level.handle {
                             let value = conn.get(&level);
                             info!("[gatt] Read Event to Level Characteristic: {:?}", value);
+                            event.accept()
+                        } else if event.handle() == status_handle {
+                            event.accept_unprocessed(&status)
+                        } else {
+                            event.accept()
                         }
                     }
                     GattEvent::Write(event) => {
@@ -120,13 +127,30 @@ async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnect
                             event.with_data(|offset, data| {
                                 info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data)
                             });
+                            event.accept()
+                        } else if event.handle() == status_handle {
+                            match event.validate(1, 1) {
+                                Ok(()) => {
+                                    event.with_data(|offset, data| {
+                                        if data.len() == 1 {
+                                            // If data.len() is 1, offset must be 0 or else validate would have errored
+                                            assert!(offset == 0);
+                                            status = data[0] != 0;
+                                        }
+                                    });
+                                    event.accept_unprocessed()
+                                }
+                                Err(err) => event.reject(err),
+                            }
+                        } else {
+                            event.accept()
                         }
                     }
-                    _ => {}
+                    _ => event.accept(),
                 };
                 // This step is also performed at drop(), but writing it explicitly is necessary
                 // in order to ensure reply is sent.
-                match event.accept() {
+                match reply {
                     Ok(reply) => reply.send().await,
                     Err(e) => warn!("[gatt] error sending response: {:?}", e),
                 };

--- a/examples/apps/src/ble_bas_peripheral_auth.rs
+++ b/examples/apps/src/ble_bas_peripheral_auth.rs
@@ -162,7 +162,7 @@ where
                     }
                     GattEvent::Write(event) => {
                         if event.handle() == level.handle {
-                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
+                            event.with_data(|offset, data| info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data));
                         }
                         #[cfg(feature = "security")]
                         if conn.raw().security_level()?.authenticated() {

--- a/examples/apps/src/ble_bas_peripheral_auth.rs
+++ b/examples/apps/src/ble_bas_peripheral_auth.rs
@@ -162,7 +162,9 @@ where
                     }
                     GattEvent::Write(event) => {
                         if event.handle() == level.handle {
-                            event.with_data(|offset, data| info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data));
+                            event.with_data(|offset, data| {
+                                info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data)
+                            });
                         }
                         #[cfg(feature = "security")]
                         if conn.raw().security_level()?.authenticated() {
@@ -232,7 +234,7 @@ async fn custom_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnection<'
     let level = server.battery_service.level;
     loop {
         tick = tick.wrapping_add(1);
-        if level.notify(conn, &tick).await.is_err() {
+        if level.notify(conn, &tick, true).await.is_err() {
             break;
         };
         Timer::after_secs(2).await;

--- a/examples/apps/src/ble_bas_peripheral_bonding.rs
+++ b/examples/apps/src/ble_bas_peripheral_bonding.rs
@@ -194,7 +194,9 @@ async fn gatt_events_task<S: NorFlash>(
                     }
                     GattEvent::Write(event) => {
                         if event.handle() == level.handle {
-                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
+                            event.with_data(|offset, data| {
+                                info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data)
+                            });
                         }
                     }
                     GattEvent::NotAllowed(event) => {

--- a/examples/apps/src/ble_bas_peripheral_bonding.rs
+++ b/examples/apps/src/ble_bas_peripheral_bonding.rs
@@ -264,7 +264,7 @@ async fn custom_task<C: Controller, P: PacketPool>(
     loop {
         tick = tick.wrapping_add(1);
         info!("[custom_task] notifying connection of tick {}", tick);
-        if level.notify(conn, &tick).await.is_err() {
+        if level.notify(conn, &tick, true).await.is_err() {
             info!("[custom_task] error notifying connection");
             break;
         };

--- a/examples/apps/src/ble_bas_peripheral_pass_key.rs
+++ b/examples/apps/src/ble_bas_peripheral_pass_key.rs
@@ -133,7 +133,9 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
                     }
                     GattEvent::Write(event) => {
                         if event.handle() == level.handle {
-                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
+                            event.with_data(|offset, data| {
+                                info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data)
+                            });
                         }
                     }
                     GattEvent::NotAllowed(event) => {

--- a/examples/apps/src/ble_bas_peripheral_pass_key.rs
+++ b/examples/apps/src/ble_bas_peripheral_pass_key.rs
@@ -200,7 +200,7 @@ async fn custom_task<C: Controller, P: PacketPool>(
     loop {
         tick = tick.wrapping_add(1);
         info!("[custom_task] notifying connection of tick {}", tick);
-        if level.notify(conn, &tick).await.is_err() {
+        if level.notify(conn, &tick, true).await.is_err() {
             info!("[custom_task] error notifying connection");
             break;
         };

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -134,7 +134,9 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
                     }
                     GattEvent::Write(event) => {
                         if event.handle() == level.handle {
-                            event.with_data(|offset, data| info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data));
+                            event.with_data(|offset, data| {
+                                info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data)
+                            });
                         }
                     }
                     GattEvent::NotAllowed(event) => {
@@ -199,7 +201,7 @@ async fn custom_task<C: Controller, P: PacketPool>(
     loop {
         tick = tick.wrapping_add(1);
         info!("[custom_task] notifying connection of tick {}", tick);
-        if level.notify(conn, &tick).await.is_err() {
+        if level.notify(conn, &tick, true).await.is_err() {
             info!("[custom_task] error notifying connection");
             break;
         };

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -134,7 +134,7 @@ async fn gatt_events_task(server: &Server<'_>, conn: &GattConnection<'_, '_, Def
                     }
                     GattEvent::Write(event) => {
                         if event.handle() == level.handle {
-                            info!("[gatt] Write Event to Level Characteristic: {:?}", event.data());
+                            event.with_data(|offset, data| info!("[gatt] Write Event to Level Characteristic at {}: {:?}", offset, data));
                         }
                     }
                     GattEvent::NotAllowed(event) => {

--- a/host-macros/src/service.rs
+++ b/host-macros/src/service.rs
@@ -427,9 +427,12 @@ fn set_properties(args: &PropertiesArgs) -> Vec<TokenStream2> {
 fn set_permissions(args: &PermissionArgs) -> TokenStream2 {
     let read = args.read;
     let write = args.write;
-    quote! {trouble_host::attribute::AttPermissions {
-        read: #read,
-        write: #write,
-        ..Default::default()
-    }}
+    quote! {
+        #[allow(clippy::needless_update)]
+        trouble_host::attribute::AttPermissions {
+            read: #read,
+            write: #write,
+            ..Default::default()
+        }
+    }
 }

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -983,6 +983,14 @@ pub struct Characteristic<T: AsGatt + ?Sized> {
 }
 
 impl<T: AsGatt + ?Sized> Characteristic<T> {
+    /// Check if notifications should be sent to `connection` for this characteristic.
+    pub fn should_notify<P: PacketPool>(&self, connection: &GattConnection<'_, '_, P>) -> bool {
+        let Some(cccd_handle) = self.cccd_handle else {
+            return false;
+        };
+        connection.server.should_notify(connection.raw(), cccd_handle)
+    }
+
     /// Send a notification to `connection` with a new `value` for the characteristic.
     ///
     /// If `store` is true, the new value will be written to the table before sending the notification.
@@ -1017,6 +1025,14 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
         let pdu = gatt::assemble(conn, crate::att::AttServer::Unsolicited(uns))?;
         conn.send(pdu).await;
         Ok(())
+    }
+
+    /// Check if indications should be sent to `connection` for this characteristic.
+    pub fn should_indicate<P: PacketPool>(&self, connection: &GattConnection<'_, '_, P>) -> bool {
+        let Some(cccd_handle) = self.cccd_handle else {
+            return false;
+        };
+        connection.server.should_notify(connection.raw(), cccd_handle)
     }
 
     /// Send an indication to `connection` with a new `value` for the characteristic.

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -1004,9 +1004,25 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
         value: &T,
         store: bool,
     ) -> Result<(), Error> {
+        self.notify_raw(connection, value.as_gatt(), store).await
+    }
+
+    /// Send a notification to `connection` with a new `value` for the characteristic.
+    ///
+    /// If `store` is true, the new value will be written to the table before sending the notification.
+    ///
+    /// If the provided connection has not subscribed for this characteristic, it will not be notified.
+    ///
+    /// If the characteristic does not support notifications, an error is returned.
+    pub async fn notify_raw<P: PacketPool>(
+        &self,
+        connection: &GattConnection<'_, '_, P>,
+        value: &[u8],
+        store: bool,
+    ) -> Result<(), Error> {
         let server = connection.server;
         if store {
-            connection.set(self, value)?;
+            server.set(connection.raw(), self.handle, value)?;
         }
 
         let cccd_handle = self.cccd_handle.ok_or(Error::NotFound)?;
@@ -1020,7 +1036,7 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
 
         let uns = AttUns::Notify {
             handle: self.handle,
-            data: value.as_gatt(),
+            data: value,
         };
         let pdu = gatt::assemble(conn, crate::att::AttServer::Unsolicited(uns))?;
         conn.send(pdu).await;
@@ -1051,9 +1067,28 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
         value: &T,
         store: bool,
     ) -> Result<(), Error> {
+        self.indicate_raw(connection, value.as_gatt(), store).await
+    }
+
+    /// Send an indication to `connection` with a new `value` for the characteristic.
+    ///
+    /// If `store` is true, the new value will be written to the table before sending the indication.
+    ///
+    /// If the provided connection has not subscribed for this characteristic, it will not be sent an indication.
+    ///
+    /// If the characteristic does not support indications, an error is returned.
+    ///
+    /// This function does not block for the confirmation to the indication message, if the client sends a confirmation
+    /// this will be seen on the [GattConnection] as a [crate::att::AttClient::Confirmation] event.
+    pub async fn indicate_raw<P: PacketPool>(
+        &self,
+        connection: &GattConnection<'_, '_, P>,
+        value: &[u8],
+        store: bool,
+    ) -> Result<(), Error> {
         let server = connection.server;
         if store {
-            connection.set(self, value)?;
+            server.set(connection.raw(), self.handle, value)?;
         }
 
         let cccd_handle = self.cccd_handle.ok_or(Error::NotFound)?;
@@ -1067,7 +1102,7 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
 
         let uns = AttUns::Indicate {
             handle: self.handle,
-            data: value.as_gatt(),
+            data: value,
         };
         let pdu = gatt::assemble(conn, crate::att::AttServer::Unsolicited(uns))?;
         conn.send(pdu).await;
@@ -1108,6 +1143,18 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
         T: FromGatt,
     {
         server.table().get(self)
+    }
+
+    /// Access the raw byte value of the characteristic.
+    pub fn with_raw_value<M: RawMutex, P: PacketPool, R, const AT: usize, const CN: usize>(
+        &self,
+        server: &AttributeServer<'_, M, P, AT, CN>,
+        f: impl FnOnce(&[u8]) -> R,
+    ) -> Option<R> {
+        server
+            .table()
+            .with_attribute(self.handle, |att| att.data.value().map(f))
+            .flatten()
     }
 
     /// Returns the attribute handle for the characteristic's client characteristic configuration descriptor (if available)

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -983,14 +983,23 @@ pub struct Characteristic<T: AsGatt + ?Sized> {
 }
 
 impl<T: AsGatt + ?Sized> Characteristic<T> {
-    /// Write a value to a characteristic, and notify a connection with the new value of the characteristic.
+    /// Send a notification to `connection` with a new `value` for the characteristic.
+    ///
+    /// If `store` is true, the new value will be written to the table before sending the notification.
     ///
     /// If the provided connection has not subscribed for this characteristic, it will not be notified.
     ///
     /// If the characteristic does not support notifications, an error is returned.
-    pub async fn notify<P: PacketPool>(&self, connection: &GattConnection<'_, '_, P>, value: &T) -> Result<(), Error> {
+    pub async fn notify<P: PacketPool>(
+        &self,
+        connection: &GattConnection<'_, '_, P>,
+        value: &T,
+        store: bool,
+    ) -> Result<(), Error> {
         let server = connection.server;
-        connection.set(self, value)?;
+        if store {
+            connection.set(self, value)?;
+        }
 
         let cccd_handle = self.cccd_handle.ok_or(Error::NotFound)?;
         let conn = connection.raw();
@@ -1010,7 +1019,9 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
         Ok(())
     }
 
-    /// Write a value to a characteristic, and indicate a connection with the new value of the characteristic.
+    /// Send an indication to `connection` with a new `value` for the characteristic.
+    ///
+    /// If `store` is true, the new value will be written to the table before sending the indication.
     ///
     /// If the provided connection has not subscribed for this characteristic, it will not be sent an indication.
     ///
@@ -1022,9 +1033,12 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
         &self,
         connection: &GattConnection<'_, '_, P>,
         value: &T,
+        store: bool,
     ) -> Result<(), Error> {
         let server = connection.server;
-        connection.set(self, value)?;
+        if store {
+            connection.set(self, value)?;
+        }
 
         let cccd_handle = self.cccd_handle.ok_or(Error::NotFound)?;
         let conn = connection.raw();

--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -6,8 +6,10 @@ use self::client_att_table::ClientAttTables;
 pub use self::client_att_table::{ClientAttTable, ClientAttTableBuilder, ClientAttTableView};
 use crate::att::{self, AttClient, AttCmd, AttErrorCode, AttReq};
 use crate::attribute::{Attribute, AttributeData, AttributeTable, CCCD};
+use crate::connection::Connection;
 use crate::cursor::WriteCursor;
-use crate::prelude::Connection;
+#[cfg(feature = "gatt")]
+use crate::types::gatt_traits::AsGatt;
 use crate::types::uuid::Uuid;
 use crate::{codec, Error, Identity, PacketPool};
 
@@ -780,13 +782,13 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CONN_MAX: 
     /// connection is checked for notification/indication subscriptions and
     /// sent the appropriate PDU.
     #[cfg(feature = "gatt")]
-    pub async fn write_and_notify<C: crate::Controller>(
+    pub async fn write_and_notify<C: crate::Controller, T: AsGatt + ?Sized>(
         &self,
         stack: &crate::Stack<'_, C, P>,
         value_handle: u16,
-        data: &[u8],
+        data: &T,
     ) -> Result<(), Error> {
-        self.att_table.write(value_handle, 0, data)?;
+        self.att_table.write(value_handle, 0, data.as_gatt())?;
 
         // Check if the next handle is a CCCD
         let cccd_handle = value_handle + 1;
@@ -796,18 +798,42 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CONN_MAX: 
             return Ok(());
         }
 
+        self.notify(stack, value_handle, data).await
+    }
+
+    /// Send notifications/indications to all connected peers that have subscribed
+    /// via the CCCD without updating the value stored in the attribute table.
+    ///
+    /// If the attribute at `value_handle + 1` is not a CCCD (UUID 0x2902), an error
+    /// is returned. Each connection is checked for notification/indication
+    /// subscriptions and sent the appropriate PDU.
+    #[cfg(feature = "gatt")]
+    pub async fn notify<C: crate::Controller, T: AsGatt + ?Sized>(
+        &self,
+        stack: &crate::Stack<'_, C, P>,
+        value_handle: u16,
+        data: &T,
+    ) -> Result<(), Error> {
+        // Check if the next handle is a CCCD
+        let cccd_handle = value_handle + 1;
+        if self.att_table.uuid(cccd_handle)
+            != Some(bt_hci::uuid::descriptors::CLIENT_CHARACTERISTIC_CONFIGURATION.into())
+        {
+            return Err(Error::InvalidValue);
+        }
+
+        let data = data.as_gatt();
         for conn in stack.connections() {
-            if self.should_notify(&conn, cccd_handle) {
-                let uns = att::AttUns::Notify {
+            if self.should_indicate(&conn, cccd_handle) {
+                let uns = att::AttUns::Indicate {
                     handle: value_handle,
                     data,
                 };
                 if let Ok(pdu) = crate::gatt::assemble(&conn, att::AttServer::Unsolicited(uns)) {
                     conn.send(pdu).await;
                 }
-            }
-            if self.should_indicate(&conn, cccd_handle) {
-                let uns = att::AttUns::Indicate {
+            } else if self.should_notify(&conn, cccd_handle) {
+                let uns = att::AttUns::Notify {
                     handle: value_handle,
                     data,
                 };

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -394,6 +394,12 @@ impl<'stack, 'server, P: PacketPool> GattEvent<'stack, 'server, P> {
             AttClient::Request(AttReq::Read { .. }) | AttClient::Request(AttReq::ReadBlob { .. }) => {
                 GattEvent::Read(ReadEvent { data, server })
             }
+            #[cfg(feature = "att-queued-writes")]
+            AttClient::Request(AttReq::ExecuteWrite { flags, .. })
+                if flags == 0x01 && data.connection.with_prepare_write(|pw| pw.handle != 0) =>
+            {
+                GattEvent::Write(WriteEvent { data, server })
+            }
             _ => GattEvent::Other(OtherEvent { data, server }),
         }
     }
@@ -504,20 +510,40 @@ pub struct WriteEvent<'stack, 'server, P: PacketPool> {
 impl<'stack, P: PacketPool> WriteEvent<'stack, '_, P> {
     /// Characteristic handle that was written
     pub fn handle(&self) -> u16 {
-        // We know that the unwrap cannot fail, because `ReadEvent` wraps
-        // ATT payloads that always do have a handle
-        unwrap!(self.data.handle())
+        match self.data.incoming() {
+            AttClient::Request(AttReq::Write { handle, .. }) | AttClient::Command(AttCmd::Write { handle, .. }) => {
+                handle
+            }
+            #[cfg(feature = "att-queued-writes")]
+            AttClient::Request(AttReq::ExecuteWrite { .. }) => self.data.connection.with_prepare_write(|pw| pw.handle),
+            _ => unreachable!(),
+        }
     }
 
     /// Raw data to be written
-    pub fn data(&self) -> &[u8] {
-        // Note: write event data is always at offset 3, right?
-        &self.data.pdu.as_ref().unwrap().as_ref()[3..]
+    pub fn with_data<R>(&self, f: impl FnOnce(usize, &[u8]) -> R) -> R {
+        match self.data.incoming() {
+            AttClient::Request(AttReq::Write { data, .. }) | AttClient::Command(AttCmd::Write { data, .. }) => {
+                f(0, data)
+            }
+            #[cfg(feature = "att-queued-writes")]
+            AttClient::Request(AttReq::ExecuteWrite { .. }) => self.data.connection.with_prepare_write(|pw| {
+                let data = &pw.buf[..pw.len as usize];
+                f(usize::from(pw.offset), data)
+            }),
+            _ => unreachable!(),
+        }
     }
 
     /// Characteristic data to be written
     pub fn value<T: FromGatt>(&self, _c: &Characteristic<T>) -> Result<T, FromGattError> {
-        T::from_gatt(self.data())
+        self.with_data(|offset, data| {
+            if offset == 0 {
+                T::from_gatt(data)
+            } else {
+                Err(FromGattError::InvalidLength)
+            }
+        })
     }
 
     /// Accept the event, making it processed by the server.
@@ -1961,7 +1987,7 @@ mod tests {
         match event {
             GattEvent::Write(write) => {
                 assert_eq!(write.handle(), characteristic.handle);
-                assert_eq!(write.data(), &payload);
+                write.with_data(|_, data| assert_eq!(data, &payload));
                 let reply = write.accept().unwrap();
                 assert!(
                     reply.att_payload().is_none(),

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -471,6 +471,36 @@ impl<'stack, P: PacketPool> ReadEvent<'stack, '_, P> {
         process(&mut self.data, self.server, Ok(()))
     }
 
+    /// Accept the event without server processing.
+    pub fn accept_unprocessed<T: AsGatt + ?Sized>(mut self, data: &T) -> Result<Reply<'stack, P>, Error> {
+        let (rsp, offset) = match self.data.incoming() {
+            AttClient::Request(AttReq::Read { .. }) => (att::ATT_READ_RSP, 0),
+            AttClient::Request(AttReq::ReadBlob { offset, .. }) => (att::ATT_READ_BLOB_RSP, offset as usize),
+            _ => unreachable!(),
+        };
+        self.data.pdu = None;
+
+        let mut tx = P::allocate().ok_or(Error::OutOfMemory)?;
+        let mut w = WriteCursor::new(tx.as_mut());
+        let (mut header, mut payload) = w.split(4)?;
+        // Limit the buffer given to process() so that multi-entry ATT responses
+        // (ReadByType, ReadByGroupType, FindInformation) are bounded by the
+        // negotiated ATT MTU. Without this, entries are written into the full
+        // packet-pool buffer and then post-hoc truncated, which can split an
+        // entry in half and produce a malformed PDU.
+        let mtu = self.data.connection.get_att_mtu() as usize;
+        let len = payload.len().saturating_sub(offset).min(mtu - 1);
+
+        payload.write(rsp)?;
+        payload.append(&data.as_gatt()[offset..][..len])?;
+        header.write(payload.len() as u16)?;
+        header.write(4_u16)?;
+
+        let len = header.len() + payload.len();
+        let pdu = Pdu::new(tx, len);
+        Ok(Reply::new(self.data.connection.clone(), Some(pdu)))
+    }
+
     /// Reject the event with the provided error code, it will not be processed by the attribute server.
     pub fn reject(mut self, err: AttErrorCode) -> Result<Reply<'stack, P>, Error> {
         process(&mut self.data, self.server, Err(err))
@@ -546,11 +576,53 @@ impl<'stack, P: PacketPool> WriteEvent<'stack, '_, P> {
         })
     }
 
+    /// Validate the offset and length of the write request against the attribute's `len` and `capacity`
+    pub fn validate(&self, len: usize, capacity: usize) -> Result<(), AttErrorCode> {
+        self.with_data(|offset, data| {
+            if offset > len {
+                Err(AttErrorCode::INVALID_OFFSET)
+            } else if offset + data.len() > capacity {
+                Err(AttErrorCode::INVALID_ATTRIBUTE_VALUE_LENGTH)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
     /// Accept the event, making it processed by the server.
     ///
     /// Automatically called if drop() is invoked.
     pub fn accept(mut self) -> Result<Reply<'stack, P>, Error> {
         process(&mut self.data, self.server, Ok(()))
+    }
+
+    /// Accept the event without server processing.
+    pub fn accept_unprocessed(mut self) -> Result<Reply<'stack, P>, Error> {
+        let rsp = match self.data.incoming() {
+            AttClient::Request(AttReq::Write { .. }) => Some(att::ATT_WRITE_RSP),
+            AttClient::Command(AttCmd::Write { .. }) => None,
+            #[cfg(feature = "att-queued-writes")]
+            AttClient::Request(AttReq::ExecuteWrite { .. }) => {
+                self.data.connection.clear_prepare_write();
+                Some(att::ATT_EXECUTE_WRITE_RSP)
+            }
+            _ => unreachable!(),
+        };
+
+        self.data.pdu = None;
+
+        if let Some(rsp) = rsp {
+            let mut tx = P::allocate().ok_or(Error::OutOfMemory)?;
+            let mut w = WriteCursor::new(tx.as_mut());
+            w.write(1_u16)?;
+            w.write(4_u16)?;
+            w.write(rsp)?;
+            let len = w.len();
+            let pdu = Pdu::new(tx, len);
+            Ok(Reply::new(self.data.connection.clone(), Some(pdu)))
+        } else {
+            Ok(Reply::new(self.data.connection.clone(), None))
+        }
     }
 
     /// Reject the event with the provided error code, it will not be processed by the attribute server.

--- a/host/src/types/gatt_traits.rs
+++ b/host/src/types/gatt_traits.rs
@@ -92,6 +92,29 @@ primitive!(
     BluetoothUuid16
 );
 
+impl FixedGattValue for () {
+    const SIZE: usize = 0;
+}
+
+impl FromGatt for () {
+    fn from_gatt(data: &[u8]) -> Result<Self, FromGattError> {
+        if data.len() != Self::SIZE {
+            Err(FromGattError::InvalidLength)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl AsGatt for () {
+    const MIN_SIZE: usize = Self::SIZE;
+    const MAX_SIZE: usize = Self::SIZE;
+
+    fn as_gatt(&self) -> &[u8] {
+        &[]
+    }
+}
+
 impl FixedGattValue for bool {
     const SIZE: usize = 1;
 }

--- a/tester/app/src/connection.rs
+++ b/tester/app/src/connection.rs
@@ -40,7 +40,7 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                 } => {
                     info!("Gatt Write handle={}", w.handle());
                     let handle = w.handle();
-                    let data = Box::from(w.data());
+                    let data = w.with_data(|_, data| Box::from(data));
                     let reply = w.accept()?;
                     reply.send().await;
                     events.send(Event::AttrValueChanged { handle, data }).await;


### PR DESCRIPTION
This adds missing features necessary to fully support user-managed attributes in an `AttributeTable`. This allows the user's `GattConnection::next()` event loop to fully process GATT requests without their being processed by the `AttributeTable`.

I looked at adding some sort of deferred/closure variant to `AttributeData` as discussed [here](https://github.com/embassy-rs/trouble/pull/561#pullrequestreview-3959232717) and in #441, but I found that at least for my use cases providing the necessary context to a closure was more difficult than just processing it as part of the event loop. I think it would still be possible to add some sort of dyn trait object variant of `AttributeData` if desired, but these changes make the event loop option fully functional.

I updated the `ble_bas_peripheral` example to make the `status` characteristic user-managed to demonstrate the basic approach.

## API Changes

- `Characteristic::notify` and `Characteristic::indicate` get an additional `bool` parameter to control whether the new value should be written to the table or not.
- Added the following methods to `Characteristic`:
  - `notify_raw`
  - `indicate_raw`
  - `should_notify`
  - `should_indicate`
  - `with_raw_value`
- Added `notify` method to `AttributeServer` to send a notification to all clients without writing the value to the table.
- `GattEvent::Write` is extended to also include execute write requests for long attribute value writes.
- `WriteEvent::data() -> &[u8]` becomes `WriteEvent::with_data(Fn(offset, &[u8]))` to support execute write requests.
- `WriteEvent` and `ReadEvent` get `accept_unprocessed()` methods to accept the request without processing by the `AttributeServer`.
- `WriteEvent::validate` validates the write request against the provided attribute length and capacity values and returns a `Result` with the correct `AttErrorCode` on failure.
- Implemented the GATT traits for `()`