### PR TITLE
feat: add HCI ISO (CIS) event and data support

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -84,6 +84,8 @@ channel-metrics = []
 security = [ "dep:p256", "dep:aes", "dep:cmac", "dep:rand_core", "dep:rand_chacha", "dep:rand" ]
 # Enable LE Legacy Pairing (BLE 4.0/4.1 fallback when peer doesn't support Secure Connections)
 legacy-pairing = ["security"]
+# Enable Isochronous endpoint support
+iso = []
 
 # Enable ATT queued writes (long characteristic writes)
 att-queued-writes = ["gatt"]

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -25,16 +25,20 @@ use bt_hci::cmd::le::{
 use bt_hci::cmd::link_control::Disconnect;
 use bt_hci::cmd::{self, AsyncCmd, SyncCmd};
 use bt_hci::controller::{blocking, Controller, ControllerCmdAsync, ControllerCmdSync};
-use bt_hci::data::{AclBroadcastFlag, AclPacket, AclPacketBoundary, IsoPacket};
+#[cfg(feature = "iso")]
+use bt_hci::data::IsoPacket;
+use bt_hci::data::{AclBroadcastFlag, AclPacket, AclPacketBoundary};
 #[cfg(feature = "scan")]
 use bt_hci::event::le::LeAdvertisingReport;
 #[cfg(feature = "scan")]
 use bt_hci::event::le::LeExtendedAdvertisingReport;
 use bt_hci::event::le::{
-    LeAdvertisingSetTerminated, LeCisEstablished, LeCisRequest, LeConnectionComplete, LeConnectionRateChange,
-    LeConnectionUpdateComplete, LeDataLengthChange, LeEnhancedConnectionComplete, LeEventKind, LeEventPacket,
-    LeFrameSpaceUpdateComplete, LePhyUpdateComplete, LeRemoteConnectionParameterRequest,
+    LeAdvertisingSetTerminated, LeConnectionComplete, LeConnectionRateChange, LeConnectionUpdateComplete,
+    LeDataLengthChange, LeEnhancedConnectionComplete, LeEventKind, LeEventPacket, LeFrameSpaceUpdateComplete,
+    LePhyUpdateComplete, LeRemoteConnectionParameterRequest,
 };
+#[cfg(feature = "iso")]
+use bt_hci::event::le::{LeCisEstablished, LeCisRequest};
 use bt_hci::event::{DisconnectionComplete, EventKind, NumberOfCompletedPackets, Vendor};
 #[cfg(feature = "security")]
 use bt_hci::param::BdAddr;
@@ -1047,10 +1051,13 @@ pub trait EventHandler {
     fn on_packets_completed(&self, _num_completed: usize) {}
 
     /// Handle an LE CIS Request event
+    #[cfg(feature = "iso")]
     fn on_cis_request(&self, _event: &LeCisRequest) {}
     /// Handle an LE CIS Established event
+    #[cfg(feature = "iso")]
     fn on_cis_established(&self, _event: &LeCisEstablished) {}
     /// Handle an incoming HCI ISO data packet
+    #[cfg(feature = "iso")]
     fn on_iso_data(&self, _packet: &IsoPacket<'_>) {}
 }
 
@@ -1391,10 +1398,12 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                         .connections
                                         .post_handle_event(event.handle, ConnectionEvent::RequestConnectionParams(req));
                                 }
+                                #[cfg(feature = "iso")]
                                 LeEventKind::LeCisRequest => {
                                     let e = unwrap!(LeCisRequest::from_hci_bytes_complete(event.data));
                                     event_handler.on_cis_request(&e);
                                 }
+                                #[cfg(feature = "iso")]
                                 LeEventKind::LeCisEstablished => {
                                     let e = unwrap!(LeCisEstablished::from_hci_bytes_complete(event.data));
                                     event_handler.on_cis_established(&e);
@@ -1454,6 +1463,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                         _ => {}
                     }
                 }
+                #[cfg(feature = "iso")]
                 Ok(ControllerToHostPacket::Iso(packet)) => {
                     event_handler.on_iso_data(&packet);
                 }
@@ -1550,9 +1560,10 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
             .enable_le_ext_adv_report(true)
             .enable_le_long_term_key_request(true)
             .enable_le_phy_update_complete(true)
