### PR TITLE
fix(security): SMP cross connection guards

### DIFF
--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -462,7 +462,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 {
                     storage.security_level = SecurityLevel::NoEncryption;
                     storage.bondable = false;
-                    self.security_manager.disconnect(&storage.peer_identity);
+                    self.security_manager.disconnect(storage);
                 }
                 #[cfg(feature = "att-queued-writes")]
                 storage.prepare_write.clear();
@@ -791,7 +791,11 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
             } else if storage.security_level != SecurityLevel::NoEncryption {
                 return Ok(());
             }
-            storage.peer_identity.addr
+            storage
+                .resolvable_addrs
+                .peer
+                .map(|a| Address::new(AddrKind::RANDOM, a))
+                .unwrap_or(storage.peer_identity.addr)
         };
 
         if !self.security_manager.is_pairing_in_progress(address) {

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -5,9 +5,7 @@ use core::future::Future;
 use core::num::NonZeroU16;
 use core::task::{Context, Poll};
 
-#[cfg(feature = "security")]
-use bt_hci::param::BdAddr;
-use bt_hci::param::{ConnHandle, DisconnectReason, LeConnRole, Status};
+use bt_hci::param::{AddrKind, BdAddr, ConnHandle, DisconnectReason, LeConnRole, Status};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::waitqueue::WakerRegistration;
@@ -141,7 +139,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     fn connection_by_handle(&self, handle: ConnHandle) -> Option<Ref<'_, ConnectionStorage<P::Packet>>> {
         Ref::filter_map(self.connections.borrow(), |connections| {
             for storage in connections.iter() {
-                if storage.handle == Some(handle)
+                if storage.handle == handle
                     && matches!(storage.state, ConnectionState::Connected | ConnectionState::Connecting)
                 {
                     return Some(storage);
@@ -155,7 +153,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     fn connection_by_handle_mut(&self, handle: ConnHandle) -> Option<RefMut<'_, ConnectionStorage<P::Packet>>> {
         RefMut::filter_map(self.connections.borrow_mut(), |connections| {
             for storage in connections.iter_mut() {
-                if storage.handle == Some(handle)
+                if storage.handle == handle
                     && matches!(storage.state, ConnectionState::Connected | ConnectionState::Connecting)
                 {
                     return Some(storage);
@@ -167,15 +165,15 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     }
 
     pub(crate) fn role(&self, index: u8) -> LeConnRole {
-        self.connection(index).role.unwrap()
+        self.connection(index).role
     }
 
     pub(crate) fn role_by_handle(&self, handle: ConnHandle) -> Option<LeConnRole> {
-        self.connection_by_handle(handle).and_then(|connection| connection.role)
+        self.connection_by_handle(handle).map(|connection| connection.role)
     }
 
     pub(crate) fn handle(&self, index: u8) -> ConnHandle {
-        self.connection(index).handle.unwrap()
+        self.connection(index).handle
     }
 
     pub(crate) fn state(&self, index: u8) -> ConnectionState {
@@ -202,7 +200,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
     pub(crate) fn post_handle_event(&self, handle: ConnHandle, event: ConnectionEvent) -> Result<(), Error> {
         for entry in self.connections.borrow_mut().iter_mut() {
-            if entry.state == ConnectionState::Connected && Some(handle) == entry.handle {
+            if entry.state == ConnectionState::Connected && handle == entry.handle {
                 if let ConnectionEvent::ConnectionParamsUpdated {
                     conn_interval,
                     peripheral_latency,
@@ -226,8 +224,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     #[cfg(feature = "gatt")]
     pub(crate) fn post_gatt(&self, handle: ConnHandle, pdu: Pdu<P::Packet>) -> Result<(), Error> {
         for entry in self.connections.borrow().iter() {
-            if matches!(entry.state, ConnectionState::Connecting | ConnectionState::Connected)
-                && Some(handle) == entry.handle
+            if matches!(entry.state, ConnectionState::Connecting | ConnectionState::Connected) && handle == entry.handle
             {
                 entry.gatt.try_send(pdu).map_err(|_| Error::OutOfMemory)?;
                 return Ok(());
@@ -239,8 +236,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     #[cfg(feature = "gatt")]
     pub(crate) fn post_gatt_client(&self, handle: ConnHandle, pdu: Pdu<P::Packet>) -> Result<(), Error> {
         for entry in self.connections.borrow().iter() {
-            if matches!(entry.state, ConnectionState::Connecting | ConnectionState::Connected)
-                && Some(handle) == entry.handle
+            if matches!(entry.state, ConnectionState::Connecting | ConnectionState::Connected) && handle == entry.handle
             {
                 entry.gatt_client.try_send(pdu).map_err(|_| Error::OutOfMemory)?;
                 return Ok(());
@@ -321,11 +317,11 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     }
 
     pub(crate) fn peer_address(&self, index: u8) -> Address {
-        self.connection(index).peer_identity.map(|i| i.addr).unwrap_or_default()
+        self.connection(index).peer_identity.addr
     }
 
     pub(crate) fn peer_identity(&self, index: u8) -> Identity {
-        self.connection(index).peer_identity.unwrap()
+        self.connection(index).peer_identity
     }
 
     pub(crate) fn params(&self, index: u8) -> ConnParams {
@@ -350,7 +346,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
     pub(crate) fn request_handle_disconnect(&self, handle: ConnHandle, reason: DisconnectReason) {
         if let Some(mut entry) = self.connection_by_handle_mut(handle) {
-            if entry.state == ConnectionState::Connected && Some(handle) == entry.handle {
+            if entry.state == ConnectionState::Connected && handle == entry.handle {
                 entry.state = ConnectionState::DisconnectRequest(reason);
                 self.state.borrow_mut().disconnect_waker.wake();
             }
@@ -370,7 +366,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
             if let ConnectionState::DisconnectRequest(reason) = storage.state {
                 return Poll::Ready(DisconnectRequest {
                     index: idx,
-                    handle: storage.handle.unwrap(),
+                    handle: storage.handle,
                     reason,
                     connections: self.connections,
                 });
@@ -381,12 +377,9 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
     pub(crate) fn get_connected_handle(&'d self, h: ConnHandle) -> Option<Connection<'d, P>> {
         for (index, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
-            match (storage.handle, &storage.state) {
-                (Some(handle), ConnectionState::Connected) if handle == h => {
-                    storage.inc_ref();
-                    return Some(Connection::new(index as u8, self));
-                }
-                _ => {}
+            if storage.handle == h && storage.state == ConnectionState::Connected {
+                storage.inc_ref();
+                return Some(Connection::new(index as u8, self));
             }
         }
         None
@@ -402,13 +395,9 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
     pub(crate) fn get_connection_by_peer_address(&'d self, peer_address: Address) -> Option<Connection<'d, P>> {
         for (index, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
-            if storage.state == ConnectionState::Connected {
-                if let Some(peer) = &storage.peer_identity {
-                    if peer.match_address(&peer_address) {
-                        storage.inc_ref();
-                        return Some(Connection::new(index as u8, self));
-                    }
-                }
+            if storage.state == ConnectionState::Connected && storage.peer_identity.match_address(&peer_address) {
+                storage.inc_ref();
+                return Some(Connection::new(index as u8, self));
             }
         }
         None
@@ -451,7 +440,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
     pub(crate) fn disconnected(&self, h: ConnHandle, reason: Status) -> Result<(), Error> {
         for (idx, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
-            if Some(h) == storage.handle && storage.state != ConnectionState::Disconnected {
+            if h == storage.handle && storage.state != ConnectionState::Disconnected {
                 storage.state = ConnectionState::Disconnected;
                 storage.reassembly.clear();
                 storage.acl_send_locked = false;
@@ -473,9 +462,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 {
                     storage.security_level = SecurityLevel::NoEncryption;
                     storage.bondable = false;
-                    if let Some(identity) = storage.peer_identity.as_ref() {
-                        self.security_manager.disconnect(identity);
-                    }
+                    self.security_manager.disconnect(&storage.peer_identity);
                 }
                 #[cfg(feature = "att-queued-writes")]
                 storage.prepare_write.clear();
@@ -523,7 +510,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 storage.link_credits = default_credits;
                 storage.acl_send_locked = false;
                 storage.att_mtu = None;
-                storage.handle.replace(handle);
+                storage.handle = handle;
                 #[cfg(feature = "security")]
                 let identity = self
                     .security_manager
@@ -532,8 +519,8 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                     .unwrap_or(peer_addr.into());
                 #[cfg(not(feature = "security"))]
                 let identity = Identity::from(peer_addr);
-                storage.peer_identity.replace(identity);
-                storage.role.replace(role);
+                storage.peer_identity = identity;
+                storage.role = role;
                 storage.params = params;
                 #[cfg(feature = "security")]
                 {
@@ -580,12 +567,12 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         core::mem::drop(state);
         for (idx, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
             if let ConnectionState::Connecting = storage.state {
-                let handle = storage.handle.unwrap();
-                let r = storage.role.unwrap();
+                let handle = storage.handle;
+                let r = storage.role;
                 if r == role {
                     if !peers.is_empty() {
                         for peer in peers.iter() {
-                            if storage.peer_identity.unwrap().match_address(peer) {
+                            if storage.peer_identity.match_address(peer) {
                                 storage.state = ConnectionState::Connected;
                                 debug!("[link][poll_accept] connection accepted: state: {:?}", storage);
                                 assert_eq!(storage.refcount, 0);
@@ -645,7 +632,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     pub(crate) fn confirm_sent(&self, handle: ConnHandle, packets: usize) -> Result<(), Error> {
         for storage in self.connections.borrow_mut().iter_mut() {
             match storage.state {
-                ConnectionState::Connecting | ConnectionState::Connected if handle == storage.handle.unwrap() => {
+                ConnectionState::Connecting | ConnectionState::Connected if handle == storage.handle => {
                     storage.link_credits += packets;
                     storage.link_credit_waker.wake();
                     return Ok(());
@@ -662,7 +649,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         cx: Option<&mut Context<'_>>,
     ) -> Poll<Result<AclSendLock<'_, P>, Error>> {
         for (index, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
-            if storage.handle != Some(handle) {
+            if storage.handle != handle {
                 continue;
             }
 
@@ -696,12 +683,12 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     }
 
     pub(crate) async fn send(&self, index: u8, pdu: Pdu<P::Packet>) {
-        let handle = self.connection(index).handle.unwrap();
+        let handle = self.connection(index).handle;
         self.outbound.send((handle, pdu)).await
     }
 
     pub(crate) fn try_send(&self, index: u8, pdu: Pdu<P::Packet>) -> Result<(), Error> {
-        let handle = self.connection(index).handle.unwrap();
+        let handle = self.connection(index).handle;
         self.outbound.try_send((handle, pdu)).map_err(|_| Error::OutOfMemory)
     }
 
@@ -716,7 +703,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     pub(crate) fn get_att_mtu_handle(&self, conn: ConnHandle) -> u16 {
         for storage in self.connections.borrow_mut().iter_mut() {
             match storage.state {
-                ConnectionState::Connected if storage.handle.unwrap() == conn => {
+                ConnectionState::Connected if storage.handle == conn => {
                     return storage.att_mtu();
                 }
                 _ => {}
@@ -734,7 +721,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         // both via `connection_by_handle_mut`.
         for storage in self.connections.borrow_mut().iter_mut() {
             match storage.state {
-                ConnectionState::Connecting | ConnectionState::Connected if storage.handle.unwrap() == conn => {
+                ConnectionState::Connecting | ConnectionState::Connected if storage.handle == conn => {
                     storage.att_mtu = NonZeroU16::new(default_att_mtu.min(mtu));
                     return storage.att_mtu();
                 }
@@ -790,13 +777,9 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     #[cfg(feature = "security")]
     pub(crate) fn is_bonded_peer(&self, index: u8) -> bool {
         let storage = self.connection(index);
-        if let Some(identity) = storage.peer_identity.as_ref() {
-            self.security_manager
-                .get_peer_bond_information(identity)
-                .is_some_and(|b| b.is_bonded)
-        } else {
-            false
-        }
+        self.security_manager
+            .get_peer_bond_information(&storage.peer_identity)
+            .is_some_and(|b| b.is_bonded)
     }
 
     #[cfg(feature = "security")]
@@ -808,10 +791,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
             } else if storage.security_level != SecurityLevel::NoEncryption {
                 return Ok(());
             }
-            match storage.peer_identity.as_ref() {
-                Some(identity) => identity.addr,
-                _ => return Err(Error::InvalidValue),
-            }
+            storage.peer_identity.addr
         };
 
         if !self.security_manager.is_pairing_in_progress(address) {
@@ -924,7 +904,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         {
             for storage in self.connections.borrow().iter() {
                 match storage.state {
-                    ConnectionState::Connected if storage.handle.unwrap() == handle => {
+                    ConnectionState::Connected if storage.handle == handle => {
                         if storage.smp_timeout {
                             warn!("Ignoring security channel packet after SMP timeout");
                             return Ok(());
@@ -971,7 +951,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
         match _event {
             crate::security_manager::SecurityEventData::SendLongTermKey(handle, ediv, rand) => {
-                let identity = self.connection_by_handle(handle).and_then(|x| x.peer_identity);
+                let identity = self.connection_by_handle(handle).map(|x| x.peer_identity);
                 if let Some(identity) = identity {
                     // Match EDIV/Rand against stored bonds to find the correct LTK.
                     // During active legacy pairing (STK phase), the STK is stored with EDIV=0, Rand=0.
@@ -1000,7 +980,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 }
             }
             crate::security_manager::SecurityEventData::EnableEncryption(handle, bond_info) => {
-                let role = self.connection_by_handle(handle).and_then(|x| x.role);
+                let role = self.connection_by_handle(handle).map(|x| x.role);
                 if let Some(role) = role {
                     if LeConnRole::Central == role {
                         #[cfg(feature = "legacy-pairing")]
@@ -1018,13 +998,11 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 warn!("[host] Pairing timeout");
                 if let Some(peer_address) = self.security_manager.peer_address() {
                     for (index, storage) in self.connections.borrow_mut().iter_mut().enumerate() {
-                        if storage.state == ConnectionState::Connected {
-                            if let Some(peer) = &storage.peer_identity {
-                                if peer.match_address(&peer_address) {
-                                    storage.smp_timeout = true;
-                                    break;
-                                }
-                            }
+                        if storage.state == ConnectionState::Connected
+                            && storage.peer_identity.match_address(&peer_address)
+                        {
+                            storage.smp_timeout = true;
+                            break;
                         }
                     }
                 }
@@ -1040,7 +1018,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 // address distributed during key exchange, which may differ from the
                 // address seen at connection time (e.g. a temporary RPA).
                 if let Some(mut connection) = self.connection_by_handle_mut(handle) {
-                    connection.peer_identity = Some(identity);
+                    connection.peer_identity = identity;
                 }
             }
         }
@@ -1160,9 +1138,9 @@ impl<P> DisconnectRequest<'_, P> {
 }
 pub struct ConnectionStorage<P> {
     pub state: ConnectionState,
-    pub handle: Option<ConnHandle>,
-    pub role: Option<LeConnRole>,
-    pub peer_identity: Option<Identity>,
+    pub handle: ConnHandle,
+    pub role: LeConnRole,
+    pub peer_identity: Identity,
     pub params: ConnParams,
     pub att_mtu: Option<NonZeroU16>,
     pub link_credits: usize,
@@ -1273,9 +1251,16 @@ impl<P> ConnectionStorage<P> {
     pub(crate) const fn new() -> ConnectionStorage<P> {
         ConnectionStorage {
             state: ConnectionState::Disconnected,
-            handle: None,
-            role: None,
-            peer_identity: None,
+            handle: ConnHandle(0),
+            role: LeConnRole::Central,
+            peer_identity: Identity {
+                addr: Address {
+                    kind: AddrKind::PUBLIC,
+                    addr: BdAddr([0; 6]),
+                },
+                #[cfg(feature = "security")]
+                irk: None,
+            },
             params: ConnParams::new(),
             att_mtu: None,
             link_credits: 0,
@@ -1397,9 +1382,9 @@ impl<P> defmt::Format for ConnectionStorage<P> {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ConnectionState {
+    Disconnected,
     DisconnectRequest(DisconnectReason),
     Disconnecting(DisconnectReason),
-    Disconnected,
     Connecting,
     Connected,
 }

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -437,8 +437,8 @@ impl Inner {
                 events,
                 secret_key: &self.secret_key,
                 public_key: &self.public_key,
-                peer_identity: storage.peer_identity.ok_or(Error::InvalidValue)?,
-                conn_handle: storage.handle.ok_or(Error::InvalidValue)?,
+                peer_identity: storage.peer_identity,
+                conn_handle: storage.handle,
                 connections,
                 storage,
                 state: &self.state,
@@ -468,10 +468,10 @@ impl Inner {
                 events,
                 secret_key: &self.secret_key,
                 public_key: &self.public_key,
-                peer_identity: storage.peer_identity.ok_or(Error::InvalidValue)?,
+                peer_identity: storage.peer_identity,
                 connections,
                 storage,
-                conn_handle: storage.handle.ok_or(Error::InvalidValue)?,
+                conn_handle: storage.handle,
                 state: &self.state,
             };
             let res = sm.handle_event(pairing::Event::LinkEncryptedResult(encrypted), &mut ops, &mut self.rng);
@@ -488,10 +488,10 @@ impl Inner {
                 let _ = events.try_send(SecurityEventData::TimerChange);
             }
             res
-        } else if let Some(identity) = storage.peer_identity.as_ref() {
+        } else {
             match bonds
                 .iter()
-                .find(|bond| bond.identity.match_identity(identity))
+                .find(|bond| bond.identity.match_identity(&storage.peer_identity))
                 .cloned()
             {
                 Some(b) if encrypted => {
@@ -506,13 +506,11 @@ impl Inner {
                 _ => {
                     warn!(
                         "[smp] Either encryption failed to enable or bond not found for {:?}",
-                        identity
+                        storage.peer_identity
                     );
                     storage.security_level = SecurityLevel::NoEncryption;
                 }
             }
-            Ok(())
-        } else {
             Ok(())
         };
 
@@ -548,10 +546,10 @@ impl Inner {
                     events,
                     secret_key: &self.secret_key,
                     public_key: &self.public_key,
-                    peer_identity: storage.peer_identity.unwrap_or_default(),
+                    peer_identity: storage.peer_identity,
                     connections,
                     storage,
-                    conn_handle: storage.handle.unwrap_or(ConnHandle::new(0)),
+                    conn_handle: storage.handle,
                     state: &self.state,
                 },
                 &mut self.rng,
@@ -574,11 +572,11 @@ impl Inner {
         storage: &ConnectionStorage<<P as PacketPool>::Packet>,
         user_initiated: bool,
     ) -> Result<(), Error> {
-        let role = storage.role.ok_or(Error::InvalidValue)?;
+        let role = storage.role;
 
         if !self.is_idle() {
             // If pairing is already in progress for this peer, consider the request fulfilled.
-            let peer_identity = storage.peer_identity.ok_or(Error::InvalidValue)?;
+            let peer_identity = storage.peer_identity;
             let peer_address = peer_identity.addr;
             if self
                 .pairing_sm
@@ -590,8 +588,8 @@ impl Inner {
             return Err(Error::InvalidState);
         }
 
-        let handle = storage.handle.ok_or(Error::InvalidValue)?;
-        let peer_identity = storage.peer_identity.ok_or(Error::InvalidValue)?;
+        let handle = storage.handle;
+        let peer_identity = storage.peer_identity;
         let local_address = self.connection_local_address(storage)?;
         let peer_address = Self::connection_peer_address(peer_identity.addr, storage);
         let local_io = self.io_capabilities;
@@ -843,9 +841,9 @@ impl<'d> SecurityManager<'d> {
         let cmd = SmpCommand {
             command,
             payload: &buffer[1..size],
-            peer_address: storage.peer_identity.ok_or(Error::InvalidValue)?.addr,
-            handle: storage.handle.ok_or(Error::InvalidValue)?,
-            peer_identity: storage.peer_identity.ok_or(Error::InvalidValue)?,
+            peer_address: storage.peer_identity.addr,
+            handle: storage.handle,
+            peer_identity: storage.peer_identity,
         };
         self.inner.borrow_mut().handle_peripheral(
             &mut self.bonds.borrow_mut(),
@@ -866,9 +864,9 @@ impl<'d> SecurityManager<'d> {
         let cmd = SmpCommand {
             command,
             payload: &buffer[1..size],
-            peer_address: storage.peer_identity.ok_or(Error::InvalidValue)?.addr,
-            handle: storage.handle.ok_or(Error::InvalidValue)?,
-            peer_identity: storage.peer_identity.ok_or(Error::InvalidValue)?,
+            peer_address: storage.peer_identity.addr,
+            handle: storage.handle,
+            peer_identity: storage.peer_identity,
         };
         self.inner
             .borrow_mut()
@@ -882,7 +880,7 @@ impl<'d> SecurityManager<'d> {
         connections: &ConnectionManager<P>,
         storage: &ConnectionStorage<P::Packet>,
     ) -> Result<(), Error> {
-        let role = storage.role.ok_or(Error::InvalidValue)?;
+        let role = storage.role;
 
         let result = if role == LeConnRole::Peripheral {
             self.handle_peripheral(pdu, connections, storage)
@@ -928,7 +926,7 @@ impl<'d> SecurityManager<'d> {
 
             // Cease sending security manager messages on timeout
             if *error != Error::Timeout {
-                let handle = storage.handle.ok_or(Error::InvalidValue)?;
+                let handle = storage.handle;
                 let mut packet = self.prepare_packet(Command::PairingFailed, connections)?;
                 let payload = packet.payload_mut();
                 payload[0] = u8::from(reason);

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -207,7 +207,6 @@ struct Inner {
 struct SmpCommand<'a> {
     command: Command,
     payload: &'a [u8],
-    peer_address: Address,
     handle: ConnHandle,
     peer_identity: Identity,
 }
@@ -260,7 +259,6 @@ impl Inner {
         let SmpCommand {
             command,
             payload,
-            peer_address,
             handle,
             peer_identity,
         } = *cmd;
@@ -352,7 +350,6 @@ impl Inner {
         let SmpCommand {
             command,
             payload,
-            peer_address,
             handle,
             peer_identity,
         } = *cmd;
@@ -827,7 +824,6 @@ impl<'d> SecurityManager<'d> {
         let cmd = SmpCommand {
             command,
             payload: &buffer[1..size],
-            peer_address: storage.peer_identity.addr,
             handle: storage.handle,
             peer_identity: storage.peer_identity,
         };
@@ -850,7 +846,6 @@ impl<'d> SecurityManager<'d> {
         let cmd = SmpCommand {
             command,
             payload: &buffer[1..size],
-            peer_address: storage.peer_identity.addr,
             handle: storage.handle,
             peer_identity: storage.peer_identity,
         };

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -1276,3 +1276,130 @@ impl<'sm, 'cm, 'cm2, 'cs, P: PacketPool> PairingOps<P> for PairingOpsImpl<'sm, '
         self.state.local_address.ok_or(Error::InvalidValue)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::cell::RefCell;
+    use std::boxed::Box;
+
+    use bt_hci::param::{ConnHandle, LeConnRole};
+    use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+    use rand_chacha::ChaCha12Rng;
+    use rand_core::SeedableRng;
+
+    use super::*;
+    use crate::connection::ConnParams;
+    use crate::connection_manager::{ConnectionManager, ConnectionStorage};
+    use crate::prelude::DefaultPacketPool;
+    use crate::IoCapabilities;
+
+    fn setup_manager() -> &'static ConnectionManager<'static, DefaultPacketPool> {
+        let storage: &RefCell<[_]> = Box::leak(Box::new(RefCell::new([const { ConnectionStorage::new() }; 2])));
+        let bond_storage: &RefCell<heapless::VecView<_>> =
+            Box::leak(Box::new(RefCell::new(heapless::Vec::<BondInformation, 4>::new())));
+        Box::leak(Box::new(ConnectionManager::new(storage, bond_storage)))
+    }
+
+    fn test_inner(peer_address: Address) -> Inner {
+        let mut rng = ChaCha12Rng::from_seed([7; 32]);
+        let secret_key = crypto::SecretKey::new(&mut rng);
+        let public_key = secret_key.public_key();
+        Inner {
+            rng,
+            secret_key,
+            public_key,
+            state: SecurityManagerData {
+                local_address: Some(Address::random([1, 2, 3, 4, 5, 6])),
+                local_irk: None,
+            },
+            pairing_sm: Some(Pairing::new_peripheral(
+                Address::random([1, 2, 3, 4, 5, 6]),
+                peer_address,
+                IoCapabilities::NoInputNoOutput,
+            )),
+            finished_waker: WakerRegistration::new(),
+            io_capabilities: IoCapabilities::NoInputNoOutput,
+            #[cfg(feature = "legacy-pairing")]
+            secure_connections_only: false,
+        }
+    }
+
+    #[test]
+    fn encryption_success_uses_bond_when_pairing_sm_is_for_other_peer() {
+        let mgr = setup_manager();
+        let handle = ConnHandle::new(2);
+        let current = Identity::from(Address::random([0x10, 2, 3, 4, 5, 6]));
+        let other = Address::random([0x40, 2, 3, 4, 5, 6]);
+        unwrap!(mgr.connect(handle, current.addr, LeConnRole::Peripheral, ConnParams::new()));
+
+        let mut inner = test_inner(other);
+        let mut bonds: heapless::Vec<BondInformation, 4> = heapless::Vec::new();
+        unwrap!(bonds.push(BondInformation::new(
+            current,
+            LongTermKey::new(1),
+            SecurityLevel::EncryptedAuthenticated,
+            true,
+        )));
+        let events = Channel::<NoopRawMutex, SecurityEventData, 3>::new();
+
+        unwrap!(mgr.with_connected_handle(handle, |storage| {
+            unwrap!(inner.handle_encryption_success(&mut bonds, &events, true, mgr, storage));
+            assert_eq!(storage.security_level, SecurityLevel::EncryptedAuthenticated);
+            assert!(inner.pairing_sm.is_some());
+            assert_eq!(inner.pairing_sm.as_ref().unwrap().peer_address(), other);
+            Ok(())
+        }));
+    }
+
+    #[test]
+    fn encryption_failure_rejects_current_bond_without_touching_other_peer_sm() {
+        let mgr = setup_manager();
+        let handle = ConnHandle::new(3);
+        let current = Identity::from(Address::random([0x11, 2, 3, 4, 5, 6]));
+        let other = Address::random([0x41, 2, 3, 4, 5, 6]);
+        unwrap!(mgr.connect(handle, current.addr, LeConnRole::Peripheral, ConnParams::new()));
+
+        let mut inner = test_inner(other);
+        let mut bonds: heapless::Vec<BondInformation, 4> = heapless::Vec::new();
+        unwrap!(bonds.push(BondInformation::new(
+            current,
+            LongTermKey::new(2),
+            SecurityLevel::Encrypted,
+            true,
+        )));
+        let events = Channel::<NoopRawMutex, SecurityEventData, 3>::new();
+
+        unwrap!(mgr.with_connected_handle(handle, |storage| {
+            inner.handle_encryption_failure(&mut bonds, &events, mgr, storage);
+            assert!(storage.bond_rejected);
+            assert!(inner.pairing_sm.is_some());
+            assert_eq!(inner.pairing_sm.as_ref().unwrap().peer_address(), other);
+            Ok(())
+        }));
+    }
+
+    #[test]
+    fn pairing_event_for_other_peer_fails_without_advancing_sm() {
+        let mgr = setup_manager();
+        let handle = ConnHandle::new(4);
+        let current = Identity::from(Address::random([0x12, 2, 3, 4, 5, 6]));
+        let other = Address::random([0x42, 2, 3, 4, 5, 6]);
+        unwrap!(mgr.connect(handle, current.addr, LeConnRole::Peripheral, ConnParams::new()));
+
+        let mut inner = test_inner(other);
+        let mut bonds: heapless::Vec<BondInformation, 4> = heapless::Vec::new();
+        let events = Channel::<NoopRawMutex, SecurityEventData, 3>::new();
+
+        unwrap!(mgr.with_connected_handle(handle, |storage| {
+            assert_eq!(
+                inner.handle_pairing_event(&mut bonds, &events, pairing::Event::PassKeyConfirm, mgr, storage),
+                Err(Error::InvalidState)
+            );
+            assert!(inner.pairing_sm.is_some());
+            assert_eq!(inner.pairing_sm.as_ref().unwrap().peer_address(), other);
+            Ok(())
+        }));
+    }
+}

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -233,14 +233,20 @@ impl Inner {
     /// Get the peer address to use for pairing calculations.
     /// When privacy is enabled and a peer RPA was used for this connection, use it;
     /// otherwise fall back to the identity address.
-    fn connection_peer_address<P>(identity_addr: Address, storage: &ConnectionStorage<P>) -> Address {
+    fn connection_peer_address<P>(storage: &ConnectionStorage<P>) -> Address {
         if let Some(rpa) = storage.resolvable_addrs.peer {
-            return Address {
+            Address {
                 kind: bt_hci::param::AddrKind::RANDOM,
                 addr: rpa,
-            };
+            }
+        } else {
+            storage.peer_identity.addr
         }
-        identity_addr
+    }
+
+    fn pairing_sm_for<'a, P>(sm: Option<&'a mut Pairing>, storage: &ConnectionStorage<P>) -> Option<&'a mut Pairing> {
+        let expected = Self::connection_peer_address(storage);
+        sm.filter(|sm| sm.peer_address() == expected)
     }
 
     fn handle_peripheral<P: PacketPool>(
@@ -258,9 +264,9 @@ impl Inner {
             handle,
             peer_identity,
         } = *cmd;
-        if self.is_idle() {
+        if self.is_idle() && command == Command::PairingRequest {
             let local_address = self.connection_local_address(storage)?;
-            let peer_address = Self::connection_peer_address(peer_address, storage);
+            let peer_address = Self::connection_peer_address(storage);
             let local_io = self.io_capabilities;
 
             #[cfg(feature = "legacy-pairing")]
@@ -298,7 +304,9 @@ impl Inner {
             && payload.len() >= 4
             && (!AuthReq::from(payload[2]).secure_connection()
                 || payload[3] < crate::security_manager::constants::ENCRYPTION_KEY_SIZE_128_BITS)
-            && self.pairing_sm.as_ref().is_some_and(|p| p.is_lesc_peripheral())
+            && self.pairing_sm.as_ref().is_some_and(|sm| {
+                sm.peer_address() == Self::connection_peer_address(storage) && sm.is_lesc_peripheral()
+            })
         {
             if self.secure_connections_only {
                 if payload[3] < crate::security_manager::constants::ENCRYPTION_KEY_SIZE_128_BITS {
@@ -306,29 +314,17 @@ impl Inner {
                 }
                 return Err(Error::Security(Reason::AuthenticationRequirements));
             }
-            let old = self.pairing_sm.take().unwrap();
-            self.pairing_sm = Some(old.switch_to_legacy_peripheral()?);
+            if let Some(old) = self.pairing_sm.take() {
+                self.pairing_sm = Some(old.switch_to_legacy_peripheral()?);
+            }
         }
 
-        if self.pairing_sm.as_ref().unwrap().is_central() {
+        let Some(pairing_sm) = Self::pairing_sm_for(self.pairing_sm.as_mut(), storage) else {
             return Err(Error::InvalidState);
-        }
-        let address = self.pairing_sm.as_ref().unwrap().peer_address();
+        };
 
-        // The state machine stores the connection-level peer address: the RPA,
-        // when the controller resolved one (see `connection_peer_address`, and
-        // the SMP confirm-value calculations that require the on-air address).
-        // The incoming command carries the *resolved identity* address, so the
-        // command address must be normalized the same way before comparing.
-        // Comparing them directly rejected every pairing attempt from a peer
-        // whose RPA was resolved against a stored bond -- i.e. a bonded peer
-        // that lost its keys could never re-pair until the local bond (and so
-        // the resolving-list entry) was deleted.
-        if address != Self::connection_peer_address(peer_address, storage) {
-            // A pairing is already in progress with a *different* peer address;
-            // reject and reset rather than mixing two exchanges.
-            self.pairing_sm = None;
-            return Err(Error::InvalidValue);
+        if pairing_sm.is_central() {
+            return Err(Error::InvalidState);
         }
 
         let mut ops = PairingOpsImpl {
@@ -342,10 +338,7 @@ impl Inner {
             peer_identity,
             state: &self.state,
         };
-        self.pairing_sm
-            .as_mut()
-            .unwrap()
-            .handle_l2cap_command(command, payload, &mut ops, &mut self.rng)
+        pairing_sm.handle_l2cap_command(command, payload, &mut ops, &mut self.rng)
     }
 
     fn handle_central<P: PacketPool>(
@@ -363,10 +356,10 @@ impl Inner {
             handle,
             peer_identity,
         } = *cmd;
-        if self.is_idle() {
+        if self.is_idle() && command == Command::SecurityRequest {
             self.pairing_sm = Some(Pairing::new_central(
                 self.connection_local_address(storage)?,
-                Self::connection_peer_address(peer_address, storage),
+                Self::connection_peer_address(storage),
                 self.io_capabilities,
             ));
         }
@@ -378,7 +371,10 @@ impl Inner {
             && payload.len() >= 4
             && (!AuthReq::from(payload[2]).secure_connection()
                 || payload[3] < crate::security_manager::constants::ENCRYPTION_KEY_SIZE_128_BITS)
-            && self.pairing_sm.as_ref().is_some_and(|p| p.is_lesc_central())
+            && self
+                .pairing_sm
+                .as_ref()
+                .is_some_and(|sm| sm.peer_address() == Self::connection_peer_address(storage) && sm.is_lesc_central())
         {
             if self.secure_connections_only {
                 if payload[3] < crate::security_manager::constants::ENCRYPTION_KEY_SIZE_128_BITS {
@@ -386,24 +382,17 @@ impl Inner {
                 }
                 return Err(Error::Security(Reason::AuthenticationRequirements));
             }
-            let old = self.pairing_sm.take().unwrap();
-            self.pairing_sm = Some(old.switch_to_legacy_central()?);
+            if let Some(old) = self.pairing_sm.take() {
+                self.pairing_sm = Some(old.switch_to_legacy_central()?);
+            }
         }
 
-        if !self.pairing_sm.as_ref().unwrap().is_central() {
+        let Some(pairing_sm) = Self::pairing_sm_for(self.pairing_sm.as_mut(), storage) else {
             return Err(Error::InvalidState);
-        }
-        let address = self.pairing_sm.as_ref().unwrap().peer_address();
+        };
 
-        // See the matching check in `handle_peripheral`: the state machine
-        // stores the connection-level peer address (the RPA when one was
-        // resolved), while the command carries the resolved identity, so the
-        // command address must be normalized before comparing.
-        if address != Self::connection_peer_address(peer_address, storage) {
-            // A pairing is already in progress with a *different* peer address;
-            // reject and reset rather than mixing two exchanges.
-            self.pairing_sm = None;
-            return Err(Error::InvalidValue);
+        if !pairing_sm.is_central() {
+            return Err(Error::InvalidState);
         }
 
         let mut ops = PairingOpsImpl {
@@ -417,10 +406,7 @@ impl Inner {
             peer_identity,
             state: &self.state,
         };
-        self.pairing_sm
-            .as_mut()
-            .unwrap()
-            .handle_l2cap_command(command, payload, &mut ops, &mut self.rng)
+        pairing_sm.handle_l2cap_command(command, payload, &mut ops, &mut self.rng)
     }
 
     fn handle_pairing_event<P: PacketPool>(
@@ -431,7 +417,7 @@ impl Inner {
         connections: &ConnectionManager<'_, P>,
         storage: &ConnectionStorage<P::Packet>,
     ) -> Result<(), Error> {
-        if let Some(sm) = self.pairing_sm.as_mut() {
+        if let Some(sm) = Self::pairing_sm_for(self.pairing_sm.as_mut(), storage) {
             let mut ops = PairingOpsImpl {
                 bonds,
                 events,
@@ -448,9 +434,10 @@ impl Inner {
                 sm.reset_timeout();
                 let _ = events.try_send(SecurityEventData::TimerChange);
             }
-            return res;
+            res
+        } else {
+            Err(Error::InvalidState)
         }
-        Ok(())
     }
 
     fn handle_encryption_success<P: PacketPool>(
@@ -462,7 +449,7 @@ impl Inner {
         storage: &mut ConnectionStorage<P::Packet>,
     ) -> Result<(), Error> {
         let mut bond = None;
-        let res: Result<(), Error> = if let Some(sm) = self.pairing_sm.as_mut() {
+        let res: Result<(), Error> = if let Some(sm) = Self::pairing_sm_for(self.pairing_sm.as_mut(), storage) {
             let mut ops = PairingOpsImpl {
                 bonds,
                 events,
@@ -532,7 +519,11 @@ impl Inner {
         connections: &ConnectionManager<'_, P>,
         storage: &mut ConnectionStorage<P::Packet>,
     ) {
-        if let Some(sm) = self.pairing_sm.as_mut() {
+        let has_bond = bonds.iter().any(|b| b.identity.match_identity(&storage.peer_identity));
+        if has_bond {
+            storage.bond_rejected = true;
+        }
+        if let Some(sm) = Self::pairing_sm_for(self.pairing_sm.as_mut(), storage) {
             // If we were waiting for bonded encryption, mark the bond as
             // rejected on this connection so the next pairing attempt will
             // skip bonded encryption and initiate fresh pairing instead.
@@ -576,22 +567,17 @@ impl Inner {
 
         if !self.is_idle() {
             // If pairing is already in progress for this peer, consider the request fulfilled.
-            let peer_identity = storage.peer_identity;
-            let peer_address = peer_identity.addr;
-            if self
-                .pairing_sm
-                .as_ref()
-                .is_some_and(|sm| sm.peer_address() == peer_address && sm.result().is_none())
-            {
+            if Self::pairing_sm_for(self.pairing_sm.as_mut(), storage).is_some() {
                 return Ok(());
+            } else {
+                return Err(Error::InvalidState);
             }
-            return Err(Error::InvalidState);
         }
 
         let handle = storage.handle;
         let peer_identity = storage.peer_identity;
         let local_address = self.connection_local_address(storage)?;
-        let peer_address = Self::connection_peer_address(peer_identity.addr, storage);
+        let peer_address = Self::connection_peer_address(storage);
         let local_io = self.io_capabilities;
         let mut ops = PairingOpsImpl {
             bonds,

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -959,21 +959,20 @@ impl<'d> SecurityManager<'d> {
     }
 
     /// Channel disconnected
-    pub(crate) fn disconnect(&self, identity: &Identity) {
+    pub(crate) fn disconnect<P>(&self, storage: &ConnectionStorage<P>) {
         {
             let mut inner = self.inner.borrow_mut();
             if inner
                 .pairing_sm
-                .as_ref()
-                .is_some_and(|sm| sm.peer_address() == identity.addr)
+                .take_if(|p| p.peer_address() == Inner::connection_peer_address(storage))
+                .is_some()
             {
-                inner.pairing_sm = None;
                 inner.finished_waker.wake();
             }
         }
         self.bonds
             .borrow_mut()
-            .retain(|x| x.is_bonded || x.identity != *identity);
+            .retain(|x| x.is_bonded || x.identity != storage.peer_identity);
     }
 
     /// Handle recevied events from HCI


### PR DESCRIPTION
This mostly adds some additional checks to the SMP to make sure that events from one connection can't interfere with the pairing state machine of a different connection. It also improves the consistency of using the connections RPA within the SMP rather than the identity address.

I also removed the `Option` from the `handle`, `role`, and `peer_identity` fields in `ConnectionStorage`. These fields are all guaranteed to be populated when a connection is allocated and therefore observable. Removing the options removes a significant number of `unwrap()`s and `if let Some(...)` guards which could never fail. It may also save a small amount of memory.