### PR TITLE
fix(security): update peer identity when bond is finalized

### DIFF
--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -959,10 +959,16 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
             }
             crate::security_manager::SecurityEventData::TimerChange => (),
             #[cfg(feature = "security")]
-            crate::security_manager::SecurityEventData::BondAdded(identity) => {
+            crate::security_manager::SecurityEventData::BondAdded(handle, identity) => {
                 host.resolving_list_state
                     .borrow_mut()
                     .push(crate::host::ResolvingListUpdate::Add(identity));
+                // Update the connection's stored peer identity to reflect the identity
+                // address distributed during key exchange, which may differ from the
+                // address seen at connection time (e.g. a temporary RPA).
+                if let Some(mut connection) = self.connection_by_handle_mut(handle) {
+                    connection.peer_identity = Some(identity);
+                }
             }
         }
         Ok(())

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -48,7 +48,7 @@ pub(crate) enum SecurityEventData {
     /// Pairing timer changed
     TimerChange,
     /// A new bond was stored during pairing
-    BondAdded(crate::Identity),
+    BondAdded(ConnHandle, crate::Identity),
 }
 
 /// Bond Information
@@ -1171,7 +1171,9 @@ impl<'sm, 'cm, 'cm2, 'cs, P: PacketPool> PairingOps<P> for PairingOpsImpl<'sm, '
     fn try_update_bond_information(&mut self, bond: &BondInformation) -> Result<(), Error> {
         add_bond(self.bonds, bond.clone())?;
         if bond.identity.irk.is_some() {
-            let _ = self.events.try_send(SecurityEventData::BondAdded(bond.identity));
+            let _ = self
+                .events
+                .try_send(SecurityEventData::BondAdded(self.conn_handle, bond.identity));
         }
         Ok(())
     }


### PR DESCRIPTION
When reconnecting a peer that completed bonding earlier in the same instance of the host stack, the stack would crash with `InvalidState`. The reason for this was that pairing state was not properly cleared during disconnect, and the reason for that was that the disconnect procedure compared the identity address in the pairing state machine to the RPA initially received at connection.

This change updates ConnectionManager's storage with the identity address of the peer once bonding is complete so that disconnect properly clears pairing state, allowing reconnect to succeed.