-            .enable_le_data_length_change(true)
-            .enable_le_cis_established_v1(true)
-            .enable_le_cis_request(true);
+            .enable_le_data_length_change(true);
+
+        #[cfg(feature = "iso")]
+        let mask = mask.enable_le_cis_established_v1(true).enable_le_cis_request(true);
 
         #[cfg(feature = "connection-params-update")]
         let mask = mask.enable_le_remote_conn_parameter_request(true);

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -25,15 +25,15 @@ use bt_hci::cmd::le::{
 use bt_hci::cmd::link_control::Disconnect;
 use bt_hci::cmd::{self, AsyncCmd, SyncCmd};
 use bt_hci::controller::{blocking, Controller, ControllerCmdAsync, ControllerCmdSync};
-use bt_hci::data::{AclBroadcastFlag, AclPacket, AclPacketBoundary};
+use bt_hci::data::{AclBroadcastFlag, AclPacket, AclPacketBoundary, IsoPacket};
 #[cfg(feature = "scan")]
 use bt_hci::event::le::LeAdvertisingReport;
 #[cfg(feature = "scan")]
 use bt_hci::event::le::LeExtendedAdvertisingReport;
 use bt_hci::event::le::{
-    LeAdvertisingSetTerminated, LeConnectionComplete, LeConnectionRateChange, LeConnectionUpdateComplete,
-    LeDataLengthChange, LeEnhancedConnectionComplete, LeEventKind, LeEventPacket, LeFrameSpaceUpdateComplete,
-    LePhyUpdateComplete, LeRemoteConnectionParameterRequest,
+    LeAdvertisingSetTerminated, LeCisEstablished, LeCisRequest, LeConnectionComplete, LeConnectionRateChange,
+    LeConnectionUpdateComplete, LeDataLengthChange, LeEnhancedConnectionComplete, LeEventKind, LeEventPacket,
+    LeFrameSpaceUpdateComplete, LePhyUpdateComplete, LeRemoteConnectionParameterRequest,
 };
 use bt_hci::event::{DisconnectionComplete, EventKind, NumberOfCompletedPackets, Vendor};
 #[cfg(feature = "security")]
@@ -1045,6 +1045,13 @@ pub trait EventHandler {
     /// ACL data packets have been transmitted over the air. Useful for
     /// measuring actual air delivery rate and estimating connection event timing.
     fn on_packets_completed(&self, _num_completed: usize) {}
+
+    /// Handle an LE CIS Request event
+    fn on_cis_request(&self, _event: &LeCisRequest) {}
+    /// Handle an LE CIS Established event
+    fn on_cis_established(&self, _event: &LeCisEstablished) {}
+    /// Handle an incoming HCI ISO data packet
+    fn on_iso_data(&self, _packet: &IsoPacket<'_>) {}
 }
 
 struct DummyHandler;
@@ -1384,6 +1391,14 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                         .connections
                                         .post_handle_event(event.handle, ConnectionEvent::RequestConnectionParams(req));
                                 }
+                                LeEventKind::LeCisRequest => {
+                                    let e = unwrap!(LeCisRequest::from_hci_bytes_complete(event.data));
+                                    event_handler.on_cis_request(&e);
+                                }
+                                LeEventKind::LeCisEstablished => {
+                                    let e = unwrap!(LeCisEstablished::from_hci_bytes_complete(event.data));
+                                    event_handler.on_cis_established(&e);
+                                }
                                 _ => {
                                     warn!("Unknown LE event!");
                                 }
@@ -1438,6 +1453,9 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                         // Ignore
                         _ => {}
                     }
+                }
+                Ok(ControllerToHostPacket::Iso(packet)) => {
+                    event_handler.on_iso_data(&packet);
                 }
                 // Ignore
                 Ok(_) => {}
@@ -1532,7 +1550,9 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
             .enable_le_ext_adv_report(true)
             .enable_le_long_term_key_request(true)
             .enable_le_phy_update_complete(true)
-            .enable_le_data_length_change(true);
+            .enable_le_data_length_change(true)
+            .enable_le_cis_established_v1(true)
+            .enable_le_cis_request(true);
 
         #[cfg(feature = "connection-params-update")]
         let mask = mask.enable_le_remote_conn_parameter_request(true);

