### PR TITLE
fix: L2CAP ACL fragmentation and ATT MTU exchange

### DIFF
--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -985,14 +985,14 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         let (first, remaining) = buf.split_at(buf.len().min(mps as usize - 2));
 
         let len = encode(first, &mut p_buf[..], peer_cid, Some(buf.len() as u16))?;
-        ble.l2cap(conn, (len - 4) as u16, 1).await?.send(&p_buf[..len]).await?;
+        ble.l2cap_pdu(conn, len as u16).await?.send(&p_buf[..len]).await?;
         grant.confirm(1);
 
         let chunks = remaining.chunks(mps as usize);
 
         for chunk in chunks {
             let len = encode(chunk, &mut p_buf[..], peer_cid, None)?;
-            ble.l2cap(conn, (len - 4) as u16, 1).await?.send(&p_buf[..len]).await?;
+            ble.l2cap_pdu(conn, len as u16).await?.send(&p_buf[..len]).await?;
             grant.confirm(1);
         }
         Ok(())
@@ -1016,7 +1016,8 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         }
 
         // The number of packets we'll need to send for this payload
-        let len = (buf.len() as u16).saturating_add(2);
+        let sdu_len = buf.len() as u16;
+        let len = sdu_len.saturating_add(2);
         let n_packets = len.div_ceil(mps);
 
         let mut grant = match self.poll_request_to_send(index, n_packets, None) {
@@ -1027,7 +1028,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         };
 
         // Pre-request
-        let mut sender = ble.try_l2cap(conn, len, n_packets)?;
+        let mut sender = ble.try_l2cap_sdu(conn, sdu_len, mps)?;
 
         // Segment using mps
         let (first, remaining) = buf.split_at(buf.len().min(mps as usize - 2));

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -985,14 +985,14 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         let (first, remaining) = buf.split_at(buf.len().min(mps as usize - 2));
 
         let len = encode(first, &mut p_buf[..], peer_cid, Some(buf.len() as u16))?;
-        ble.l2cap_pdu(conn, len as u16).await?.send(&p_buf[..len]).await?;
+        ble.l2cap_pdu(conn).await?.send(&p_buf[..len]).await?;
         grant.confirm(1);
 
         let chunks = remaining.chunks(mps as usize);
 
         for chunk in chunks {
             let len = encode(chunk, &mut p_buf[..], peer_cid, None)?;
-            ble.l2cap_pdu(conn, len as u16).await?.send(&p_buf[..len]).await?;
+            ble.l2cap_pdu(conn).await?.send(&p_buf[..len]).await?;
             grant.confirm(1);
         }
         Ok(())

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -19,9 +19,9 @@ use bt_hci::{
 use embassy_sync::blocking_mutex::raw::RawMutex;
 use embassy_time::Duration;
 
-use crate::connection_manager::ConnectionManager;
 #[cfg(feature = "connection-metrics")]
 pub use crate::connection_manager::Metrics as ConnectionMetrics;
+use crate::connection_manager::{ConnectionManager, ConnectionState};
 use crate::pdu::Pdu;
 #[cfg(feature = "gatt")]
 use crate::prelude::{AttributeServer, GattConnection};
@@ -509,6 +509,14 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         Self { index, manager }
     }
 
+    pub(crate) fn manager(&self) -> &ConnectionManager<'stack, P> {
+        self.manager
+    }
+
+    pub(crate) fn index(&self) -> u8 {
+        self.index
+    }
+
     pub(crate) fn set_att_mtu(&self, mtu: u16) {
         self.manager.set_att_mtu(self.index, mtu);
     }
@@ -561,6 +569,10 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
     #[cfg(feature = "gatt")]
     pub(crate) async fn wait_indication_confirmation(&self) -> Result<(), Error> {
         self.manager.wait_indication_confirmation(self.index).await
+    }
+
+    pub(crate) fn state(&self) -> ConnectionState {
+        self.manager.state(self.index)
     }
 
     /// Check if still connected

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -525,6 +525,10 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         self.manager.get_att_mtu(self.index)
     }
 
+    pub(crate) fn is_att_mtu_exchanged(&self) -> bool {
+        self.manager.is_att_mtu_exchanged(self.index)
+    }
+
     pub(crate) fn set_l2cap_listening(&self, listening: bool) {
         self.manager.set_l2cap_listening(self.index, listening);
     }

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -98,7 +98,6 @@ struct State {
     peripheral_waker: WakerRegistration,
     disconnect_waker: WakerRegistration,
     default_link_credits: usize,
-    default_att_mtu: u16,
 }
 
 type EventChannel = Channel<NoopRawMutex, ConnectionEvent, { config::CONNECTION_EVENT_QUEUE_SIZE }>;
