### PR TITLE
feat: add security-p256-cortex-m4 feature

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -33,6 +33,7 @@ futures = { version = "0.3", default-features = false }
 heapless = "0.9"
 trouble-host-macros = { path = "../host-macros", version = "0.5.0", optional = true }
 p256 = { version = "0.13.2", default-features = false, features = ["ecdh","arithmetic"], optional = true }
+p256-cortex-m4 = { version = "0.1.0-alpha.6", default-features = false, optional = true }
 rand_core = { version = "0.6", optional = true }
 rand_chacha = { version = "0.3", default-features = false, optional = true }
 rand = { version="0.8", default-features = false, optional = true}
@@ -82,6 +83,8 @@ connection-metrics = []
 # Enable additional channel metrics
 channel-metrics = []
 security = [ "dep:p256", "dep:aes", "dep:cmac", "dep:rand_core", "dep:rand_chacha", "dep:rand" ]
+# Use the assembly-optimized P-256 implementation for LESC pairing (ARM Cortex-M4 targets only).
+security-p256-cortex-m4 = [ "security", "dep:p256-cortex-m4" ]
 # Enable LE Legacy Pairing (BLE 4.0/4.1 fallback when peer doesn't support Secure Connections)
 legacy-pairing = ["security"]
 

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -44,9 +44,9 @@ use bt_hci::param::{
 };
 use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
 use embassy_futures::select::{select3, select5, Either3, Either5};
-#[cfg(any(feature = "scan", all(feature = "security", feature = "central")))]
+#[cfg(any(feature = "scan", feature = "security"))]
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-#[cfg(all(feature = "security", feature = "central"))]
+#[cfg(feature = "security")]
 use embassy_sync::mutex::Mutex;
 use embassy_sync::once_lock::OnceLock;
 #[cfg(feature = "scan")]

--- a/host/src/security_manager/crypto.rs
+++ b/host/src/security_manager/crypto.rs
@@ -7,6 +7,7 @@ use aes::cipher::{BlockEncrypt, KeyInit};
 use aes::Aes128;
 use bt_hci::param::BdAddr;
 use cmac::digest;
+#[cfg(not(feature = "security-p256-cortex-m4"))]
 use p256::ecdh;
 use rand_core::{CryptoRng, RngCore};
 
@@ -368,10 +369,18 @@ pub struct Confirm(pub u128);
 pub struct NumCompare(pub u32);
 
 /// P-256 elliptic curve secret key.
+#[cfg(not(feature = "security-p256-cortex-m4"))]
 #[derive(Clone)]
 #[must_use]
 #[repr(transparent)]
 pub struct SecretKey(p256::NonZeroScalar);
+
+/// P-256 elliptic curve secret key.
+#[cfg(feature = "security-p256-cortex-m4")]
+#[derive(Clone)]
+#[must_use]
+#[repr(transparent)]
+pub struct SecretKey(p256_cortex_m4::SecretKey);
 
 impl core::fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -386,15 +395,60 @@ impl defmt::Format for SecretKey {
     }
 }
 
+#[cfg(feature = "security-p256-cortex-m4")]
 impl SecretKey {
     /// Generates a new random secret key.
     #[allow(clippy::new_without_default)]
-    #[inline(always)]
+    pub fn new<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
+        Self(p256_cortex_m4::SecretKey::random(rng))
+    }
+
+    /// Computes the associated public key.
+    pub fn public_key(&self) -> PublicKey {
+        let pk = self.0.public_key();
+        PublicKey {
+            x: PublicKeyX(Coord(pk.x())),
+            y: Coord(pk.y()),
+        }
+    }
+
+    /// Computes a shared secret from the local secret key and remote public
+    /// key. Returns [`None`] if the public key is either invalid or derived
+    /// from the same secret key ([Vol 3] Part H, Section 2.3.5.6.1).
+    ///
+    /// `local_pk` must be the public key of `self`; passing it in avoids an
+    /// expensive scalar multiplication to recompute it.
+    #[must_use]
+    pub fn dh_key(&self, pk: PublicKey, local_pk: &PublicKey) -> Option<DHKey> {
+        if pk.is_debug() {
+            return None; // TODO: Compile-time option for debug-only mode
+        }
+        if pk == *local_pk {
+            return None;
+        }
+
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(pk.x.as_be_bytes());
+        bytes[32..].copy_from_slice(&pk.y.0);
+        // from_untagged_bytes validates that the point is on the curve
+        let rpk = p256_cortex_m4::PublicKey::from_untagged_bytes(&bytes).ok()?;
+        let mut secret = [0u8; 32];
+        secret.copy_from_slice(self.0.agree(&rpk).as_bytes());
+        Some(DHKey(secret))
+    }
+}
+
+#[cfg(not(feature = "security-p256-cortex-m4"))]
+impl SecretKey {
+    /// Generates a new random secret key.
+    #[allow(clippy::new_without_default)]
+    #[inline(never)]
     pub fn new<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
         Self(p256::NonZeroScalar::random(rng))
     }
 
     /// Computes the associated public key.
