### PR TITLE
feat(central): Various improvements to central

### DIFF
--- a/examples/apps/src/ble_scanner.rs
+++ b/examples/apps/src/ble_scanner.rs
@@ -24,13 +24,13 @@ where
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();
-    let central = stack.central();
+    let mut central = stack.central();
     let mut runner = stack.runner();
 
     let printer = Printer {
         seen: RefCell::new(Deque::new()),
     };
-    let mut scanner = Scanner::new(central);
+    let mut scanner = Scanner::new(&mut central);
     let _ = join(runner.run_with_handler(&printer), async {
         let mut config = ScanConfig::default();
         config.active = true;

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -33,9 +33,9 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
 
         let host = self.host;
         let _drop = crate::host::OnDrop::new(|| {
-            host.connect_command_state.cancel(true);
+            host.connect_command_state.cancel(false);
         });
-        host.connect_command_state.request().await;
+        host.request_operation(&host.connect_command_state, false).await;
 
         let peer = if config.scan_config.filter_accept_list.len() == 1 {
             config.scan_config.filter_accept_list[0]
@@ -94,7 +94,7 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         let _drop = crate::host::OnDrop::new(|| {
             host.connect_command_state.cancel(true);
         });
-        host.connect_command_state.request().await;
+        host.request_operation(&host.connect_command_state, true).await;
 
         let peer = if config.scan_config.filter_accept_list.len() == 1 {
             config.scan_config.filter_accept_list[0]

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -3,7 +3,7 @@ use bt_hci::cmd::le::{
     LeAddDeviceToFilterAcceptList, LeClearFilterAcceptList, LeCreateConn, LeExtCreateConn, LeSetDefaultRateParameters,
 };
 use bt_hci::controller::{Controller, ControllerCmdAsync, ControllerCmdSync};
-use bt_hci::param::{AddrKind, BdAddr, InitiatingPhy, LeConnRole, PhyParams};
+use bt_hci::param::{InitiatingPhy, LeConnRole, PhyParams};
 use embassy_futures::select::{select, Either};
 
 use crate::connection::{ConnectConfig, ConnectRateParams, Connection, PhySet};
@@ -37,14 +37,19 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         });
         host.connect_command_state.request().await;
 
-        self.set_accept_filter(config.scan_config.filter_accept_list).await?;
+        let peer = if config.scan_config.filter_accept_list.len() == 1 {
+            config.scan_config.filter_accept_list[0]
+        } else {
+            self.set_accept_filter(config.scan_config.filter_accept_list).await?;
+            Address::default()
+        };
 
         host.async_command(LeCreateConn::new(
             bt_hci_duration(config.scan_config.interval),
             bt_hci_duration(config.scan_config.window),
-            true,
-            AddrKind::PUBLIC,
-            BdAddr::default(),
+            config.scan_config.filter_accept_list.len() > 1,
+            peer.kind,
+            peer.addr,
             host.own_addr_kind(),
             bt_hci_duration(config.connect_params.min_connection_interval),
             bt_hci_duration(config.connect_params.max_connection_interval),
@@ -91,7 +96,12 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         });
         host.connect_command_state.request().await;
 
-        self.set_accept_filter(config.scan_config.filter_accept_list).await?;
+        let peer = if config.scan_config.filter_accept_list.len() == 1 {
+            config.scan_config.filter_accept_list[0]
+        } else {
+            self.set_accept_filter(config.scan_config.filter_accept_list).await?;
+            Address::default()
+        };
 
         let initiating = InitiatingPhy {
             scan_interval: bt_hci_duration(config.scan_config.interval),
@@ -106,10 +116,10 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         let phy_params = create_phy_params(initiating, config.scan_config.phys);
 
         host.async_command(LeExtCreateConn::new(
-            true,
+            config.scan_config.filter_accept_list.len() > 1,
             host.own_addr_kind(),
-            AddrKind::PUBLIC,
-            BdAddr::default(),
+            peer.kind,
+            peer.addr,
             phy_params,
         ))
         .await?;

--- a/host/src/command.rs
+++ b/host/src/command.rs
@@ -5,7 +5,7 @@ use core::task::{Context, Poll};
 use embassy_sync::waitqueue::WakerRegistration;
 
 pub enum State<CTX> {
-    Active,
+    Active(CTX),
     Cancel(CTX),
     Idle,
 }
@@ -38,13 +38,13 @@ impl<CTX: Clone + Copy> CommandState<CTX> {
     }
 
     /// Request a new command
-    pub async fn request(&self) {
+    pub async fn request(&self, ctx: CTX) {
         poll_fn(|cx| {
             self.with_inner(|inner| {
                 inner.host.register(cx.waker());
                 match inner.state {
                     State::Idle => {
-                        inner.state = State::Active;
+                        inner.state = State::Active(ctx);
                         Poll::Ready(())
                     }
                     _ => Poll::Pending,
@@ -99,6 +99,15 @@ impl<CTX: Clone + Copy> CommandState<CTX> {
     /// Check if the command state is idle.
     pub fn is_idle(&self) -> bool {
         self.with_inner(|inner| matches!(inner.state, State::Idle))
+    }
+
+    /// Check whether an active or canceling command's context matches a predicate.
+    #[cfg(all(feature = "security", feature = "central"))]
+    pub fn is_active_with(&self, predicate: impl Fn(CTX) -> bool) -> bool {
+        self.with_inner(|inner| match inner.state {
+            State::Active(ctx) | State::Cancel(ctx) => predicate(ctx),
+            State::Idle => false,
+        })
     }
 
     pub fn done(&self) {

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -491,6 +491,27 @@ pub struct Connection<'stack, P: PacketPool> {
     manager: &'stack ConnectionManager<'stack, P>,
 }
 
+impl<P: PacketPool> core::fmt::Debug for Connection<'_, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Connection").field(&self.index).finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<P: PacketPool> defmt::Format for Connection<'_, P> {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "Connection({})", self.index)
+    }
+}
+
+impl<P: PacketPool> PartialEq for Connection<'_, P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index && core::ptr::eq(self.manager, other.manager)
+    }
+}
+
+impl<P: PacketPool> Eq for Connection<'_, P> {}
+
 impl<P: PacketPool> Clone for Connection<'_, P> {
     fn clone(&self) -> Self {
         self.manager.inc_ref(self.index);

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -1668,8 +1668,8 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                 Either4::Third(action) => match action {
                     CancelledCommandState::Connect(_) => {
                         trace!("[host] cancel connection create");
-                        if host.command(LeCreateConnCancel::new()).await.is_err() {
-                            warn!("[host] error cancelling connection");
+                        if let Err(err) = host.command(LeCreateConnCancel::new()).await {
+                            warn!("[host] error cancelling connection: {:?}", err);
                         }
                         // Signal to ensure no one is stuck
                         host.connect_command_state.canceled();

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -43,14 +43,18 @@ use bt_hci::param::{
     LeEventMask, Status,
 };
 use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
-use embassy_futures::select::{select3, select4, Either3, Either4};
-#[cfg(feature = "scan")]
+use embassy_futures::select::{select3, select5, Either3, Either5};
+#[cfg(any(feature = "scan", all(feature = "security", feature = "central")))]
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+#[cfg(all(feature = "security", feature = "central"))]
+use embassy_sync::mutex::Mutex;
 use embassy_sync::once_lock::OnceLock;
 #[cfg(feature = "scan")]
 use embassy_sync::signal::Signal;
 use embassy_sync::waitqueue::WakerRegistration;
 use embassy_time::Duration;
+#[cfg(all(feature = "security", feature = "central"))]
+use embassy_time::{Instant, Timer};
 use futures::pin_mut;
 
 use crate::att::{AttClient, AttServer};
@@ -137,7 +141,11 @@ pub(crate) struct BleHost<'d, T, P: PacketPool> {
     pub(crate) connect_command_state: CommandState<bool>,
     pub(crate) scan_command_state: CommandState<bool>,
     #[cfg(feature = "security")]
+    pub(crate) command_request_gate: Mutex<NoopRawMutex, ()>,
+    #[cfg(feature = "security")]
     pub(crate) rpa_timeout: Cell<embassy_time::Duration>,
+    #[cfg(all(feature = "security", feature = "central"))]
+    pub(crate) rpa_expires_at: Cell<Instant>,
     #[cfg(feature = "security")]
     pub(crate) resolving_list_state: RefCell<ResolvingListSignal>,
     #[cfg(feature = "scan")]
@@ -277,7 +285,11 @@ where
             scan_command_state: CommandState::new(),
             connect_command_state: CommandState::new(),
             #[cfg(feature = "security")]
+            command_request_gate: Mutex::new(()),
+            #[cfg(feature = "security")]
             rpa_timeout: Cell::new(embassy_time::Duration::from_secs(900)),
+            #[cfg(all(feature = "security", feature = "central"))]
+            rpa_expires_at: Cell::new(Instant::from_ticks(0)),
             #[cfg(feature = "security")]
             resolving_list_state: RefCell::new(ResolvingListSignal::new()),
             #[cfg(feature = "scan")]
@@ -295,6 +307,11 @@ where
         }
         if let Poll::Ready(ctx) = self.scan_command_state.poll_cancelled(cx) {
             return Poll::Ready(CancelledCommandState::Scan(ctx));
+        }
+
+        #[cfg(all(feature = "security", feature = "central"))]
+        if self.is_privacy_enabled() && self.is_rpa_rotation_ready() {
+            return Poll::Ready(CancelledCommandState::RotateRpa);
         }
 
         #[cfg(feature = "security")]
@@ -329,6 +346,51 @@ where
         self.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC)
     }
 
+    /// Atomically mark an address-using procedure active relative to RPA rotation.
+    pub(crate) async fn request_operation<CTX: Clone + Copy>(&self, state: &CommandState<CTX>, ctx: CTX) {
+        #[cfg(feature = "security")]
+        let _guard = self.command_request_gate.lock().await;
+        state.request(ctx).await;
+    }
+
+    #[cfg(all(feature = "security", feature = "central"))]
+    fn is_rpa_rotation_ready(&self) -> bool {
+        self.is_privacy_enabled()
+            && self.connect_command_state.is_idle()
+            && !self.advertise_command_state.is_active_with(|extended| !extended)
+            && self.scan_command_state.is_idle()
+            && Instant::now() >= self.rpa_expires_at.get()
+    }
+
+    #[cfg(all(feature = "security", feature = "central"))]
+    async fn wait_for_rpa_expiration(&self) {
+        while Instant::now() < self.rpa_expires_at.get() {
+            Timer::at(self.rpa_expires_at.get()).await
+        }
+        if !self.is_rpa_rotation_ready() {
+            // A command is still active, so rely on poll_cancelled to wake the runner loop instead
+            core::future::pending::<()>().await;
+        }
+    }
+
+    #[cfg(all(feature = "security", feature = "central"))]
+    async fn rotate_rpa(&self) -> Result<(), BleHostError<T::Error>>
+    where
+        T: ControllerCmdSync<LeSetRandomAddr>,
+    {
+        let _guard = self.command_request_gate.lock().await;
+        if !self.is_rpa_rotation_ready() {
+            return Ok(());
+        }
+        let Some(rpa) = self.connections.security_manager.generate_local_rpa() else {
+            return Ok(());
+        };
+        LeSetRandomAddr::new(rpa).exec(&self.controller).await?;
+        self.rpa_expires_at.set(Instant::now() + self.rpa_timeout.get());
+        trace!("[host] rotated private address");
+        Ok(())
+    }
+
     /// Sync the controller's resolving list based on a pending update.
     #[cfg(feature = "security")]
     pub(crate) async fn sync_resolving_list(&self, update: ResolvingListUpdate) -> Result<(), BleHostError<T::Error>>
@@ -340,6 +402,14 @@ where
             + ControllerCmdSync<LeSetPrivacyMode>,
         T::Error: crate::fmt::Format,
     {
+        let _guard = self.command_request_gate.lock().await;
+        if !(self.connect_command_state.is_idle()
+            && self.advertise_command_state.is_idle()
+            && self.scan_command_state.is_idle())
+        {
+            return Ok(());
+        }
+
         let local_irk = self.connections.security_manager.get_local_irk();
         let local_irk_bytes = local_irk.map(|k| k.to_le_bytes()).unwrap_or_default();
 
@@ -1466,6 +1536,8 @@ enum CancelledCommandState {
     Scan(bool),
     #[cfg(feature = "security")]
     SyncResolvingList(ResolvingListUpdate),
+    #[cfg(all(feature = "security", feature = "central"))]
+    RotateRpa,
 }
 
 impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
@@ -1506,8 +1578,20 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
             host.connections.security_manager.set_random_generator_seed(seed);
         }
 
-        if let Some(addr) = host.address {
-            LeSetRandomAddr::new(addr.addr).exec(&host.controller).await?;
+        {
+            let addr = host.address.map(|a| a.addr);
+
+            #[cfg(all(feature = "security", feature = "central"))]
+            let addr = host.connections.security_manager.generate_local_rpa().or(addr);
+
+            if let Some(addr) = addr {
+                LeSetRandomAddr::new(addr).exec(&host.controller).await?;
+
+                #[cfg(all(feature = "security", feature = "central"))]
+                if host.is_privacy_enabled() {
+                    host.rpa_expires_at.set(Instant::now() + host.rpa_timeout.get());
+                }
+            }
         }
 
         SetEventMask::new(
@@ -1624,7 +1708,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
         }
 
         loop {
-            match select4(
+            match select5(
                 poll_fn(|cx| host.connections.poll_disconnecting(Some(cx))),
                 poll_fn(|cx| host.channels.poll_disconnecting(Some(cx))),
                 poll_fn(|cx| host.poll_cancelled(cx)),
@@ -1634,12 +1718,20 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                 },
                 #[cfg(not(feature = "security"))]
                 {
-                    poll_fn(|cx| Poll::<()>::Pending)
+                    core::future::pending::<()>()
+                },
+                #[cfg(all(feature = "security", feature = "central"))]
+                {
+                    host.wait_for_rpa_expiration()
+                },
+                #[cfg(not(all(feature = "security", feature = "central")))]
+                {
+                    core::future::pending::<()>()
                 },
             )
             .await
             {
-                Either4::First(request) => {
+                Either5::First(request) => {
                     trace!("[host] poll disconnecting links");
                     match host.command(Disconnect::new(request.handle(), request.reason())).await {
                         Ok(_) => {}
@@ -1652,7 +1744,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                     }
                     request.confirm();
                 }
-                Either4::Second(request) => {
+                Either5::Second(request) => {
                     trace!("[host] poll disconnecting channels");
                     match request.send(host).await {
                         Ok(_) => {}
@@ -1665,7 +1757,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                     }
                     request.confirm();
                 }
-                Either4::Third(action) => match action {
+                Either5::Third(action) => match action {
                     CancelledCommandState::Connect(_) => {
                         trace!("[host] cancel connection create");
                         if let Err(err) = host.command(LeCreateConnCancel::new()).await {
@@ -1703,12 +1795,22 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                     CancelledCommandState::SyncResolvingList(update) => {
                         host.sync_resolving_list(update).await?;
                     }
+                    #[cfg(all(feature = "security", feature = "central"))]
+                    CancelledCommandState::RotateRpa => {
+                        host.rotate_rpa().await?;
+                    }
                 },
-                Either4::Fourth(request) => {
+                Either5::Fourth(request) => {
                     #[cfg(feature = "security")]
                     {
                         let event_data = request.unwrap_or(SecurityEventData::Timeout);
                         host.connections.handle_security_event(host, event_data).await?;
+                    }
+                }
+                Either5::Fifth(()) => {
+                    #[cfg(all(feature = "security", feature = "central"))]
+                    {
+                        host.rotate_rpa().await?;
                     }
                 }
             }

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -44,7 +44,11 @@ use bt_hci::param::{
 };
 use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
 use embassy_futures::select::{select3, select4, Either3, Either4};
+#[cfg(feature = "scan")]
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::once_lock::OnceLock;
+#[cfg(feature = "scan")]
+use embassy_sync::signal::Signal;
 use embassy_sync::waitqueue::WakerRegistration;
 use embassy_time::Duration;
 use futures::pin_mut;
@@ -136,6 +140,8 @@ pub(crate) struct BleHost<'d, T, P: PacketPool> {
     pub(crate) rpa_timeout: Cell<embassy_time::Duration>,
     #[cfg(feature = "security")]
     pub(crate) resolving_list_state: RefCell<ResolvingListSignal>,
+    #[cfg(feature = "scan")]
+    pub(crate) scan_timeout: Signal<NoopRawMutex, ()>,
 }
 
 #[derive(Clone, Copy)]
@@ -274,6 +280,8 @@ where
             rpa_timeout: Cell::new(embassy_time::Duration::from_secs(900)),
             #[cfg(feature = "security")]
             resolving_list_state: RefCell::new(ResolvingListSignal::new()),
+            #[cfg(feature = "scan")]
+            scan_timeout: Signal::new(),
         }
     }
 
@@ -1254,7 +1262,10 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                         host.connect_command_state.canceled();
                                     }
                                 }
-                                LeEventKind::LeScanTimeout => {}
+                                LeEventKind::LeScanTimeout => {
+                                    #[cfg(feature = "scan")]
+                                    host.scan_timeout.signal(());
+                                }
                                 LeEventKind::LeAdvertisingSetTerminated => {
                                     let set = unwrap!(LeAdvertisingSetTerminated::from_hci_bytes_complete(event.data));
                                     host.advertise_state.terminate(set.adv_handle);

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -764,7 +764,7 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
 
     /// Enable BLE address privacy with the given Identity Resolving Key (IRK).
     ///
-    /// When privacy is enabled, the controller generates Resolvable Private Addresses (RPAs)
+    /// When privacy is enabled, Resolvable Private Addresses (RPAs) are generated
     /// that rotate periodically, preventing device tracking while allowing bonded peers to
     /// resolve the device's identity.
     ///
@@ -783,7 +783,10 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
 
     /// Set the RPA (Resolvable Private Address) rotation timeout.
     ///
-    /// The controller will automatically generate a new RPA after this duration.
+    /// New RPAs will be generated after this duration. Note that host generated RPAs
+    /// (used for active scanning of and connecting to unbonded devices) will only rotate
+    /// when scanning, connection initiation, and legacy advertising are all idle.
+    ///
     /// Default is 900 seconds (15 minutes) per the BLE specification.
     #[cfg(feature = "security")]
     pub fn set_rpa_timeout(mut self, timeout: Duration) -> Self {

--- a/host/src/peripheral.rs
+++ b/host/src/peripheral.rs
@@ -64,7 +64,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
         let drop = crate::host::OnDrop::new(|| {
             host.advertise_command_state.cancel(false);
         });
-        host.advertise_command_state.request().await;
+        host.request_operation(&host.advertise_command_state, false).await;
 
         // Clear current advertising terminations
         host.advertise_state.reset();
@@ -209,7 +209,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
         let drop = crate::host::OnDrop::new(|| {
             host.advertise_command_state.cancel(true);
         });
-        host.advertise_command_state.request().await;
+        host.request_operation(&host.advertise_command_state, true).await;
 
         // Clear current advertising terminations
         host.advertise_state.reset();
@@ -218,7 +218,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
             let handle = AdvHandle::new(i as u8);
             let data: RawAdvertisement<'k> = set.data.into();
             let params = set.params;
-            let peer = data.peer.unwrap_or(Address::new(AddrKind::PUBLIC, BdAddr::default()));
+            let peer = data.peer.unwrap_or_default();
             let own_addr_kind = params.own_addr_kind.unwrap_or_else(|| host.own_addr_kind());
             let random_addr = if let Some(addr) = set.address {
                 Some(addr)

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -106,7 +106,9 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
         });
         host.scan_command_state.request().await;
 
-        self.central.set_accept_filter(config.filter_accept_list).await?;
+        if !config.filter_accept_list.is_empty() {
+            self.central.set_accept_filter(config.filter_accept_list).await?;
+        }
 
         let params = LeSetScanParams::new(
             if config.active {

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -1,4 +1,6 @@
 //! Scan config.
+use core::future::Future;
+
 use bt_hci::cmd::le::{
     LeAddDeviceToFilterAcceptList, LeClearFilterAcceptList, LeSetExtScanEnable, LeSetExtScanParams, LeSetScanEnable,
     LeSetScanParams,
@@ -6,6 +8,8 @@ use bt_hci::cmd::le::{
 use bt_hci::controller::{Controller, ControllerCmdSync};
 use bt_hci::param::{FilterDuplicates, ScanningPhy};
 pub use bt_hci::param::{LeAdvReportsIter, LeExtAdvReportsIter};
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::signal::Signal;
 use embassy_time::Instant;
 
 use crate::command::CommandState;
@@ -67,6 +71,7 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
         ))
         .await?;
 
+        host.scan_timeout.reset();
         host.command(LeSetExtScanEnable::new(
             true,
             config.filter_duplicates,
@@ -82,6 +87,7 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
             } else {
                 Some(Instant::now() + config.timeout)
             },
+            timeout: &host.scan_timeout,
             done: false,
         })
     }
@@ -131,6 +137,7 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
             } else {
                 Some(Instant::now() + config.timeout)
             },
+            timeout: &host.scan_timeout,
             done: false,
         })
     }
@@ -140,11 +147,21 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
 pub struct ScanSession<'d, const EXTENDED: bool> {
     command_state: &'d CommandState<bool>,
     deadline: Option<Instant>,
+    timeout: &'d Signal<NoopRawMutex, ()>,
     done: bool,
 }
 
 impl<const EXTENDED: bool> Drop for ScanSession<'_, EXTENDED> {
     fn drop(&mut self) {
         self.command_state.cancel(EXTENDED);
+    }
+}
+
+impl<'d> Future for ScanSession<'d, true> {
+    type Output = ();
+
+    fn poll(self: core::pin::Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> core::task::Poll<Self::Output> {
+        let this = self.get_mut();
+        core::pin::pin!(this.timeout.wait()).poll(cx)
     }
 }

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -48,7 +48,7 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
         let drop = crate::host::OnDrop::new(|| {
             host.scan_command_state.cancel(true);
         });
-        host.scan_command_state.request().await;
+        host.request_operation(&host.scan_command_state, true).await;
         self.central.set_accept_filter(config.filter_accept_list).await?;
 
         let scanning = ScanningPhy {
@@ -104,7 +104,7 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
         let drop = crate::host::OnDrop::new(|| {
             host.scan_command_state.cancel(false);
         });
-        host.scan_command_state.request().await;
+        host.request_operation(&host.scan_command_state, false).await;
 
         if !config.filter_accept_list.is_empty() {
             self.central.set_accept_filter(config.filter_accept_list).await?;

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -149,9 +149,20 @@ pub struct ScanSession<'d, const EXTENDED: bool> {
     done: bool,
 }
 
+impl<const EXTENDED: bool> ScanSession<'_, EXTENDED> {
+    /// Stop scanning and wait until the controller has disabled scanning.
+    pub async fn stop(mut self) {
+        self.command_state.cancel(EXTENDED);
+        self.command_state.wait_idle().await;
+        self.done = true;
+    }
+}
+
 impl<const EXTENDED: bool> Drop for ScanSession<'_, EXTENDED> {
     fn drop(&mut self) {
-        self.command_state.cancel(EXTENDED);
+        if !self.done {
+            self.command_state.cancel(EXTENDED);
+        }
     }
 }
 

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -21,25 +21,23 @@ use crate::{bt_hci_duration, BleHostError, Central, PacketPool};
 ///
 /// The buffer size can be tuned if in a noisy environment that
 /// returns a lot of results.
-pub struct Scanner<'d, C: Controller, P: PacketPool> {
-    central: Central<'d, C, P>,
+pub struct Scanner<'d, 'stack, C: Controller, P: PacketPool> {
+    central: &'d mut Central<'stack, C, P>,
 }
 
-impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
+impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
     /// Create a new scanner with the provided central.
-    pub fn new(central: Central<'d, C, P>) -> Self {
+    pub fn new(central: &'d mut Central<'stack, C, P>) -> Self {
         Self { central }
-    }
-
-    /// Retrieve the underlying central
-    pub fn into_inner(self) -> Central<'d, C, P> {
-        self.central
     }
 
     /// Performs an extended BLE scan, return a report for discovering peripherals.
     ///
     /// Scan is stopped when a report is received. Call this method repeatedly to continue scanning.
-    pub async fn scan_ext(&mut self, config: &ScanConfig<'_>) -> Result<ScanSession<'_, true>, BleHostError<C::Error>>
+    pub async fn scan_ext(
+        &mut self,
+        config: &ScanConfig<'_>,
+    ) -> Result<ScanSession<'stack, true>, BleHostError<C::Error>>
     where
         C: ControllerCmdSync<LeSetExtScanEnable>
             + ControllerCmdSync<LeSetExtScanParams>
@@ -95,7 +93,7 @@ impl<'d, C: Controller, P: PacketPool> Scanner<'d, C, P> {
     /// Performs a BLE scan, return a report for discovering peripherals.
     ///
     /// Scan is stopped when a report is received. Call this method repeatedly to continue scanning.
-    pub async fn scan(&mut self, config: &ScanConfig<'_>) -> Result<ScanSession<'_, false>, BleHostError<C::Error>>
+    pub async fn scan(&mut self, config: &ScanConfig<'_>) -> Result<ScanSession<'stack, false>, BleHostError<C::Error>>
     where
         C: ControllerCmdSync<LeSetScanParams>
             + ControllerCmdSync<LeSetScanEnable>

--- a/host/src/security_manager/mod.rs
+++ b/host/src/security_manager/mod.rs
@@ -12,6 +12,8 @@ use core::task::Poll;
 
 use bt_hci::event::le::{LeEventKind, LeEventPacket, LeLongTermKeyRequest};
 use bt_hci::event::{EncryptionChangeV1, EncryptionKeyRefreshComplete, EventKind, EventPacket};
+#[cfg(feature = "central")]
+use bt_hci::param::BdAddr;
 use bt_hci::param::{ConnHandle, EncryptionEnabledLevel, LeConnRole};
 use bt_hci::FromHciBytes;
 pub use crypto::{IdentityResolvingKey, LongTermKey};
@@ -748,6 +750,14 @@ impl<'d> SecurityManager<'d> {
     /// Returns `Some` when privacy is enabled, `None` otherwise.
     pub(crate) fn get_local_irk(&self) -> Option<IdentityResolvingKey> {
         self.inner.borrow().state.local_irk
+    }
+
+    /// Generate a local resolvable private address when privacy is enabled.
+    #[cfg(feature = "central")]
+    pub(crate) fn generate_local_rpa(&self) -> Option<BdAddr> {
+        let mut inner = self.inner.borrow_mut();
+        let irk = inner.state.local_irk?;
+        Some(BdAddr::new(irk.generate_resolvable_address(&mut inner.rng)))
     }
 
     /// Add a bonded device

--- a/tester/app/src/central.rs
+++ b/tester/app/src/central.rs
@@ -76,7 +76,7 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                     window: Duration::from_millis(50),
                     ..Default::default()
                 };
-                let mut scanner = Scanner::new(central);
+                let mut scanner = Scanner::new(&mut central);
                 match scanner.scan_ext(&config).await {
                     Ok(session) => {
                         info!("Scan started");
@@ -105,7 +105,6 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                         cmd.reply(Response::Fail).await;
                     }
                 }
-                central = scanner.into_inner();
             }
             Command::StopDiscovery => {
                 // Not currently scanning, treat as idempotent success


### PR DESCRIPTION
This PR has a handful of improvements to the central and scan modules.

Scanning:
- `ScanSession` is now a future that resolves when the scan times out (if the scan config has a timeout)
- `ScanSession::stop()` is a method to stop the scan then asynchronously wait for the scan to be cancelled in the controller. This is needed to know when it is safe to try to use the central for something else, such as connecting to a discovered peer.
- `Scanner` now mutably borrows from `Central` instead of taking ownership. This makes it much easier to deal with lifetimes for applications that alternately scan and connect (no more `into_inner()` and having to pass the `Central` around by value everywhere).

The filter accept list is a shared resource (between advertising, scanning and connecting) on the controller so I've made several changes to tighten up when it is used to reduce contention:
- If a scan config has an empty filter accept list, the filter accept list is not touched.
- When connecting to a single peer, a direct connection command is used instead of the filter accept list.

The change to using direct connection commands exposed an issue with using the controller generated resolvable private addresses. Specifically, the controller will only use the generated RPA when the peer address of the command can be found in the resolving list. There are a few cases where this can fail:
- Active scanning of an unbonded peer (pre-existing issue)
- Initiating direct connection to an unbonded peer (new issue due to the filter accept list changes)
- Directed advertising to an unbonded peer (pre-existing issue)

I've added functionality to the host to generate RPAs when the `central` and `security` features are both enabled. This resolves the first two issues.

Directed advertising to an unbonded peer using legacy advertising (e.g. `advertise`) will use RPAs when the `central` feature is enabled, but will still use the identity address when the `central` feature is not enabled. Directed advertising to an unbonded peer using extended advertising (e.g. `advertise_ext`) will use the identity address unless an alternative random address is provided as the `address` in the `AdvertisementSet`. My belief is that directed advertising to unbonded peers should be quite rare and since it can be worked around by the application using extended advertising and providing an address in the advertisement set I kept my changes restricted to the `central` feature flag. Let me know if you'd prefer I remove that limitation.