@@ -115,7 +114,6 @@ pub(crate) struct ConnectionManager<'d, P: PacketPool> {
 impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     pub(crate) fn new(
         connections: &'d RefCell<[ConnectionStorage<P::Packet>]>,
-        default_att_mtu: u16,
         #[cfg(feature = "security")] bond_storage: &'d RefCell<heapless::VecView<crate::BondInformation>>,
     ) -> Self {
         Self {
@@ -124,7 +122,6 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 peripheral_waker: WakerRegistration::new(),
                 disconnect_waker: WakerRegistration::new(),
                 default_link_credits: 0,
-                default_att_mtu,
             }),
             connections,
             outbound: Channel::new(),
@@ -517,7 +514,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     ) -> Result<(), Error> {
         let mut state = self.state.borrow_mut();
         let default_credits = state.default_link_credits;
-        let default_att_mtu = state.default_att_mtu;
+        let default_att_mtu = self.default_att_mtu();
         for (idx, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
             if ConnectionState::Disconnected == storage.state && storage.refcount == 0 {
                 storage.events.clear();
@@ -641,9 +638,8 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         }
     }
 
-    pub(crate) fn set_default_att_mtu(&self, att_mtu: u16) {
-        let mut state = self.state.borrow_mut();
-        state.default_att_mtu = att_mtu;
+    pub(crate) const fn default_att_mtu(&self) -> u16 {
+        (P::MTU - 4) as u16
     }
 
     pub(crate) fn confirm_sent(&self, handle: ConnHandle, packets: usize) -> Result<(), Error> {
@@ -726,14 +722,12 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 _ => {}
             }
         }
-        self.state.borrow().default_att_mtu
+        self.default_att_mtu()
     }
 
     pub(crate) fn exchange_att_mtu(&self, conn: ConnHandle, mtu: u16) -> u16 {
-        let state = self.state.borrow();
-        debug!("exchange_att_mtu: {}, current default: {}", mtu, state.default_att_mtu);
-        let default_att_mtu = state.default_att_mtu;
-        core::mem::drop(state);
+        debug!("exchange_att_mtu: {}, current default: {}", mtu, self.default_att_mtu());
+        let default_att_mtu = self.default_att_mtu();
         // Both states are live link-layer connections; the transition
         // to `Connected` is just the application polling `accept()` and
         // is unrelated to ATT activity. `handle_acl` already accepts
@@ -1514,7 +1508,6 @@ pub(crate) mod tests {
         >::new())));
         let mgr = ConnectionManager::new(
             storage,
-            23,
             #[cfg(feature = "security")]
             bond_storage,
         );

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -2,6 +2,7 @@ use core::cell::{Ref, RefCell, RefMut};
 use core::future::poll_fn;
 #[cfg(feature = "security")]
 use core::future::Future;
+use core::num::NonZeroU16;
 use core::task::{Context, Poll};
 
 #[cfg(feature = "security")]
@@ -335,7 +336,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     }
 
     pub(crate) fn set_att_mtu(&self, index: u8, mtu: u16) {
-        self.connection_mut(index).att_mtu = mtu;
+        self.connection_mut(index).att_mtu = NonZeroU16::new(mtu);
     }
 
     pub(crate) fn set_l2cap_listening(&self, index: u8, listening: bool) {
@@ -524,8 +525,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 storage.state = ConnectionState::Connecting;
                 storage.link_credits = default_credits;
                 storage.acl_send_locked = false;
-                // Default ATT MTU is 23
-                storage.att_mtu = 23;
+                storage.att_mtu = None;
                 storage.handle.replace(handle);
                 #[cfg(feature = "security")]
                 let identity = self
@@ -692,7 +692,11 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     }
 
     pub(crate) fn get_att_mtu(&self, index: u8) -> u16 {
-        self.connection(index).att_mtu
+        self.connection(index).att_mtu()
+    }
+
+    pub(crate) fn is_att_mtu_exchanged(&self, index: u8) -> bool {
+        self.connection(index).att_mtu.is_some()
     }
 
     pub(crate) async fn send(&self, index: u8, pdu: Pdu<P::Packet>) {
@@ -717,7 +721,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         for storage in self.connections.borrow_mut().iter_mut() {
             match storage.state {
                 ConnectionState::Connected if storage.handle.unwrap() == conn => {
-                    return storage.att_mtu;
+                    return storage.att_mtu();
                 }
                 _ => {}
             }
@@ -737,8 +741,8 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         for storage in self.connections.borrow_mut().iter_mut() {
             match storage.state {
                 ConnectionState::Connecting | ConnectionState::Connected if storage.handle.unwrap() == conn => {
-                    storage.att_mtu = default_att_mtu.min(mtu);
-                    return storage.att_mtu;
+                    storage.att_mtu = NonZeroU16::new(default_att_mtu.min(mtu));
+                    return storage.att_mtu();
                 }
                 _ => {}
             }
@@ -1166,7 +1170,7 @@ pub struct ConnectionStorage<P> {
     pub role: Option<LeConnRole>,
     pub peer_identity: Option<Identity>,
     pub params: ConnParams,
-    pub att_mtu: u16,
+    pub att_mtu: Option<NonZeroU16>,
     pub link_credits: usize,
     pub link_credit_waker: WakerRegistration,
     pub acl_send_locked: bool,
@@ -1279,7 +1283,7 @@ impl<P> ConnectionStorage<P> {
             role: None,
             peer_identity: None,
             params: ConnParams::new(),
-            att_mtu: 23,
+            att_mtu: None,
             link_credits: 0,
             link_credit_waker: WakerRegistration::new(),
             acl_send_locked: false,
@@ -1348,6 +1352,11 @@ impl<P> ConnectionStorage<P> {
         } else {
             false
         }
+    }
+
+    fn att_mtu(&self) -> u16 {
+        // Default ATT MTU is 23
+        self.att_mtu.map_or(23, |mtu| mtu.get())
     }
 }
 

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -132,11 +132,11 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         }
     }
 
-    fn connection(&self, index: u8) -> Ref<'_, ConnectionStorage<P::Packet>> {
+    pub(crate) fn connection(&self, index: u8) -> Ref<'_, ConnectionStorage<P::Packet>> {
         Ref::map(self.connections.borrow(), |x| &x[index as usize])
     }
 
