### PR TITLE
Configurable advertising packet filtering

### DIFF
--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -7,8 +7,8 @@ use bt_hci::cmd::le::{
 use bt_hci::cmd::status::ReadRssi;
 use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
 use bt_hci::param::{
-    AllPhys, ConnHandle, DisconnectReason, FrameSpaceInitiator, LeConnRole, PhyKind, PhyMask, PhyOptions, SpacingTypes,
-    Status,
+    AllPhys, ConnHandle, DisconnectReason, FilterDuplicates, FrameSpaceInitiator, LeConnRole, PhyKind, PhyMask,
+    PhyOptions, SpacingTypes, Status,
 };
 #[cfg(feature = "connection-params-update")]
 use bt_hci::{
@@ -80,6 +80,8 @@ pub struct ScanConfig<'d> {
     pub window: Duration,
     /// Scan timeout.
     pub timeout: Duration,
+    /// Duplicate advertising filtering.
+    pub filter_duplicates: FilterDuplicates,
 }
 
 impl Default for ScanConfig<'_> {
@@ -91,6 +93,7 @@ impl Default for ScanConfig<'_> {
             interval: Duration::from_secs(1),
             window: Duration::from_secs(1),
             timeout: Duration::from_secs(0),
+            filter_duplicates: FilterDuplicates::Disabled,
         }
     }
 }

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -69,7 +69,7 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
 
         host.command(LeSetExtScanEnable::new(
             true,
-            FilterDuplicates::Disabled,
+            config.filter_duplicates,
             bt_hci_duration(config.timeout),
             bt_hci::param::Duration::from_secs(0),
         ))
@@ -121,7 +121,8 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
         );
         host.command(params).await?;
 
-        host.command(LeSetScanEnable::new(true, true)).await?;
+        let filter_duplicates = !matches!(config.filter_duplicates, FilterDuplicates::Disabled);
+        host.command(LeSetScanEnable::new(true, filter_duplicates)).await?;
         drop.defuse();
         Ok(ScanSession {
             command_state: &self.central.host.scan_command_state,


### PR DESCRIPTION
There's currently no way to specify whether we want to filter duplicate advertising packets.

```rs
// trouble/host/src/scan.rs:124
// The second true hardcodes it to deduping
host.command(LeSetScanEnable::new(true, true)).await?;
```

This PR just adds that field to `ScanConfig` and we thread it through.

I think this technically is a "breaking change" since we don't have a #[non_exhaustive] on ScanConfig.

But everywhere in the codebase uses `..Default::default()` as far as I can tell.

This will also be a small behavior change too for `scan` - it used to default to deduping - and now we unify on not deduping same as `scan_ext`. For consistency alone, I think this PR is worth it.

Legacy scan users who want back the old behavior, they'll need to opt back in:

```rs
ScanConfig {
  filter_duplicates: FilterDuplicates::Enabled
  ..
}
```

Let me know if you rather not the change of behavior, I think I might be able to finesse it but the diff will look a bit uglier