+    #[inline(never)]
     pub fn public_key(&self) -> PublicKey {
         use p256::elliptic_curve::sec1::Coordinates::Uncompressed;
         use p256::elliptic_curve::sec1::ToEncodedPoint;
@@ -415,6 +469,7 @@ impl SecretKey {
     /// `local_pk` must be the public key of `self`; passing it in avoids an
     /// expensive scalar multiplication to recompute it.
     #[must_use]
+    #[inline(never)]
     pub fn dh_key(&self, pk: PublicKey, local_pk: &PublicKey) -> Option<DHKey> {
         use p256::elliptic_curve::sec1::FromEncodedPoint;
         if pk.is_debug() {
@@ -518,10 +573,19 @@ impl PublicKeyX {
 }
 
 /// P-256 elliptic curve shared secret ([Vol 3] Part H, Section 2.3.5.6.1).
+#[cfg(not(feature = "security-p256-cortex-m4"))]
 #[must_use]
 #[repr(transparent)]
 pub struct DHKey(ecdh::SharedSecret);
 
+/// P-256 elliptic curve shared secret ([Vol 3] Part H, Section 2.3.5.6.1).
+#[cfg(feature = "security-p256-cortex-m4")]
+#[derive(Clone)]
+#[must_use]
+#[repr(transparent)]
+pub struct DHKey([u8; 32]);
+
+#[cfg(not(feature = "security-p256-cortex-m4"))]
 impl Clone for DHKey {
     fn clone(&self) -> Self {
         Self(ecdh::SharedSecret::from(*self.0.raw_secret_bytes()))
@@ -542,6 +606,18 @@ impl defmt::Format for DHKey {
 }
 
 impl DHKey {
+    /// Big-endian x-coordinate of the shared secret.
+    #[cfg(not(feature = "security-p256-cortex-m4"))]
+    fn secret_bytes(&self) -> [u8; 32] {
+        (*self.0.raw_secret_bytes()).into()
+    }
+
+    /// Big-endian x-coordinate of the shared secret.
+    #[cfg(feature = "security-p256-cortex-m4")]
+    fn secret_bytes(&self) -> [u8; 32] {
+        self.0
+    }
+
     /// Generates LE Secure Connections `MacKey` and `LTK`
     /// ([Vol 3] Part H, Section 2.2.7).
     #[inline]
@@ -559,7 +635,7 @@ impl DHKey {
                 .finalize_key()
         };
         let mut m = AesCmac::new(&Key::new(0x6C88_8391_AAF5_A538_6037_0BDB_5A60_83BE));
-        m.update(self.0.raw_secret_bytes());
+        m.update(self.secret_bytes());
         let mut m = AesCmac::new(&m.finalize_key());
         (MacKey(half(&mut m, 0)), LongTermKey(u128::from(&half(&mut m, 1))))
     }


### PR DESCRIPTION
Use the assembly-optimized `p256-cortex-m4 `crate (https://crates.io/crates/p256_cortex_m4) for LESC pairing on Cortex-M4 targets. Roughly 10x faster and far less stack usage than the pure-Rust p256 crate, which matters for my nRF52810 target.

I added a benchmark (not on this branch) here: https://github.com/joelsa/trouble-fork/tree/p256-cortex-m4-benchmark

The results are:

```
[INFO ] P-256 LESC pairing microbenchmark (8 iterations) (p256_bench src/bin/p256_bench.rs:193)
[INFO ] TIMER0 @ 16 MHz --- 1 tick = 62.5 ns = 4 CPU cycles @ 64 MHz (p256_bench src/bin/p256_bench.rs:194)
[INFO ] p256 (pure Rust, `security` feature): (p256_bench src/bin/p256_bench.rs:196)
[INFO ]     keygen: avg 1437 us (92004 cyc)  min 1426 us  max 1452 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ]     public_key: avg 155944 us (9980432 cyc)  min 155944 us  max 155944 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ]     ecdh: avg 155927 us (9979328 cyc)  min 155927 us  max 155927 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ]     pairing: avg 313308 us (20051764 cyc)  min 313297 us  max 313323 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ] p256-cortex-m4 (asm, `security-p256-cortex-m4` feature): (p256_bench src/bin/p256_bench.rs:203)
[INFO ]     keygen: avg 1420 us (90880 cyc)  min 1400 us  max 1438 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ]     public_key: avg 7648 us (489528 cyc)  min 7648 us  max 7648 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ]     ecdh: avg 21834 us (1397432 cyc)  min 21834 us  max 21834 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ]     pairing: avg 30903 us (1977840 cyc)  min 30884 us  max 30922 us (p256_bench src/bin/p256_bench.rs:76)
[INFO ] Speedup (cortex-m4 vs pure Rust): (p256_bench src/bin/p256_bench.rs:210)
[INFO ]     keygen: 1.0x faster (p256_bench src/bin/p256_bench.rs:175)
[INFO ]     public_key: 20.3x faster (p256_bench src/bin/p256_bench.rs:175)
[INFO ]     ecdh: 7.1x faster (p256_bench src/bin/p256_bench.rs:175)
[INFO ]     pairing: 10.1x faster (p256_bench src/bin/p256_bench.rs:175)
[INFO ] done (p256_bench src/bin/p256_bench.rs:216)
```