-    fn connection_mut(&self, index: u8) -> RefMut<'_, ConnectionStorage<P::Packet>> {
+    pub(crate) fn connection_mut(&self, index: u8) -> RefMut<'_, ConnectionStorage<P::Packet>> {
         RefMut::map(self.connections.borrow_mut(), |x| &mut x[index as usize])
     }
 
@@ -178,6 +178,10 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
     pub(crate) fn handle(&self, index: u8) -> ConnHandle {
         self.connection(index).handle.unwrap()
+    }
+
+    pub(crate) fn state(&self, index: u8) -> ConnectionState {
+        self.connection(index).state
     }
 
     pub(crate) fn is_connected(&self, index: u8) -> bool {
@@ -452,6 +456,9 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
             if Some(h) == storage.handle && storage.state != ConnectionState::Disconnected {
                 storage.state = ConnectionState::Disconnected;
                 storage.reassembly.clear();
+                storage.acl_send_locked = false;
+                storage.link_credit_waker.wake();
+                storage.acl_send_lock_waker.wake();
                 let _ = storage.events.try_send(ConnectionEvent::Disconnected { reason });
                 #[cfg(feature = "gatt")]
                 {
@@ -516,6 +523,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 storage.reassembly.clear();
                 storage.state = ConnectionState::Connecting;
                 storage.link_credits = default_credits;
+                storage.acl_send_locked = false;
                 // Default ATT MTU is 23
                 storage.att_mtu = 23;
                 storage.handle.replace(handle);
@@ -652,33 +660,34 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         Err(Error::NotFound)
     }
 
-    pub(crate) fn poll_request_to_send(
+    pub(crate) fn poll_acquire_acl_send_lock(
         &self,
         handle: ConnHandle,
-        packets: usize,
         cx: Option<&mut Context<'_>>,
-    ) -> Poll<Result<PacketGrant<'_, P::Packet>, Error>> {
-        for storage in self.connections.borrow_mut().iter_mut() {
-            match storage.state {
-                ConnectionState::Connecting | ConnectionState::Connected if storage.handle.unwrap() == handle => {
-                    if packets <= storage.link_credits {
-                        storage.link_credits -= packets;
+    ) -> Poll<Result<AclSendLock<'_, P>, Error>> {
+        for (index, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
+            if storage.handle != Some(handle) {
+                continue;
+            }
 
-                        return Poll::Ready(Ok(PacketGrant::new(self.connections, handle, packets)));
-                    } else {
-                        if let Some(cx) = cx {
-                            storage.link_credit_waker.register(cx.waker());
-                        }
-                        #[cfg(feature = "connection-metrics")]
-                        storage.metrics.blocked_send();
+            if !matches!(storage.state, ConnectionState::Connecting | ConnectionState::Connected) {
+                return Poll::Ready(Err(Error::Disconnected));
+            }
 
-                        return Poll::Pending;
-                    }
+            if !storage.acl_send_locked {
+                storage.acl_send_locked = true;
+                return Poll::Ready(Ok(AclSendLock::new(handle, self)));
+            } else {
+                if let Some(cx) = cx {
+                    storage.acl_send_lock_waker.register(cx.waker());
                 }
-                _ => {}
+                #[cfg(feature = "connection-metrics")]
+                storage.metrics.blocked_send();
+
+                return Poll::Pending;
             }
         }
-        warn!("[link][pool_request_to_send] connection {:?} not found", handle);
+        warn!("[link][poll_acquire_acl_send_lock] connection {:?} not found", handle);
         Poll::Ready(Err(Error::NotFound))
     }
 
@@ -1075,6 +1084,27 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     pub(crate) fn clear_prepare_write(&self, index: u8) {
         self.connection_mut(index).prepare_write.clear();
     }
+
+    pub(crate) fn has_link_credits(&self, handle: ConnHandle, n: usize) -> bool {
+        self.connection_by_handle(handle)
+            .map(|conn| conn.link_credits >= n)
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn unlock_acl_send(&self, handle: ConnHandle) {
+        if let Some(mut storage) = self.connection_by_handle_mut(handle) {
+            if core::mem::replace(&mut storage.acl_send_locked, false) {
+                storage.acl_send_lock_waker.wake();
+            }
+        }
+    }
+
+    pub(crate) fn return_link_credits(&self, handle: ConnHandle, packets: usize) {
+        if let Some(mut storage) = self.connection_by_handle_mut(handle) {
+            storage.link_credits += packets;
+            storage.link_credit_waker.wake();
+        }
+    }
 }
 
 /// Iterator over currently connected connections.
@@ -1139,6 +1169,8 @@ pub struct ConnectionStorage<P> {
     pub att_mtu: u16,
     pub link_credits: usize,
     pub link_credit_waker: WakerRegistration,
+    pub acl_send_locked: bool,
+    pub acl_send_lock_waker: WakerRegistration,
     pub refcount: u8,
     #[cfg(feature = "connection-metrics")]
     pub metrics: Metrics,
@@ -1250,6 +1282,8 @@ impl<P> ConnectionStorage<P> {
             att_mtu: 23,
             link_credits: 0,
             link_credit_waker: WakerRegistration::new(),
+            acl_send_locked: false,
+            acl_send_lock_waker: WakerRegistration::new(),
             refcount: 0,
             #[cfg(feature = "connection-metrics")]
             metrics: Metrics::new(),
@@ -1306,6 +1340,15 @@ impl<P> ConnectionStorage<P> {
             waker.wake();
         }
     }
+
+    fn take_link_credits(&mut self, n: usize) -> bool {
+        if let Some(credits) = self.link_credits.checked_sub(n) {
+            self.link_credits = credits;
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl<P> core::fmt::Debug for ConnectionStorage<P> {
@@ -1348,7 +1391,7 @@ impl<P> defmt::Format for ConnectionStorage<P> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConnectionState {
     DisconnectRequest(DisconnectReason),
@@ -1358,17 +1401,63 @@ pub enum ConnectionState {
     Connected,
 }
 
-pub struct PacketGrant<'a, P> {
-    connections: &'a RefCell<[ConnectionStorage<P>]>,
+pub struct AclSendLock<'a, P: PacketPool> {
     handle: ConnHandle,
+    manager: &'a ConnectionManager<'a, P>,
+}
+
+impl<'a, P: PacketPool> AclSendLock<'a, P> {
+    fn new(handle: ConnHandle, manager: &'a ConnectionManager<'a, P>) -> Self {
+        Self { handle, manager }
+    }
+
+    pub(crate) fn has_link_credits(&self, n_acl: usize) -> bool {
+        self.manager.has_link_credits(self.handle, n_acl)
+    }
+
+    pub(crate) fn poll_request_to_send(
+        &self,
+        packets: usize,
+        cx: Option<&mut Context<'_>>,
+    ) -> Poll<Result<PacketGrant<'a, P>, Error>> {
+        let Some(mut storage) = self.manager.connection_by_handle_mut(self.handle) else {
+            return Poll::Ready(Err(Error::Disconnected));
+        };
+
+        if !matches!(storage.state, ConnectionState::Connecting | ConnectionState::Connected) {
+            Poll::Ready(Err(Error::Disconnected))
+        } else if storage.take_link_credits(packets) {
+            Poll::Ready(Ok(PacketGrant::new(self.handle, self.manager, packets)))
+        } else {
+            #[cfg(feature = "connection-metrics")]
+            storage.metrics.blocked_send();
+
+            if let Some(cx) = cx {
+                storage.link_credit_waker.register(cx.waker());
+            }
+
+            Poll::Pending
+        }
+    }
+}
+
+impl<P: PacketPool> Drop for AclSendLock<'_, P> {
+    fn drop(&mut self) {
+        self.manager.unlock_acl_send(self.handle);
+    }
+}
+
+pub struct PacketGrant<'a, P: PacketPool> {
+    handle: ConnHandle,
+    manager: &'a ConnectionManager<'a, P>,
     packets: usize,
 }
 
-impl<'a, P> PacketGrant<'a, P> {
-    fn new(connections: &'a RefCell<[ConnectionStorage<P>]>, handle: ConnHandle, packets: usize) -> Self {
+impl<'a, P: PacketPool> PacketGrant<'a, P> {
+    fn new(handle: ConnHandle, manager: &'a ConnectionManager<'a, P>, packets: usize) -> Self {
         Self {
-            connections,
             handle,
+            manager,
             packets,
         }
     }
@@ -1377,34 +1466,17 @@ impl<'a, P> PacketGrant<'a, P> {
         self.packets = self.packets.saturating_sub(sent);
         #[cfg(feature = "connection-metrics")]
         {
-            for storage in self.connections.borrow_mut().iter_mut() {
-                match storage.state {
-                    ConnectionState::Connected if self.handle == storage.handle.unwrap() => {
-                        storage.metrics.sent(sent);
-                        break;
-                    }
-                    _ => {}
-                }
+            if let Some(mut storage) = self.manager.connection_by_handle_mut(self.handle) {
+                storage.metrics.sent(sent);
             }
         }
     }
 }
 
-impl<P> Drop for PacketGrant<'_, P> {
+impl<P: PacketPool> Drop for PacketGrant<'_, P> {
     fn drop(&mut self) {
         if self.packets > 0 {
-            for storage in self.connections.borrow_mut().iter_mut() {
-                match storage.state {
-                    ConnectionState::Connected if self.handle == storage.handle.unwrap() => {
-                        storage.link_credits += self.packets;
-                        storage.link_credit_waker.wake();
-                        return;
-                    }
-                    _ => {}
-                }
-            }
-            // make it an assert?
-            warn!("[link] connection {:?} not found", self.handle);
+            self.manager.return_link_credits(self.handle, self.packets);
         }
     }
 }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -1140,35 +1140,37 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
         _stack: &Stack<'_, C, P>,
         connection: &Connection<'reference, P>,
     ) -> Result<GattClient<'reference, C, P, MAX_SERVICES>, BleHostError<C::Error>> {
-        let l2cap = L2capHeader { channel: 4, length: 3 };
-        let mut buf = P::allocate().ok_or(Error::OutOfMemory)?;
-        let mut w = WriteCursor::new(buf.as_mut());
-        w.write_hci(&l2cap)?;
-        w.write(att::Att::Client(att::AttClient::Request(att::AttReq::ExchangeMtu {
-            mtu: P::MTU as u16 - 4,
-        })))?;
+        if !connection.is_att_mtu_exchanged() {
+            let l2cap = L2capHeader { channel: 4, length: 3 };
+            let mut buf = P::allocate().ok_or(Error::OutOfMemory)?;
+            let mut w = WriteCursor::new(buf.as_mut());
+            w.write_hci(&l2cap)?;
+            w.write(att::Att::Client(att::AttClient::Request(att::AttReq::ExchangeMtu {
+                mtu: P::MTU as u16 - 4,
+            })))?;
 
-        let len = w.len();
-        connection.send(Pdu::new(buf, len)).await;
+            let len = w.len();
+            connection.send(Pdu::new(buf, len)).await;
 
-        // Await MTU exchange completion (BT Core Spec requires sequential ATT requests)
-        with_timeout(ATT_TRANSACTION_TIMEOUT, async {
-            loop {
-                let pdu = connection.next_gatt_client().await.ok_or(Error::Disconnected)?;
-                match pdu.as_ref()[0] {
-                    att::ATT_EXCHANGE_MTU_RSP | att::ATT_ERROR_RSP => break Ok::<_, BleHostError<C::Error>>(()),
-                    _ => {
-                        warn!("[gatt] unexpected PDU during MTU exchange, discarding");
+            // Await MTU exchange completion (BT Core Spec requires sequential ATT requests)
+            with_timeout(ATT_TRANSACTION_TIMEOUT, async {
+                loop {
+                    let pdu = connection.next_gatt_client().await.ok_or(Error::Disconnected)?;
+                    match pdu.as_ref()[0] {
+                        att::ATT_EXCHANGE_MTU_RSP | att::ATT_ERROR_RSP => break Ok::<_, BleHostError<C::Error>>(()),
+                        _ => {
+                            warn!("[gatt] unexpected PDU during MTU exchange, discarding");
+                        }
                     }
                 }
-            }
-        })
-        .await
-        .map_err(|_| {
-            warn!("[gatt] MTU exchange timeout (30s), disconnecting");
-            connection.disconnect();
-            BleHostError::BleHost(Error::Timeout)
-        })??;
+            })
+            .await
+            .map_err(|_| {
+                warn!("[gatt] MTU exchange timeout (30s), disconnecting");
+                connection.disconnect();
+                BleHostError::BleHost(Error::Timeout)
+            })??;
+        }
 
         // Enable encryption with bonded peers before starting GATT operations
         // (BT Core Spec Vol 3, Part C, Section 10.3.2: client "should" enable encryption on reconnection)

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -141,6 +141,7 @@ pub(crate) struct BleHost<'d, T, P: PacketPool> {
 #[derive(Clone, Copy)]
 pub(crate) struct InitialState {
     acl_max: usize,
+    acl_total: usize,
 }
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -894,28 +895,37 @@ where
         w.write_hci(&header)?;
         w.write_hci(signal)?;
 
-        let mut sender = self.l2cap(conn, (w.len() - 4) as u16, 1).await?;
+        let mut sender = self.l2cap_pdu(conn, w.len() as u16).await?;
         sender.send(w.finish()).await?;
 
         Ok(())
     }
 
-    // Request to an L2CAP payload of len to the HCI controller for a connection.
+    // Request to send a single L2CAP PDU of pdu_len to the HCI controller for a connection.
     //
     // This function will request the appropriate number of ACL packets to be sent and
-    // the returned sender will handle fragmentation.
-    pub(crate) async fn l2cap(
+    // the returned sender will handle ACL fragmentation.
+    //
+    // This function cannot be used to send an SDU split among multiple k-frames.
+    pub(crate) async fn l2cap_pdu(
         &self,
         handle: ConnHandle,
-        len: u16,
-        n_packets: u16,
+        pdu_len: u16,
     ) -> Result<L2capSender<'_, T, P::Packet>, BleHostError<T::Error>> {
         // Take into account l2cap header.
-        let acl_max = self.initialized.get().await.acl_max as u16;
-        let len = len + (4 * n_packets);
-        let n_acl = len.div_ceil(acl_max);
-        let grant = poll_fn(|cx| self.connections.poll_request_to_send(handle, n_acl as usize, Some(cx))).await?;
-        trace!("[host] granted send packets = {}, len = {}", n_packets, len);
+        let initial_state = self.initialized.get().await;
+        let acl_max = initial_state.acl_max as u16;
+        if acl_max == 0 {
+            return Err(Error::NoPermits.into());
+        }
+
+        let n_acl = usize::from(pdu_len.div_ceil(acl_max));
+        if n_acl > initial_state.acl_total {
+            return Err(Error::NoPermits.into());
+        }
+
+        let grant = poll_fn(|cx| self.connections.poll_request_to_send(handle, n_acl, Some(cx))).await?;
+        trace!("[host] granted send packets = {}, len = {}", n_acl, pdu_len);
         Ok(L2capSender {
             controller: &self.controller,
             handle,
@@ -924,20 +934,41 @@ where
         })
     }
 
-    // Request to an L2CAP payload of len to the HCI controller for a connection.
+    // Request to send an L2CAP SDU of sdu_len to the HCI controller for a connection.
     //
     // This function will request the appropriate number of ACL packets to be sent and
-    // the returned sender will handle fragmentation.
-    pub(crate) fn try_l2cap(
+    // the returned sender will handle ACL fragmentation.
+    pub(crate) fn try_l2cap_sdu(
         &self,
         handle: ConnHandle,
-        len: u16,
-        n_packets: u16,
+        sdu_len: u16,
+        mps: u16,
     ) -> Result<L2capSender<'_, T, P::Packet>, BleHostError<T::Error>> {
-        let acl_max = self.initialized.try_get().map(|i| i.acl_max).unwrap_or(27) as u16;
-        let len = len + (4 * n_packets);
-        let n_acl = len.div_ceil(acl_max);
-        let grant = match self.connections.poll_request_to_send(handle, n_acl as usize, None) {
+        let initial_state = self.initialized.try_get().ok_or(Error::NoPermits)?;
+        let acl_max = initial_state.acl_max;
+        if acl_max == 0 {
+            return Err(Error::NoPermits.into());
+        }
+
+        const L2CAP_BASIC_HEADER_SIZE: usize = 4; // L2CAP Basic Header added to each k-frame
+        const L2CAP_SDU_LEN_SIZE: usize = 2; // L2CAP SDU Length field added to first k-frame
+
+        let mps = usize::from(mps);
+        let len = usize::from(sdu_len) + L2CAP_SDU_LEN_SIZE;
+        let full_k_frame_len = mps + L2CAP_BASIC_HEADER_SIZE;
+        let full_k_frames = len / mps;
+        let last_k_frame_len = if len.is_multiple_of(mps) {
+            0
+        } else {
+            len % mps + L2CAP_BASIC_HEADER_SIZE
+        };
+
+        let n_acl = full_k_frames * full_k_frame_len.div_ceil(acl_max) + last_k_frame_len.div_ceil(acl_max);
+        if n_acl > initial_state.acl_total {
+            return Err(Error::NoPermits.into());
+        }
+
+        let grant = match self.connections.poll_request_to_send(handle, n_acl, None) {
             Poll::Ready(res) => res?,
             Poll::Pending => {
                 return Err(Error::Busy.into());
@@ -947,7 +978,7 @@ where
             controller: &self.controller,
             handle,
             grant,
-            fragment_size: acl_max,
+            fragment_size: acl_max as u16,
         })
     }
 
@@ -1557,6 +1588,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
 
         let _ = host.initialized.init(InitialState {
             acl_max: ret.le_acl_data_packet_length as usize,
+            acl_total: ret.total_num_le_acl_data_packets as usize,
         });
         info!("[host] initialized");
 
@@ -1685,7 +1717,7 @@ impl<'d, C: Controller, P: PacketPool> TxRunner<'d, C, P> {
         let params = host.initialized.get().await;
         loop {
             let (conn, pdu) = host.connections.outbound().await;
-            match host.l2cap(conn, (pdu.len() - 4) as u16, 1).await {
+            match host.l2cap_pdu(conn, pdu.len() as u16).await {
                 Ok(mut sender) => {
                     if let Err(e) = sender.send(pdu.as_ref()).await {
                         warn!("[host] error sending outbound pdu");

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -55,7 +55,7 @@ use crate::command::CommandState;
 use crate::connection::{ConnParams, ConnectionEvent};
 #[cfg(feature = "security")]
 use crate::connection_manager::ResolvablePrivateAddrs;
-use crate::connection_manager::{ConnectionManager, ConnectionStorage, PacketGrant};
+use crate::connection_manager::{AclSendLock, ConnectionManager, ConnectionStorage};
 use crate::cursor::WriteCursor;
 use crate::pdu::Pdu;
 use crate::prelude::{ConnectionParamsRequest, RequestedConnParams};
@@ -895,7 +895,7 @@ where
         w.write_hci(&header)?;
         w.write_hci(signal)?;
 
-        let mut sender = self.l2cap_pdu(conn, w.len() as u16).await?;
+        let mut sender = self.l2cap_pdu(conn).await?;
         sender.send(w.finish()).await?;
 
         Ok(())
@@ -903,15 +903,10 @@ where
 
     // Request to send a single L2CAP PDU of pdu_len to the HCI controller for a connection.
     //
-    // This function will request the appropriate number of ACL packets to be sent and
-    // the returned sender will handle ACL fragmentation.
+    // This function will acquire the connection ACL send lock and the returned sender will handle ACL fragmentation.
     //
     // This function cannot be used to send an SDU split among multiple k-frames.
-    pub(crate) async fn l2cap_pdu(
-        &self,
-        handle: ConnHandle,
-        pdu_len: u16,
-    ) -> Result<L2capSender<'_, T, P::Packet>, BleHostError<T::Error>> {
+    pub(crate) async fn l2cap_pdu(&self, handle: ConnHandle) -> Result<L2capSender<'_, T, P>, BleHostError<T::Error>> {
         // Take into account l2cap header.
         let initial_state = self.initialized.get().await;
         let acl_max = initial_state.acl_max as u16;
@@ -919,36 +914,37 @@ where
             return Err(Error::NoPermits.into());
         }
 
-        let n_acl = usize::from(pdu_len.div_ceil(acl_max));
-        if n_acl > initial_state.acl_total {
-            return Err(Error::NoPermits.into());
-        }
-
-        let grant = poll_fn(|cx| self.connections.poll_request_to_send(handle, n_acl, Some(cx))).await?;
-        trace!("[host] granted send packets = {}, len = {}", n_acl, pdu_len);
+        let acl_send_lock = poll_fn(|cx| self.connections.poll_acquire_acl_send_lock(handle, Some(cx))).await?;
         Ok(L2capSender {
             controller: &self.controller,
             handle,
-            grant,
+            acl_send_lock,
             fragment_size: acl_max,
+            max_fragments: initial_state.acl_total,
         })
     }
 
     // Request to send an L2CAP SDU of sdu_len to the HCI controller for a connection.
     //
-    // This function will request the appropriate number of ACL packets to be sent and
-    // the returned sender will handle ACL fragmentation.
+    // This function will acquire the connection ACL send lock and the returned sender will handle ACL fragmentation.
     pub(crate) fn try_l2cap_sdu(
         &self,
         handle: ConnHandle,
         sdu_len: u16,
         mps: u16,
-    ) -> Result<L2capSender<'_, T, P::Packet>, BleHostError<T::Error>> {
+    ) -> Result<L2capSender<'_, T, P>, BleHostError<T::Error>> {
         let initial_state = self.initialized.try_get().ok_or(Error::NoPermits)?;
         let acl_max = initial_state.acl_max;
         if acl_max == 0 {
             return Err(Error::NoPermits.into());
         }
+
+        let acl_send_lock = match self.connections.poll_acquire_acl_send_lock(handle, None) {
+            Poll::Ready(res) => res?,
+            Poll::Pending => {
+                return Err(Error::Busy.into());
+            }
+        };
 
         const L2CAP_BASIC_HEADER_SIZE: usize = 4; // L2CAP Basic Header added to each k-frame
         const L2CAP_SDU_LEN_SIZE: usize = 2; // L2CAP SDU Length field added to first k-frame
@@ -966,19 +962,16 @@ where
         let n_acl = full_k_frames * full_k_frame_len.div_ceil(acl_max) + last_k_frame_len.div_ceil(acl_max);
         if n_acl > initial_state.acl_total {
             return Err(Error::NoPermits.into());
+        } else if !acl_send_lock.has_link_credits(n_acl) {
+            return Err(Error::Busy.into());
         }
 
-        let grant = match self.connections.poll_request_to_send(handle, n_acl, None) {
-            Poll::Ready(res) => res?,
-            Poll::Pending => {
-                return Err(Error::Busy.into());
-            }
-        };
         Ok(L2capSender {
             controller: &self.controller,
             handle,
-            grant,
+            acl_send_lock,
             fragment_size: acl_max as u16,
+            max_fragments: initial_state.acl_total,
         })
     }
 
@@ -1717,7 +1710,7 @@ impl<'d, C: Controller, P: PacketPool> TxRunner<'d, C, P> {
         let params = host.initialized.get().await;
         loop {
             let (conn, pdu) = host.connections.outbound().await;
-            match host.l2cap_pdu(conn, pdu.len() as u16).await {
+            match host.l2cap_pdu(conn).await {
                 Ok(mut sender) => {
                     if let Err(e) = sender.send(pdu.as_ref()).await {
                         warn!("[host] error sending outbound pdu");
@@ -1739,18 +1732,28 @@ impl<'d, C: Controller, P: PacketPool> TxRunner<'d, C, P> {
     }
 }
 
-pub struct L2capSender<'a, T: Controller, P> {
+pub struct L2capSender<'a, T: Controller, P: PacketPool> {
     pub(crate) controller: &'a T,
     pub(crate) handle: ConnHandle,
-    pub(crate) grant: PacketGrant<'a, P>,
+    pub(crate) acl_send_lock: AclSendLock<'a, P>,
     pub(crate) fragment_size: u16,
+    pub(crate) max_fragments: usize,
 }
 
-impl<'a, T: Controller, P> L2capSender<'a, T, P> {
+impl<'a, T: Controller, P: PacketPool> L2capSender<'a, T, P> {
     pub(crate) fn try_send(&mut self, pdu: &[u8]) -> Result<(), BleHostError<T::Error>>
     where
         T: blocking::Controller,
     {
+        let n_acl = pdu.chunks(self.fragment_size as usize).len();
+        if n_acl > self.max_fragments {
+            return Err(Error::NoPermits.into());
+        }
+
+        let mut grant = match self.acl_send_lock.poll_request_to_send(n_acl, None) {
+            Poll::Ready(res) => res?,
+            Poll::Pending => return Err(Error::Busy.into()),
+        };
         let mut pbf = AclPacketBoundary::FirstNonFlushable;
         //info!(
         //    "[host] fragmenting PDU of size {} into {} sized fragments",
@@ -1760,8 +1763,8 @@ impl<'a, T: Controller, P> L2capSender<'a, T, P> {
         for chunk in pdu.chunks(self.fragment_size as usize) {
             let acl = AclPacket::new(self.handle, pbf, AclBroadcastFlag::PointToPoint, chunk);
             match self.controller.try_write_acl_data(&acl) {
-                Ok(result) => {
-                    self.grant.confirm(1);
+                Ok(_result) => {
+                    grant.confirm(1);
                     trace!("[host] sent acl packet len = {}", chunk.len());
                 }
                 Err(blocking::TryError::Busy) => {
@@ -1783,12 +1786,13 @@ impl<'a, T: Controller, P> L2capSender<'a, T, P> {
         //);
         let mut pbf = AclPacketBoundary::FirstNonFlushable;
         for chunk in pdu.chunks(self.fragment_size as usize) {
+            let mut grant = poll_fn(|cx| self.acl_send_lock.poll_request_to_send(1, Some(cx))).await?;
             let acl = AclPacket::new(self.handle, pbf, AclBroadcastFlag::PointToPoint, chunk);
             self.controller
                 .write_acl_data(&acl)
                 .await
                 .map_err(BleHostError::Controller)?;
-            self.grant.confirm(1);
+            grant.confirm(1);
             pbf = AclPacketBoundary::Continuing;
             trace!("[host] sent acl packet len = {}", chunk.len());
         }

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -262,7 +262,6 @@ where
             controller,
             connections: ConnectionManager::new(
                 connections,
-                P::MTU as u16 - 4,
                 #[cfg(feature = "security")]
                 bond_storage,
             ),

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -894,7 +894,7 @@ where
         w.write_hci(&header)?;
         w.write_hci(signal)?;
 
-        let mut sender = self.l2cap(conn, w.len() as u16, 1).await?;
+        let mut sender = self.l2cap(conn, (w.len() - 4) as u16, 1).await?;
         sender.send(w.finish()).await?;
 
         Ok(())
@@ -1685,7 +1685,7 @@ impl<'d, C: Controller, P: PacketPool> TxRunner<'d, C, P> {
         let params = host.initialized.get().await;
         loop {
             let (conn, pdu) = host.connections.outbound().await;
-            match host.l2cap(conn, pdu.len() as u16, 1).await {
+            match host.l2cap(conn, (pdu.len() - 4) as u16, 1).await {
                 Ok(mut sender) => {
                     if let Err(e) = sender.send(pdu.as_ref()).await {
                         warn!("[host] error sending outbound pdu");

--- a/tester/app/Cargo.lock
+++ b/tester/app/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "trouble-host"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "bt-hci",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "trouble-host-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "convert_case",
  "darling",


### PR DESCRIPTION
This fixes some issues with packet fragmentation:
- There were some edge cases around l2cap packet fragmentation where sizes were not being calculated correctly.
- There was no synchronization preventing other PDUs from interleaving with a fragmented PDU which would prevent successful reassembly.
- Large PDUs that exceeded the size of the controller buffers could not be sent.

I've reworked the fragmentation calculations. In an async context, we no longer require enough ACL buffers for the full PDU up front. Instead we acquire an `AclSendLock` to prevent other ACL packets from being sent then send ACL packets as buffers become available until the entire PDU is sent. This allows large PDUs to be sent even if the controller's buffers are small. Blocking sends still check for enough buffers up front because there's no opportunity for buffers to be returned in a sync context.

I've also included a change to prevent redundant ATT MTU exchanges after one succeeds.