### PR TITLE
fix(gap): store device name by reference instead of a one-shot StaticCell

### DIFF
--- a/host/src/gap.rs
+++ b/host/src/gap.rs
@@ -127,3 +127,27 @@ impl<'a> CentralConfig<'a> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+
+    use super::*;
+
+    // Building the GAP config twice must not panic. With the one-shot StaticCell
+    // the second build panicked ("StaticCell already full").
+    #[test]
+    fn gap_config_can_be_built_twice() {
+        for _ in 0..2 {
+            let mut table: AttributeTable<'_, NoopRawMutex, 16> = AttributeTable::new();
+            GapConfig::Peripheral(PeripheralConfig {
+                name: "trouble",
+                appearance: &appearance::UNKNOWN,
+            })
+            .build(&mut table)
+            .unwrap();
+        }
+    }
+}

--- a/host/src/gap.rs
+++ b/host/src/gap.rs
@@ -8,8 +8,6 @@
 //! parameters accessible on the user interface level.
 
 use embassy_sync::blocking_mutex::raw::RawMutex;
-use heapless::String;
-use static_cell::StaticCell;
 
 use crate::prelude::*;
 
@@ -87,14 +85,14 @@ impl<'a> GapConfig<'a> {
 impl<'a> PeripheralConfig<'a> {
     /// Add the peripheral GAP config to the attribute table
     fn build<M: RawMutex, const MAX: usize>(self, table: &mut AttributeTable<'a, M, MAX>) -> Result<(), &'static str> {
-        static PERIPHERAL_NAME: StaticCell<String<DEVICE_NAME_MAX_LENGTH>> = StaticCell::new();
-        let peripheral_name = PERIPHERAL_NAME.init(String::new());
-        peripheral_name
-            .push_str(self.name)
-            .map_err(|_| "Device name is too long. Max length is 22 bytes")?;
+        // Store the name by reference (lives for `'a`); a one-shot StaticCell
+        // would panic if the server is ever built twice.
+        if self.name.len() > DEVICE_NAME_MAX_LENGTH {
+            return Err("Device name is too long. Max length is 22 bytes");
+        }
 
         let mut gap_builder = table.add_service(Service::new(service::GAP));
-        gap_builder.add_characteristic_ro(characteristic::DEVICE_NAME, peripheral_name);
+        gap_builder.add_characteristic_ro(characteristic::DEVICE_NAME, self.name);
         gap_builder.add_characteristic_ro(characteristic::APPEARANCE, self.appearance);
         #[cfg(all(feature = "security", feature = "central"))]
         gap_builder.add_characteristic_ro(characteristic::CENTRAL_ADDRESS_RESOLUTION, &1u8);
@@ -109,14 +107,14 @@ impl<'a> PeripheralConfig<'a> {
 impl<'a> CentralConfig<'a> {
     /// Add the peripheral GAP config to the attribute table
     fn build<M: RawMutex, const MAX: usize>(self, table: &mut AttributeTable<'a, M, MAX>) -> Result<(), &'static str> {
-        static CENTRAL_NAME: StaticCell<String<DEVICE_NAME_MAX_LENGTH>> = StaticCell::new();
-        let central_name = CENTRAL_NAME.init(String::new());
-        central_name
-            .push_str(self.name)
-            .map_err(|_| "Device name is too long. Max length is 22 bytes")?;
+        // Store the name by reference (lives for `'a`); a one-shot StaticCell
+        // would panic if the server is ever built twice.
+        if self.name.len() > DEVICE_NAME_MAX_LENGTH {
+            return Err("Device name is too long. Max length is 22 bytes");
+        }
 
         let mut gap_builder = table.add_service(Service::new(service::GAP));
-        gap_builder.add_characteristic_ro(characteristic::DEVICE_NAME, central_name);
+        gap_builder.add_characteristic_ro(characteristic::DEVICE_NAME, self.name);
         gap_builder.add_characteristic_ro(characteristic::APPEARANCE, self.appearance);
         #[cfg(all(feature = "security", feature = "central"))]
         gap_builder.add_characteristic_ro(characteristic::CENTRAL_ADDRESS_RESOLUTION, &1u8);


### PR DESCRIPTION
Device name is a caller-provided `&'a str` that already outlives the attribute table, so it can be stored by reference; the one-shot StaticCell copy was unnecessary and made the GAP service un-rebuildable.

```
running 1 test
test gap::tests::gap_config_can_be_built_twice ... FAILED

failures:

---- gap::tests::gap_config_can_be_built_twice stdout ----

thread 'gap::tests::gap_config_can_be_built_twice' (60124) panicked at C:\Users\ION\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\static_cell-2.1.1\src\lib.rs:84:13:
`StaticCell` is already full, it can't be initialized twice.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    gap::tests::gap_config_can_be_built_twice

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.00s

```

