### PR TITLE
feat(gatt): Wait for handle value confirmation after sending indication

### DIFF
--- a/benchmarks/nrf-sdc/Cargo.lock
+++ b/benchmarks/nrf-sdc/Cargo.lock
@@ -72,21 +72,6 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bt-hci"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211713d2e9fb4793ce4360a712c0764264aff6be48932ccf02ca2a331c0436a9"
-dependencies = [
- "btuuid",
- "defmt 1.1.0",
- "embassy-sync",
- "embedded-io",
- "embedded-io-async",
- "futures-intrusive",
- "heapless",
-]
-
-[[package]]
-name = "bt-hci"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3c66fd0a41a3b3a5906847b1bf5516048ce083e24fa9341a0fa31d3b4cd73d"
@@ -562,9 +547,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed"
-version = "1.31.0"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
+checksum = "c566da967934c6c7ee0458a9773de9b2a685bd2ce26a3b28ddfc740e640182f5"
 dependencies = [
  "az",
  "bytemuck",
@@ -831,7 +816,7 @@ dependencies = [
 [[package]]
 name = "nrf-mpsl"
 version = "0.3.0"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=812a56e3411bc3ff850d354401d95221e1f4fb84#812a56e3411bc3ff850d354401d95221e1f4fb84"
+source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=8062911a0e1e8f06f74ded93b2fb483050a84887#8062911a0e1e8f06f74ded93b2fb483050a84887"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -848,7 +833,7 @@ dependencies = [
 [[package]]
 name = "nrf-mpsl-sys"
 version = "0.2.1"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=812a56e3411bc3ff850d354401d95221e1f4fb84#812a56e3411bc3ff850d354401d95221e1f4fb84"
+source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=8062911a0e1e8f06f74ded93b2fb483050a84887#8062911a0e1e8f06f74ded93b2fb483050a84887"
 dependencies = [
  "bindgen",
  "doxygen-rs",
@@ -867,12 +852,11 @@ dependencies = [
 [[package]]
 name = "nrf-sdc"
 version = "0.4.0"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=812a56e3411bc3ff850d354401d95221e1f4fb84#812a56e3411bc3ff850d354401d95221e1f4fb84"
+source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=8062911a0e1e8f06f74ded93b2fb483050a84887#8062911a0e1e8f06f74ded93b2fb483050a84887"
 dependencies = [
- "bt-hci 0.8.1",
+ "bt-hci",
  "critical-section",
  "defmt 1.1.0",
- "embassy-hal-internal 0.5.0",
  "embassy-nrf",
  "embassy-sync",
  "embedded-io",
@@ -885,7 +869,7 @@ dependencies = [
 [[package]]
 name = "nrf-sdc-sys"
 version = "0.2.1"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=812a56e3411bc3ff850d354401d95221e1f4fb84#812a56e3411bc3ff850d354401d95221e1f4fb84"
+source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=8062911a0e1e8f06f74ded93b2fb483050a84887#8062911a0e1e8f06f74ded93b2fb483050a84887"
 dependencies = [
  "bindgen",
  "doxygen-rs",
@@ -1282,7 +1266,7 @@ dependencies = [
 name = "trouble-host"
 version = "0.6.0"
 dependencies = [
- "bt-hci 0.9.0",
+ "bt-hci",
  "defmt 1.1.0",
  "embassy-futures",
  "embassy-sync",
@@ -1299,7 +1283,7 @@ dependencies = [
 name = "trouble-nrf-sdc-tests"
 version = "0.1.0"
 dependencies = [
- "bt-hci 0.9.0",
+ "bt-hci",
  "cortex-m",
  "cortex-m-rt",
  "defmt 0.3.100",
@@ -1309,6 +1293,7 @@ dependencies = [
  "embassy-nrf",
  "embassy-sync",
  "embassy-time",
+ "fixed",
  "futures",
  "nrf-mpsl",
  "nrf-sdc",

--- a/benchmarks/nrf-sdc/Cargo.toml
+++ b/benchmarks/nrf-sdc/Cargo.toml
@@ -25,6 +25,8 @@ cortex-m-rt = "0.7.0"
 panic-probe = { version = "1.0", features = ["print-defmt"] }
 static_cell = "2"
 
+fixed = "=1.30.0"
+
 [profile.release]
 debug = 2
 

--- a/docs/pages/gatt.adoc
+++ b/docs/pages/gatt.adoc
@@ -143,7 +143,7 @@ level.notify(&conn, &new_value, true).await?;
 level.indicate(&conn, &new_value, true).await?;
 ----
 
-NOTE: Notifications/indications will only be delivered if the client has enabled them by writing to the characteristic's CCCD (Client Characteristic Configuration Descriptor). The `notify` and `indicate` calls return an error if the client hasn't subscribed.
+NOTE: Notifications/indications will only be delivered if the client has enabled them by writing to the characteristic's CCCD (Client Characteristic Configuration Descriptor).
 
 == The GATT Client
 

--- a/examples/apps/Cargo.toml
+++ b/examples/apps/Cargo.toml
@@ -23,6 +23,7 @@ defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4", optional = true }
 serde = { version = "1.0.228", default-features = false, features = ["derive"], optional = true }
 
+fixed = "=1.30.0"
 
 [features]
 defmt = [

--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -44,6 +44,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +231,12 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1198,6 +1210,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixed"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c566da967934c6c7ee0458a9773de9b2a685bd2ce26a3b28ddfc740e640182f5"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "typenum",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1348,17 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2288,6 +2323,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal-async",
  "embedded-storage-async",
+ "fixed",
  "heapless 0.9.3",
  "log",
  "rand_core 0.6.4",

--- a/examples/nrf52/Cargo.lock
+++ b/examples/nrf52/Cargo.lock
@@ -725,9 +725,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed"
-version = "1.31.0"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
+checksum = "c566da967934c6c7ee0458a9773de9b2a685bd2ce26a3b28ddfc740e640182f5"
 dependencies = [
  "az",
  "bytemuck",
@@ -1675,6 +1675,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal-async",
  "embedded-storage-async",
+ "fixed",
  "heapless 0.9.3",
  "rand_core 0.6.4",
  "sequential-storage",

--- a/examples/nrf54/Cargo.lock
+++ b/examples/nrf54/Cargo.lock
@@ -720,9 +720,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed"
-version = "1.31.0"
+version = "1.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af2cbf772fa6d1c11358f92ef554cb6b386201210bcf0e91fb7fba8a907fb40"
+checksum = "c566da967934c6c7ee0458a9773de9b2a685bd2ce26a3b28ddfc740e640182f5"
 dependencies = [
  "az",
  "bytemuck",
@@ -1676,6 +1676,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal-async",
  "embedded-storage-async",
+ "fixed",
  "heapless 0.9.3",
  "rand_core 0.6.4",
  "sequential-storage",

--- a/examples/rp-pico-2-w/Cargo.lock
+++ b/examples/rp-pico-2-w/Cargo.lock
@@ -2584,6 +2584,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-hal-async",
+ "fixed",
  "heapless",
  "rand_core 0.6.4",
  "static_cell",

--- a/examples/rp-pico-w/Cargo.lock
+++ b/examples/rp-pico-w/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
  "embassy-sync",
  "embassy-time",
  "embedded-hal-async",
+ "fixed",
  "heapless",
  "rand_core 0.6.4",
  "static_cell",

--- a/examples/serial-hci/Cargo.lock
+++ b/examples/serial-hci/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -189,6 +201,12 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -469,6 +487,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c566da967934c6c7ee0458a9773de9b2a685bd2ce26a3b28ddfc740e640182f5"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "typenum",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +633,17 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1270,6 +1311,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal-async",
  "embedded-storage-async",
+ "fixed",
  "heapless 0.9.3",
  "log",
  "rand_core 0.6.4",

--- a/examples/usb-hci/Cargo.lock
+++ b/examples/usb-hci/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "bt-hci"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211713d2e9fb4793ce4360a712c0764264aff6be48932ccf02ca2a331c0436a9"
+checksum = "8f3c66fd0a41a3b3a5906847b1bf5516048ce083e24fa9341a0fa31d3b4cd73d"
 dependencies = [
  "btuuid",
  "embassy-sync",
@@ -144,6 +150,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -244,6 +256,12 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -521,6 +539,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c566da967934c6c7ee0458a9773de9b2a685bd2ce26a3b28ddfc740e640182f5"
+dependencies = [
+ "az",
+ "bytemuck",
+ "half",
+ "typenum",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +657,17 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1230,6 +1271,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal-async",
  "embedded-storage-async",
+ "fixed",
  "heapless 0.9.2",
  "log",
  "rand_core",

--- a/host/src/attribute.rs
+++ b/host/src/attribute.rs
@@ -7,11 +7,13 @@ use bt_hci::uuid::declarations::{CHARACTERISTIC, INCLUDE, PRIMARY_SERVICE, SECON
 use bt_hci::uuid::descriptors::CLIENT_CHARACTERISTIC_CONFIGURATION;
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_sync::blocking_mutex::Mutex;
+use embassy_time::with_timeout;
 use heapless::Vec;
 
 use crate::att::{AttErrorCode, AttUns};
 use crate::attribute_server::AttributeServer;
 use crate::cursor::{ReadCursor, WriteCursor};
+use crate::gatt::ATT_TRANSACTION_TIMEOUT;
 use crate::prelude::{AsGatt, FixedGattValue, FromGatt, GattConnection, SecurityLevel};
 use crate::types::gatt_traits::FromGattError;
 pub use crate::types::uuid::Uuid;
@@ -1059,8 +1061,11 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
     ///
     /// If the characteristic does not support indications, an error is returned.
     ///
-    /// This function does not block for the confirmation to the indication message, if the client sends a confirmation
-    /// this will be seen on the [GattConnection] as a [crate::att::AttClient::Confirmation] event.
+    /// Blocks until the peer's `HandleValueConfirmation` is received, for up to 30 seconds
+    /// (BT Core Spec Vol 3, Part F, Section 3.3.3 ATT transaction timeout). On timeout the
+    /// connection is closed and `Error::Timeout` is returned. Concurrent calls on the same
+    /// connection are serialized; callers do not need to coordinate. Returns
+    /// `Error::Disconnected` if the connection is dropped while waiting.
     pub async fn indicate<P: PacketPool>(
         &self,
         connection: &GattConnection<'_, '_, P>,
@@ -1078,8 +1083,11 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
     ///
     /// If the characteristic does not support indications, an error is returned.
     ///
-    /// This function does not block for the confirmation to the indication message, if the client sends a confirmation
-    /// this will be seen on the [GattConnection] as a [crate::att::AttClient::Confirmation] event.
+    /// Blocks until the peer's `HandleValueConfirmation` is received, for up to 30 seconds
+    /// (BT Core Spec Vol 3, Part F, Section 3.3.3 ATT transaction timeout). On timeout the
+    /// connection is closed and `Error::Timeout` is returned. Concurrent calls on the same
+    /// connection are serialized; callers do not need to coordinate. Returns
+    /// `Error::Disconnected` if the connection is dropped while waiting.
     pub async fn indicate_raw<P: PacketPool>(
         &self,
         connection: &GattConnection<'_, '_, P>,
@@ -1100,13 +1108,25 @@ impl<T: AsGatt + ?Sized> Characteristic<T> {
 
         self.authorize_unsolicited(connection, cccd_handle).await?;
 
+        conn.acquire_indication_slot().await?;
+        let _drop = crate::host::OnDrop::new(|| conn.release_indication_slot());
+
         let uns = AttUns::Indicate {
             handle: self.handle,
             data: value,
         };
         let pdu = gatt::assemble(conn, crate::att::AttServer::Unsolicited(uns))?;
         conn.send(pdu).await;
-        Ok(())
+
+        match with_timeout(ATT_TRANSACTION_TIMEOUT, conn.wait_indication_confirmation()).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(e),
+            Err(_) => {
+                warn!("[gatt] ATT transaction timeout (30s) waiting for indication confirmation, disconnecting");
+                conn.disconnect();
+                Err(Error::Timeout)
+            }
+        }
     }
 
     /// Set the value of the characteristic in the provided attribute server.

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -546,6 +546,21 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         self.manager.next_gatt_client(self.index).await
     }
 
+    #[cfg(feature = "gatt")]
+    pub(crate) async fn acquire_indication_slot(&self) -> Result<(), Error> {
+        self.manager.acquire_indication_slot(self.index).await
+    }
+
+    #[cfg(feature = "gatt")]
+    pub(crate) fn release_indication_slot(&self) {
+        self.manager.release_indication_slot(self.index)
+    }
+
+    #[cfg(feature = "gatt")]
+    pub(crate) async fn wait_indication_confirmation(&self) -> Result<(), Error> {
+        self.manager.wait_indication_confirmation(self.index).await
+    }
+
     /// Check if still connected
     pub fn is_connected(&self) -> bool {
         self.manager.is_connected(self.index)

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -264,6 +264,60 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         .await
     }
 
+    #[cfg(feature = "gatt")]
+    pub(crate) async fn acquire_indication_slot(&self, index: u8) -> Result<(), Error> {
+        poll_fn(|cx| {
+            let mut connections = self.connections.borrow_mut();
+            let storage = &mut connections[index as usize];
+            if storage.state == ConnectionState::Disconnected {
+                return Poll::Ready(Err(Error::Disconnected));
+            }
+            if !storage.indication_in_flight {
+                storage.indication_in_flight = true;
+                storage.indication_cfm_received = false;
+                return Poll::Ready(Ok(()));
+            }
+            storage.indication_slot_waker.register(cx.waker());
+            Poll::Pending
+        })
+        .await
+    }
+
+    #[cfg(feature = "gatt")]
+    pub(crate) fn release_indication_slot(&self, index: u8) {
+        let mut connections = self.connections.borrow_mut();
+        let storage = &mut connections[index as usize];
+        storage.indication_in_flight = false;
+        storage.indication_cfm_received = false;
+        storage.indication_slot_waker.wake();
+    }
+
+    #[cfg(feature = "gatt")]
+    pub(crate) async fn wait_indication_confirmation(&self, index: u8) -> Result<(), Error> {
+        poll_fn(|cx| {
+            let mut connections = self.connections.borrow_mut();
+            let storage = &mut connections[index as usize];
+            if storage.indication_cfm_received {
+                storage.indication_cfm_received = false;
+                return Poll::Ready(Ok(()));
+            }
+            if storage.state == ConnectionState::Disconnected {
+                return Poll::Ready(Err(Error::Disconnected));
+            }
+            storage.indication_cfm_waker.register(cx.waker());
+            Poll::Pending
+        })
+        .await
+    }
+
+    #[cfg(feature = "gatt")]
+    pub(crate) fn signal_indication_confirmation(&self, h: ConnHandle) {
+        if let Some(mut entry) = self.connection_by_handle_mut(h) {
+            entry.indication_cfm_received = true;
+            entry.indication_cfm_waker.wake();
+        }
+    }
+
     pub(crate) fn peer_address(&self, index: u8) -> Address {
         self.connection(index).peer_identity.map(|i| i.addr).unwrap_or_default()
     }
@@ -403,6 +457,10 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 {
                     storage.gatt.clear();
                     storage.gatt_client_waker.wake();
+                    storage.indication_in_flight = false;
+                    storage.indication_cfm_received = false;
+                    storage.indication_slot_waker.wake();
+                    storage.indication_cfm_waker.wake();
                 }
                 #[cfg(feature = "connection-metrics")]
                 storage.metrics.reset();
@@ -1107,6 +1165,14 @@ pub struct ConnectionStorage<P> {
     pub(crate) gatt_client: GattChannel<P>,
     #[cfg(feature = "gatt")]
     pub(crate) gatt_client_waker: WakerRegistration,
+    #[cfg(feature = "gatt")]
+    pub(crate) indication_in_flight: bool,
+    #[cfg(feature = "gatt")]
+    pub(crate) indication_slot_waker: WakerRegistration,
+    #[cfg(feature = "gatt")]
+    pub(crate) indication_cfm_received: bool,
+    #[cfg(feature = "gatt")]
+    pub(crate) indication_cfm_waker: WakerRegistration,
     #[cfg(feature = "att-queued-writes")]
     pub(crate) prepare_write: PrepareWriteState,
 }
@@ -1205,6 +1271,14 @@ impl<P> ConnectionStorage<P> {
             gatt_client: GattChannel::new(),
             #[cfg(feature = "gatt")]
             gatt_client_waker: WakerRegistration::new(),
+            #[cfg(feature = "gatt")]
+            indication_in_flight: false,
+            #[cfg(feature = "gatt")]
+            indication_slot_waker: WakerRegistration::new(),
+            #[cfg(feature = "gatt")]
+            indication_cfm_received: false,
+            #[cfg(feature = "gatt")]
+            indication_cfm_waker: WakerRegistration::new(),
             reassembly: PacketReassembly::new(),
             #[cfg(feature = "security")]
             bondable: false,

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -937,7 +937,7 @@ const MAX_NOTIF: usize = config::GATT_CLIENT_NOTIFICATION_MAX_SUBSCRIBERS;
 const NOTIF_QSIZE: usize = config::GATT_CLIENT_NOTIFICATION_QUEUE_SIZE;
 
 /// BT Core Spec Vol 3, Part F, Section 3.3.3: ATT transaction timeout.
-const ATT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const ATT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A GATT client capable of using the GATT protocol.
 pub struct GattClient<'reference, T: Controller, P: PacketPool, const MAX_SERVICES: usize> {

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -36,6 +36,8 @@ use crate::BondInformation;
 use crate::{config, BleHostError, Error, PacketPool, Stack, MAX_INVALID_DATA_LEN};
 
 /// A GATT connection event.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GattConnectionEvent<'stack, 'server, P: PacketPool> {
     /// Connection disconnected.
     Disconnected {
@@ -311,6 +313,19 @@ pub struct GattData<'stack, P: PacketPool> {
     connection: Connection<'stack, P>,
 }
 
+impl<P: PacketPool> core::fmt::Debug for GattData<'_, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("GattData").field(&self.pdu).finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<P: PacketPool> defmt::Format for GattData<'_, P> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "GattData({})", &self.pdu)
+    }
+}
+
 impl<'stack, P: PacketPool> GattData<'stack, P> {
     pub(crate) const fn new(pdu: Pdu<P::Packet>, connection: Connection<'stack, P>) -> Self {
         Self {
@@ -361,6 +376,8 @@ impl<'stack, P: PacketPool> GattData<'stack, P> {
 }
 
 /// An event returned while processing GATT requests.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GattEvent<'stack, 'server, P: PacketPool> {
     /// A characteristic was read.
     Read(ReadEvent<'stack, 'server, P>),
@@ -465,6 +482,19 @@ pub struct ReadEvent<'stack, 'server, P: PacketPool> {
     server: &'server dyn DynamicAttributeServer<P>,
 }
 
+impl<P: PacketPool> core::fmt::Debug for ReadEvent<'_, '_, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("ReadEvent").field(&self.data).finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<P: PacketPool> defmt::Format for ReadEvent<'_, '_, P> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "ReadEvent({})", &self.data)
+    }
+}
+
 impl<'stack, P: PacketPool> ReadEvent<'stack, '_, P> {
     /// Characteristic handle that was read
     pub fn handle(&self) -> u16 {
@@ -544,6 +574,19 @@ impl<P: PacketPool> Drop for ReadEvent<'_, '_, P> {
 pub struct WriteEvent<'stack, 'server, P: PacketPool> {
     data: GattData<'stack, P>,
     server: &'server dyn DynamicAttributeServer<P>,
+}
+
+impl<P: PacketPool> core::fmt::Debug for WriteEvent<'_, '_, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("WriteEvent").field(&self.data).finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<P: PacketPool> defmt::Format for WriteEvent<'_, '_, P> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "WriteEvent({})", &self.data)
+    }
 }
 
 impl<'stack, P: PacketPool> WriteEvent<'stack, '_, P> {
@@ -670,6 +713,19 @@ pub struct OtherEvent<'stack, 'server, P: PacketPool> {
     server: &'server dyn DynamicAttributeServer<P>,
 }
 
+impl<P: PacketPool> core::fmt::Debug for OtherEvent<'_, '_, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("OtherEvent").field(&self.data).finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<P: PacketPool> defmt::Format for OtherEvent<'_, '_, P> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "OtherEvent({})", &self.data)
+    }
+}
+
 impl<'stack, P: PacketPool> OtherEvent<'stack, '_, P> {
     /// Accept the event, making it processed by the server.
     ///
@@ -713,6 +769,19 @@ pub struct NotAllowedEvent<'stack, 'server, P: PacketPool> {
     data: GattData<'stack, P>,
     err: AttErrorCode,
     server: &'server dyn DynamicAttributeServer<P>,
+}
+
+impl<P: PacketPool> core::fmt::Debug for NotAllowedEvent<'_, '_, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("NotAllowedEvent").field(&self.data).finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<P: PacketPool> defmt::Format for NotAllowedEvent<'_, '_, P> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "NotAllowedEvent({})", &self.data)
+    }
 }
 
 impl<'stack, P: PacketPool> NotAllowedEvent<'stack, '_, P> {

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -754,6 +754,9 @@ where
                 } else {
                     #[cfg(feature = "gatt")]
                     match a {
+                        Ok(att::Att::Client(AttClient::Confirmation(_))) => {
+                            self.connections.signal_indication_confirmation(acl.handle());
+                        }
                         Ok(att::Att::Client(_)) => {
                             self.connections.post_gatt(acl.handle(), pdu)?;
                         }

--- a/host/src/pdu.rs
+++ b/host/src/pdu.rs
@@ -17,6 +17,19 @@ impl<P> Pdu<P> {
     }
 }
 
+impl<P: Packet> core::fmt::Debug for Pdu<P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Pdu").field(&&self.packet.as_ref()[..self.len]).finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<P: Packet> defmt::Format for Pdu<P> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "Pdu({=[u8]:02x})", &self.packet.as_ref()[..self.len])
+    }
+}
+
 impl<P: Packet> AsRef<[u8]> for Pdu<P> {
     fn as_ref(&self) -> &[u8] {
         &self.packet.as_ref()[..self.len]


### PR DESCRIPTION
`Characteristic::indicate` and `Characteristic::indicate_raw` now wait for the handle value confirmation packet to be received before returning. This allows trouble to enforce that only one indication may be in-flight on a connection at a time. It also allows the ATT_TIMEOUT to be respected for indications.

I also locked the `fixed` crate to 1.30.0 because newer versions are not compatible with rust 1.92. If you'd prefer to update our MSRV let me know.