### PR TITLE
cap READ_BY_TYPE response size so Windows can complete discovery

### DIFF
--- a/host/src/attribute_server.rs
+++ b/host/src/attribute_server.rs
@@ -321,7 +321,14 @@ impl<'values, M: RawMutex, P: PacketPool, const ATT_MAX: usize, const CONN_MAX: 
                     // If we get here, we always have had a successful read, and we can check that we still have space
                     // left in the buffer to write the next entry if it exists.
                     if let Ok(expected_length) = ret {
-                        if body.available() < expected_length + 2 {
+                        // Also cap each READ_BY_TYPE response to ~44 bytes. Some
+                        // GATT clients (notably Windows/WinRT) silently reject a
+                        // larger discovery response even when the ATT MTU is much
+                        // bigger and nothing is fragmented — they stop sending
+                        // requests, sit idle, then drop the link. A client just
+                        // re-requests from the next handle, so capping is fully
+                        // spec-valid; it only adds a few round-trips at discovery.
+                        if body.available() < expected_length + 2 || body.len() >= 40 {
                             break;
                         }
                     }


### PR DESCRIPTION
WinRT's GATT client silently rejects a READ_BY_TYPE response once it gets a bit big — even with ATT MTU 251 and nothing fragmented. it handles the small responses fine, then after an ~86 byte one (4 char declarations) it just stops: sends no more requests, sits idle ~30s, drops the link. flutter side reports `discoverServices` "Unknown error".

repro: nrf52 peripheral (nrf-sdc + trouble), a service with 4+ characteristics that all have 128-bit UUIDs, so each READ_BY_TYPE entry is 21 bytes -> 4 entries = 86B. connect from windows. android / ios / linux are all fine, only windows chokes.

```rust
#[gatt_service(uuid = "12345678-1234-5678-1234-56789abcdef0")]
struct Svc {
    #[characteristic(uuid = "...def1", read, notify)] a: [u8; 4],
    #[characteristic(uuid = "...def2", read, notify)] b: [u8; 4],
    #[characteristic(uuid = "...def3", read, notify)] c: [u8; 4],
    #[characteristic(uuid = "...def4", read, notify)] d: [u8; 4],
}
```

this caps each READ_BY_TYPE response at ~44B (2-ish entries). the client just re-requests from the next handle, which is totally legal — costs a couple extra round trips at discovery only. with it, windows finishes discovery + the notify subscribe first try.

the magic number isn't pretty, i'll admit — happy to gate it behind a cargo feature or make it configurable if you'd rather. just wanted to get the fix up since the peripheral was basically unusable from windows without it.
