### PR TITLE
fix(att): apply MTU exchange while connection is still Connecting

### DIFF
--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -659,9 +659,13 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         debug!("exchange_att_mtu: {}, current default: {}", mtu, state.default_att_mtu);
         let default_att_mtu = state.default_att_mtu;
         core::mem::drop(state);
+        // Both states are live link-layer connections; the transition
+        // to `Connected` is just the application polling `accept()` and
+        // is unrelated to ATT activity. `handle_acl` already accepts
+        // both via `connection_by_handle_mut`.
         for storage in self.connections.borrow_mut().iter_mut() {
             match storage.state {
-                ConnectionState::Connected if storage.handle.unwrap() == conn => {
+                ConnectionState::Connecting | ConnectionState::Connected if storage.handle.unwrap() == conn => {
                     storage.att_mtu = default_att_mtu.min(mtu);
                     return storage.att_mtu;
                 }


### PR DESCRIPTION
# Problem
`exchange_att_mtu` only matched `ConnectionState::Connected`. When the central's `ATT_EXCHANGE_MTU_REQ` arrived while the storage was still in `Connecting`, the match fell through. The function returned the peer's MTU unchanged so the caller's [host] agreed att MTU and log claimed success, but `storage.att_mtu` was silently left at `23`. For the lifetime of that connection, `gatt::assemble` then truncated every notification > `20` bytes.

Whether the request lands in `Connecting` or `Connected` seems to be scheduling race between the runner task and the application's `accept()` future after `LE Connection Complete`. Sometimes it worked, sometimes not.

# Fix
Add both: `Connecting | Connected`, matching the rest of trouble's ACL ingress (`connection_by_handle_mut`).

Might be fix also for [#232](https://github.com/bislydev/aurora/issues/232).

# Test
Silicon Labs EFR32MG26 + bluez 5.66 on a Raspberry Pi. Runs a chunked write/notify protocol where each END notification carries 35 bytes (3-byte status + 32-byte SHA-256).

## Before the patch:

`defmt log: [host] agreed att MTU of 517` (the fall-through value)
on-air via btmon: `Handle Value Notification len 22 / Data[20]: 0301..` - last 15 bytes of SHA-256 lost
host-side: SHA-256 mismatch, protocol fails

## After the patch:

`defmt log: [host] agreed att MTU of 247` (= default_att_mtu.min(peer))
on-air: full 35-byte notification
host-side: all blob hashes match
