### PR TITLE
security: fix re-pairing rejection for peers with resolved addresses

### DIFF
--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -318,8 +318,18 @@ impl Inner {
         }
         let address = self.pairing_sm.as_ref().unwrap().peer_address();
 
-        if address != peer_address {
-            // TODO Is this correct?
+        // The state machine stores the connection-level peer address: the RPA,
+        // when the controller resolved one (see `connection_peer_address`, and
+        // the SMP confirm-value calculations that require the on-air address).
+        // The incoming command carries the *resolved identity* address, so the
+        // command address must be normalized the same way before comparing.
+        // Comparing them directly rejected every pairing attempt from a peer
+        // whose RPA was resolved against a stored bond -- i.e. a bonded peer
+        // that lost its keys could never re-pair until the local bond (and so
+        // the resolving-list entry) was deleted.
+        if address != Self::connection_peer_address(peer_address, storage) {
+            // A pairing is already in progress with a *different* peer address;
+            // reject and reset rather than mixing two exchanges.
             self.pairing_sm = None;
             return Err(Error::InvalidValue);
         }
@@ -388,8 +398,13 @@ impl Inner {
         }
         let address = self.pairing_sm.as_ref().unwrap().peer_address();
 
-        if address != peer_address {
-            // TODO Is this correct?
+        // See the matching check in `handle_peripheral`: the state machine
+        // stores the connection-level peer address (the RPA when one was
+        // resolved), while the command carries the resolved identity, so the
+        // command address must be normalized before comparing.
+        if address != Self::connection_peer_address(peer_address, storage) {
+            // A pairing is already in progress with a *different* peer address;
+            // reject and reset rather than mixing two exchanges.
             self.pairing_sm = None;
             return Err(Error::InvalidValue);
         }


### PR DESCRIPTION
I have some local hardware that is using BLE bonding and I've been testing out the bonding and PIN authentication. During testing, I ran into the problem where my phone would forget the bond and try to reconnect but it was failing. With help from Claude, the problem was fixed with this change which looks correct although I don't have a good understanding of the security manager internals. This change was patched by Claude into my local fork and the suggested PR description is below:

---

**Problem**: Once a peer is bonded, its IRK is in the resolving list, so its next connection arrives with a resolved identity address. If that peer deletes its keys (user un-pairs on the phone) and attempts to re-pair, the very first PairingRequest is rejected with InvalidValue and the host responds PairingFailed — the phone shows a generic pairing error, and re-pairing is impossible until the local bond is deleted (which empties the resolving list).

**Cause:** The pairing dispatch in security_manager/mod.rs guards against commands from a different peer by comparing the state machine's peer address with the command's. The state machine stores the connection-level address — the RPA when one was resolved (required for SMP confirm-value calculations) — while the command carries the resolved identity. For a resolved peer these can never match. (The guard was already flagged `// TODO Is this correct?`.)

**Fix:** Normalize the command address with connection_peer_address before comparing, in both roles. The guard still rejects interleaved exchanges from a genuinely different peer.

Verified on hardware (RP2040 + cyw43 peripheral): Android and macOS centrals that had forgotten their bond can now re-pair while the peripheral retains the stale bond; the completed re-pair replaces it.