### PR TITLE
fix: define GAP_SERVICE_ATTRIBUTE_COUNT for peripheral only

### DIFF
--- a/host/src/gap.rs
+++ b/host/src/gap.rs
@@ -24,6 +24,9 @@ const DEVICE_NAME_MAX_LENGTH: usize = 22;
 ///                                 = 6 (or 8 with security+central)
 #[cfg(not(feature = "security"))]
 pub const GAP_SERVICE_ATTRIBUTE_COUNT: usize = 6;
+/// The number of attributes added by the GAP and GATT services (with security, peripheral only)
+#[cfg(all(feature = "security", not(feature = "central")))]
+pub const GAP_SERVICE_ATTRIBUTE_COUNT: usize = 6;
 /// The number of attributes added by the GAP and GATT services (with security)
 #[cfg(all(feature = "security", feature = "central"))]
 pub const GAP_SERVICE_ATTRIBUTE_COUNT: usize = 8;


### PR DESCRIPTION
I am building a peripheral with security and found that `GAP_SERVICE_ATTRIBUTE_COUNT` was undefined for this case with `security` enabled but `central` disabled. 6 should be correct for that case, as we don't have the `CENTRAL_ADDRESS_RESOLUTION`.