### PR TITLE
fix: configure docs.rs build target and features

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -17,6 +17,10 @@ src_base_git = "https://github.com/embassy-rs/trouble-host/blob/$COMMIT/src/"
 features = ["defmt", "peripheral", "central", "gatt", "scan", "derive", "security"]
 target = "thumbv7em-none-eabi"
 
+[package.metadata.docs.rs]
+features = ["defmt", "peripheral", "central", "gatt", "scan", "derive", "security"]
+targets = ["thumbv7em-none-eabi"]
+
 [dependencies]
 aes = { version = "0.8.2", optional = true }
 bt-hci = { version = "0.8", features = ["uuid"] }


### PR DESCRIPTION
Fixes #604

Adds the correct features and target so that docs.rs can pick it up. Previously, docs.rs was only building with default features leading to many APIs gated behind non-default features hidden. Also sets the target to match the embassy docs (thumbv7em-none-eabi). 