--- a/host/src/iso.rs
+++ b/host/src/iso.rs
@@ -1,0 +1,43 @@
+//! Isochronous (CIS/BIS) HCI commands and data.
+
+use bt_hci::cmd::{AsyncCmd, SyncCmd};
+use bt_hci::controller::{Controller, ControllerCmdAsync, ControllerCmdSync};
+use bt_hci::data::IsoPacket;
+
+use crate::host::BleHost;
+use crate::{BleHostError, PacketPool};
+
+/// A type for running isochronous-stream HCI commands and data.
+pub struct Iso<'stack, C, P: PacketPool> {
+    host: &'stack BleHost<'stack, C, P>,
+}
+
+impl<'stack, C: Controller, P: PacketPool> Iso<'stack, C, P> {
+    pub(crate) fn new(host: &'stack BleHost<'stack, C, P>) -> Self {
+        Self { host }
+    }
+
+    /// Run a synchronous HCI command and return its response.
+    pub async fn command<Cmd>(&self, cmd: Cmd) -> Result<Cmd::Return, BleHostError<C::Error>>
+    where
+        Cmd: SyncCmd,
+        C: ControllerCmdSync<Cmd>,
+    {
+        self.host.command(cmd).await
+    }
+
+    /// Run an asynchronous HCI command (one whose completion arrives as a separate event, e.g.
+    /// `LE Accept CIS Request`'s `LE CIS Established`) without waiting for that event.
+    pub async fn command_async<Cmd>(&self, cmd: Cmd) -> Result<(), BleHostError<C::Error>>
+    where
+        Cmd: AsyncCmd,
+        C: ControllerCmdAsync<Cmd>,
+    {
+        self.host.async_command(cmd).await
+    }
+
+    /// Write a raw HCI ISO data packet to the controller.
+    pub async fn send(&self, packet: &IsoPacket<'_>) -> Result<(), C::Error> {
+        self.host.controller.write_iso_data(packet).await
+    }
+}

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -42,6 +42,7 @@ mod command;
 pub mod config;
 mod connection_manager;
 mod cursor;
+#[cfg(feature = "iso")]
 pub mod iso;
 #[cfg(feature = "default-packet-pool")]
 mod packet_pool;
@@ -98,6 +99,7 @@ pub mod prelude {
     #[cfg(feature = "gatt")]
     pub use crate::gatt::*;
     pub use crate::host::{ControlRunner, EventHandler, HostMetrics, Runner, RxRunner, TxRunner};
+    #[cfg(feature = "iso")]
     pub use crate::iso::Iso;
     pub use crate::l2cap::*;
     #[cfg(feature = "default-packet-pool")]
@@ -867,6 +869,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// Obtain an [`Iso`](iso::Iso) handle for isochronous-stream (CIS/BIS) HCI commands and data.
     ///
     /// This is a lightweight handle that can be created multiple times.
+    #[cfg(feature = "iso")]
     pub fn iso(&self) -> iso::Iso<'_, C, P> {
         iso::Iso::new(self.host)
     }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -42,6 +42,7 @@ mod command;
 pub mod config;
 mod connection_manager;
 mod cursor;
+pub mod iso;
 #[cfg(feature = "default-packet-pool")]
 mod packet_pool;
 mod pdu;
@@ -97,6 +98,7 @@ pub mod prelude {
     #[cfg(feature = "gatt")]
     pub use crate::gatt::*;
     pub use crate::host::{ControlRunner, EventHandler, HostMetrics, Runner, RxRunner, TxRunner};
+    pub use crate::iso::Iso;
     pub use crate::l2cap::*;
     #[cfg(feature = "default-packet-pool")]
     pub use crate::packet_pool::DefaultPacketPool;
@@ -860,6 +862,13 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     #[cfg(feature = "peripheral")]
     pub fn peripheral(&self) -> Peripheral<'_, C, P> {
         Peripheral::new(self.host)
+    }
+
+    /// Obtain an [`Iso`](iso::Iso) handle for isochronous-stream (CIS/BIS) HCI commands and data.
+    ///
+    /// This is a lightweight handle that can be created multiple times.
+    pub fn iso(&self) -> iso::Iso<'_, C, P> {
+        iso::Iso::new(self.host)
     }
 
     /// Set the IO capabilities used by the security manager.


### PR DESCRIPTION
Adds a Stack::iso() handle for isochronous-stream HCI commands and data, dispatches LE CIS Request/Established events and incoming ISO data packets to EventHandler (previously silently dropped by RxRunner's catch-all arms), and enables the corresponding event mask bits so controllers actually emit them.