### PR TITLE
refactor: Remove `C: Controller` generic from `HostResources`

### DIFF
--- a/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_central.rs
+++ b/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_central.rs
@@ -77,7 +77,7 @@ async fn main(spawner: Spawner) {
     Timer::after(Duration::from_millis(200)).await;
 
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(sdc, &mut resources)
         .set_random_address(address)
         .build();

--- a/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
+++ b/benchmarks/nrf-sdc/src/bin/l2cap_benchmark_peripheral.rs
@@ -74,7 +74,7 @@ async fn main(spawner: Spawner) {
     let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
 
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(sdc, &mut resources)
         .set_random_address(address)
         .register_l2cap_spsm(0xF2)

--- a/docs/pages/gatt.adoc
+++ b/docs/pages/gatt.adoc
@@ -238,7 +238,7 @@ struct BatteryService {
 
 pub async fn run<C: Controller>(controller: C) {
     let address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
-    let mut resources: HostResources<C, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
         HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)

--- a/docs/pages/getting_started.adoc
+++ b/docs/pages/getting_started.adoc
@@ -55,7 +55,6 @@ they generally do not need to be changed from the defaults.
 The `HostResources` type holds references to all packets, connections, channels and other data used by Trouble. The following
 generic parameters can be set:
 
-* *Controller* - Type implementing the `Controller` trait required by the host.
 * *PacketPool* - Allocator used for payloads. Should be sized according to your attribute size or l2cap MTU.
 * *CONNS* - max number of BLE connections supported.
 * *CHANNELS* - max number of L2CAP channels supported (not including GATT).
@@ -65,10 +64,8 @@ generic parameters can be set:
 The following instance would allow you to have up to 4 connections and 2 l2cap channels with an MTU configured by the `default-packet-pool-mtu-N` feature.
 
 ```
-let mut resources: HostResources<C, DefaultPacketPool, 4, 2, 1, 10> = HostResources::new();
+let mut resources: HostResources<DefaultPacketPool, 4, 2, 1, 10> = HostResources::new();
 ```
-
-where `C` is a type implementing the `Controller` trait. In many cases, the `C` parameter can be written as `_` in the resource declaration, allowing the compiler to infer it from the concrete controller value passed to `trouble_host::new`.
 
 == Creating the stack
 

--- a/docs/pages/l2cap.adoc
+++ b/docs/pages/l2cap.adoc
@@ -13,7 +13,7 @@ When using L2CAP CoC channels, you need to allocate an extra L2CAP channel slot 
 const CONNECTIONS_MAX: usize = 1;
 const L2CAP_CHANNELS_MAX: usize = 3; // Signal + ATT + 1 CoC channel
 
-let mut resources: HostResources<MyController, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
     HostResources::new();
 ----
 
@@ -187,7 +187,7 @@ const PAYLOAD_LEN: usize = 27;
 
 pub async fn run<C: Controller>(controller: C) {
     let address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
-    let mut resources: HostResources<C, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
         HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)

--- a/examples/apps/src/ble_advertise.rs
+++ b/examples/apps/src/ble_advertise.rs
@@ -18,7 +18,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, 0, 0> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, 0, 0> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_advertise_multiple.rs
+++ b/examples/apps/src/ble_advertise_multiple.rs
@@ -18,7 +18,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, 0, 0, 2> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, 0, 0, 2> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_central.rs
+++ b/examples/apps/src/ble_bas_central.rs
@@ -17,7 +17,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_central_auth.rs
+++ b/examples/apps/src/ble_bas_central_auth.rs
@@ -21,7 +21,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .set_io_capabilities(IoCapabilities::DisplayYesNo)

--- a/examples/apps/src/ble_bas_central_bonding.rs
+++ b/examples/apps/src/ble_bas_central_bonding.rs
@@ -28,7 +28,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x28, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_central_multiple.rs
+++ b/examples/apps/src/ble_bas_central_multiple.rs
@@ -17,7 +17,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_central_pass_key.rs
+++ b/examples/apps/src/ble_bas_central_pass_key.rs
@@ -17,7 +17,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .set_io_capabilities(IoCapabilities::KeyboardOnly)

--- a/examples/apps/src/ble_bas_central_sec.rs
+++ b/examples/apps/src/ble_bas_central_sec.rs
@@ -17,7 +17,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_peripheral.rs
+++ b/examples/apps/src/ble_bas_peripheral.rs
@@ -37,7 +37,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_peripheral_auth.rs
+++ b/examples/apps/src/ble_bas_peripheral_auth.rs
@@ -40,7 +40,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .set_io_capabilities(IoCapabilities::DisplayYesNo)

--- a/examples/apps/src/ble_bas_peripheral_bonding.rs
+++ b/examples/apps/src/ble_bas_peripheral_bonding.rs
@@ -74,7 +74,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x08, 0x05, 0xe4, 0xff]);
     info!("Our address = {}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_bas_peripheral_pass_key.rs
+++ b/examples/apps/src/ble_bas_peripheral_pass_key.rs
@@ -37,7 +37,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x19, 0x05, 0xe4, 0xff]);
     info!("Our address = {}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .set_io_capabilities(IoCapabilities::KeyboardOnly)

--- a/examples/apps/src/ble_bas_peripheral_sec.rs
+++ b/examples/apps/src/ble_bas_peripheral_sec.rs
@@ -43,7 +43,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_beacon.rs
+++ b/examples/apps/src/ble_beacon.rs
@@ -36,7 +36,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, 0, 0, 27> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, 0, 0, 27> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_dis_peripheral.rs
+++ b/examples/apps/src/ble_dis_peripheral.rs
@@ -34,7 +34,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_l2cap_central.rs
+++ b/examples/apps/src/ble_l2cap_central.rs
@@ -19,7 +19,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/ble_l2cap_peripheral.rs
+++ b/examples/apps/src/ble_l2cap_peripheral.rs
@@ -18,7 +18,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .register_l2cap_spsm(SPSM_L2CAP_EXAMPLES)

--- a/examples/apps/src/ble_scanner.rs
+++ b/examples/apps/src/ble_scanner.rs
@@ -20,7 +20,7 @@ where
 
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/high_throughput_ble_l2cap_central.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_central.rs
@@ -25,7 +25,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, P, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<P, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .build();

--- a/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
+++ b/examples/apps/src/high_throughput_ble_l2cap_peripheral.rs
@@ -21,7 +21,7 @@ where
     let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     info!("Our address = {:?}", address);
 
-    let mut resources: HostResources<_, P, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<P, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources)
         .set_random_address(address)
         .register_l2cap_spsm(SPSM_L2CAP_EXAMPLES)

--- a/examples/tests/tests/ble_bas_peripheral.rs
+++ b/examples/tests/tests/ble_bas_peripheral.rs
@@ -30,7 +30,7 @@ async fn run_bas_peripheral_test(labels: &[(&str, &str)], firmware: &str) {
     let peripheral_address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     let central = tokio::task::spawn_local(async move {
         let controller_central = serial::create_controller(&central).await;
-        let mut resources: HostResources<_, DefaultPacketPool, 2, 4> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, 2, 4> = HostResources::new();
         let stack = trouble_host::new(controller_central, &mut resources).build();
         let mut runner = stack.runner();
         let mut central = stack.central();

--- a/examples/tests/tests/ble_l2cap_central.rs
+++ b/examples/tests/tests/ble_l2cap_central.rs
@@ -46,7 +46,7 @@ async fn run_l2cap_central_test(labels: &[(&str, &str)], firmware: &str) {
     let peripheral = tokio::task::spawn_local(async move {
         let controller_peripheral = serial::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<_, DefaultPacketPool, 1, 1> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, 1, 1> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
             .register_l2cap_spsm(0x81)

--- a/examples/tests/tests/ble_l2cap_peripheral.rs
+++ b/examples/tests/tests/ble_l2cap_peripheral.rs
@@ -43,7 +43,7 @@ async fn run_l2cap_peripheral_test(labels: &[(&str, &str)], firmware: &str) {
     let peripheral_address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
     let central = tokio::task::spawn_local(async move {
         let controller_central = serial::create_controller(&central).await;
-        let mut resources: HostResources<_, DefaultPacketPool, 2, 4> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, 2, 4> = HostResources::new();
         let stack = trouble_host::new(controller_central, &mut resources).build();
         let mut runner = stack.runner();
         let mut central = stack.central();

--- a/host/src/central.rs
+++ b/host/src/central.rs
@@ -12,11 +12,11 @@ use crate::{bt_hci_duration, Address, BleHostError, Error, PacketPool};
 
 /// A type implementing the BLE central role.
 pub struct Central<'stack, C, P: PacketPool> {
-    pub(crate) host: &'stack BleHost<'stack, C, P>,
+    pub(crate) host: BleHost<'stack, C, P>,
 }
 
 impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
-    pub(crate) fn new(host: &'stack BleHost<'stack, C, P>) -> Self {
+    pub(crate) fn new(host: BleHost<'stack, C, P>) -> Self {
         Self { host }
     }
 
@@ -33,9 +33,9 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
 
         let host = self.host;
         let _drop = crate::host::OnDrop::new(|| {
-            host.connect_command_state.cancel(false);
+            host.connect_command_state().cancel(false);
         });
-        host.request_operation(&host.connect_command_state, false).await;
+        host.request_operation(host.connect_command_state(), false).await;
 
         let peer = if config.scan_config.filter_accept_list.len() == 1 {
             config.scan_config.filter_accept_list[0]
@@ -60,15 +60,15 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         ))
         .await?;
         match select(
-            host.connections
+            host.connections()
                 .accept(LeConnRole::Central, config.scan_config.filter_accept_list),
-            host.connect_command_state.wait_idle(),
+            host.connect_command_state().wait_idle(),
         )
         .await
         {
             Either::First(conn) => {
                 _drop.defuse();
-                host.connect_command_state.done();
+                host.connect_command_state().done();
                 Ok(conn)
             }
             Either::Second(_) => Err(Error::Timeout.into()),
@@ -92,9 +92,9 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         let host = self.host;
         // Ensure no other connect ongoing.
         let _drop = crate::host::OnDrop::new(|| {
-            host.connect_command_state.cancel(true);
+            host.connect_command_state().cancel(true);
         });
-        host.request_operation(&host.connect_command_state, true).await;
+        host.request_operation(host.connect_command_state(), true).await;
 
         let peer = if config.scan_config.filter_accept_list.len() == 1 {
             config.scan_config.filter_accept_list[0]
@@ -125,15 +125,15 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
         .await?;
 
         match select(
-            host.connections
+            host.connections()
                 .accept(LeConnRole::Central, config.scan_config.filter_accept_list),
-            host.connect_command_state.wait_idle(),
+            host.connect_command_state().wait_idle(),
         )
         .await
         {
             Either::First(conn) => {
                 _drop.defuse();
-                host.connect_command_state.done();
+                host.connect_command_state().done();
                 Ok(conn)
             }
             Either::Second(_) => Err(Error::Timeout.into()),
@@ -154,7 +154,7 @@ impl<'stack, C: Controller, P: PacketPool> Central<'stack, C, P> {
             // can match new RPAs via the resolving list.
             #[cfg(feature = "security")]
             let addr = host
-                .connections
+                .connections()
                 .security_manager
                 .get_peer_bond_information(&(*entry).into())
                 .map(|bond| bond.identity.addr)

--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -322,7 +322,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         &'d self,
         index: ChannelIndex,
         config: &L2capChannelConfig,
-        ble: &BleHost<'d, T, P>,
+        ble: BleHost<'d, T, P>,
     ) -> Result<L2capChannel<'d, P>, BleHostError<T::Error>> {
         let L2capChannelConfig {
             mtu,
@@ -383,7 +383,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         &self,
         index: ChannelIndex,
         result: LeCreditConnResultCode,
-        ble: &BleHost<'_, T, P>,
+        ble: BleHost<'_, T, P>,
     ) -> Result<(), BleHostError<T::Error>> {
         let (conn, req_id) = {
             let mut chan = self.channel_mut(index);
@@ -417,7 +417,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         conn: ConnHandle,
         spsm: u16,
         config: &L2capChannelConfig,
-        ble: &BleHost<'_, T, P>,
+        ble: BleHost<'_, T, P>,
     ) -> Result<L2capChannel<'d, P>, BleHostError<T::Error>> {
         let L2capChannelConfig {
             mtu,
@@ -479,7 +479,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         &'d self,
         conn: ConnHandle,
         idx: ChannelIndex,
-        ble: &BleHost<'_, T, P>,
+        ble: BleHost<'_, T, P>,
         cx: Option<&mut Context<'_>>,
     ) -> Poll<Result<L2capChannel<'d, P>, BleHostError<T::Error>>> {
         if let Some(cx) = cx {
@@ -487,7 +487,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         }
         let mut storage = self.channel_mut(idx);
         // Check if we've been disconnected while waiting
-        if !ble.connections.is_handle_connected(conn) {
+        if !ble.connections().is_handle_connected(conn) {
             return Poll::Ready(Err(Error::Disconnected.into()));
         }
 
@@ -909,9 +909,9 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
     pub(crate) async fn receive_sdu<T: Controller>(
         &self,
         chan: ChannelIndex,
-        ble: &BleHost<'d, T, P>,
+        ble: BleHost<'_, T, P>,
     ) -> Result<Sdu<P::Packet>, BleHostError<T::Error>> {
-        let pdu = self.receive_pdu(&ble.connections, chan).await?;
+        let pdu = self.receive_pdu(ble.connections(), chan).await?;
         let mut p_buf: [u8; 16] = [0; 16];
         self.flow_control(chan, ble, &mut p_buf).await?;
         Ok(Sdu::from_pdu(pdu))
@@ -924,9 +924,9 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         &self,
         chan: ChannelIndex,
         buf: &mut [u8],
-        ble: &BleHost<'d, T, P>,
+        ble: BleHost<'_, T, P>,
     ) -> Result<usize, BleHostError<T::Error>> {
-        let pdu = self.receive_pdu(&ble.connections, chan).await?;
+        let pdu = self.receive_pdu(ble.connections(), chan).await?;
 
         let to_copy = pdu.len().min(buf.len());
         // info!("[host] received a pdu of len {}, copying {} bytes", pdu.len(), to_copy);
@@ -968,7 +968,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         index: ChannelIndex,
         buf: &[u8],
         p_buf: &mut [u8],
-        ble: &BleHost<'d, T, P>,
+        ble: BleHost<'_, T, P>,
     ) -> Result<(), BleHostError<T::Error>> {
         let (conn, mps, mtu, peer_cid) = self.connected_channel_params(index)?;
         if buf.len() > mtu as usize {
@@ -1008,7 +1008,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
         index: ChannelIndex,
         buf: &[u8],
         p_buf: &mut [u8],
-        ble: &BleHost<'d, T, P>,
+        ble: BleHost<'_, T, P>,
     ) -> Result<(), BleHostError<T::Error>> {
         let (conn, mps, mtu, peer_cid) = self.connected_channel_params(index)?;
         if buf.len() > mtu as usize {
@@ -1075,7 +1075,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
     pub(crate) async fn send_conn_param_update_req<T: Controller>(
         &self,
         handle: ConnHandle,
-        host: &BleHost<'d, T, P>,
+        host: &BleHost<'_, T, P>,
         param: &ConnParamUpdateReq,
     ) -> Result<(), BleHostError<T::Error>> {
         let identifier = self.next_request_id();
@@ -1086,7 +1086,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
     pub(crate) async fn send_conn_param_update_res<T: Controller>(
         &self,
         handle: ConnHandle,
-        host: &BleHost<'d, T, P>,
+        host: &BleHost<'_, T, P>,
         param: &ConnParamUpdateRes,
     ) -> Result<(), BleHostError<T::Error>> {
         let identifier = self.next_request_id();
@@ -1108,7 +1108,7 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
     async fn flow_control<T: Controller>(
         &self,
         index: ChannelIndex,
-        ble: &BleHost<'d, T, P>,
+        ble: BleHost<'_, T, P>,
         p_buf: &mut [u8],
     ) -> Result<(), BleHostError<T::Error>> {
         let (conn, cid, credits) = {
@@ -1642,14 +1642,17 @@ mod tests {
 
     #[test]
     fn channel_refcount() {
-        let mut resources: HostResources<_, DefaultPacketPool, 2, 2> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, 2, 2> = HostResources::new();
         let ble = MockController::new();
 
-        let mut builder = crate::new(ble, &mut resources);
-        let ble = builder.host();
+        let builder = crate::new(ble, &mut resources);
+        let ble = BleHost::new(
+            builder.controller.as_ref().unwrap(),
+            builder.host_state.as_ref().unwrap(),
+        );
 
         let conn = ConnHandle::new(33);
-        ble.connections
+        ble.connections()
             .connect(
                 conn,
                 Address::new(AddrKind::PUBLIC, BdAddr::new([0; 6])),
@@ -1658,19 +1661,19 @@ mod tests {
             )
             .unwrap();
         let idx = ble
-            .channels
+            .channels()
             .alloc(conn, None, |storage| {
                 storage.state = ChannelState::Connecting(42);
             })
             .unwrap();
 
-        let chan = ble.channels.poll_created(conn, idx, ble, None);
+        let chan = ble.channels().poll_created(conn, idx, ble, None);
         assert!(matches!(chan, Poll::Pending));
 
-        ble.connections.disconnected(conn, Status::UNSPECIFIED).unwrap();
-        ble.channels.disconnected(conn).unwrap();
+        ble.connections().disconnected(conn, Status::UNSPECIFIED).unwrap();
+        ble.channels().disconnected(conn).unwrap();
 
-        let chan = ble.channels.poll_created(conn, idx, ble, None);
+        let chan = ble.channels().poll_created(conn, idx, ble, None);
         assert!(matches!(
             chan,
             Poll::Ready(Err(BleHostError::BleHost(Error::Disconnected)))

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -343,10 +343,14 @@ impl ConnectionParamsRequest {
             return self.reject(stack).await;
         }
 
-        match stack.host.async_command(into_le_conn_update(self.handle, params)).await {
+        match stack
+            .host()
+            .async_command(into_le_conn_update(self.handle, params))
+            .await
+        {
             Ok(()) => {
                 let param = ConnParamUpdateRes { result: 0 };
-                stack.host.send_conn_param_update_res(self.handle, &param).await
+                stack.host().send_conn_param_update_res(self.handle, &param).await
             }
             Err(BleHostError::BleHost(crate::Error::Hci(bt_hci::param::Error::UNKNOWN_CONN_IDENTIFIER))) => {
                 Err(crate::Error::Disconnected.into())
@@ -368,7 +372,7 @@ impl ConnectionParamsRequest {
     {
         self.responded = true;
         let param = ConnParamUpdateRes { result: 1 };
-        stack.host.send_conn_param_update_res(self.handle, &param).await
+        stack.host().send_conn_param_update_res(self.handle, &param).await
     }
 }
 
@@ -394,18 +398,22 @@ impl ConnectionParamsRequest {
             return self.reject(stack).await;
         }
 
-        match stack.host.async_command(into_le_conn_update(self.handle, params)).await {
+        match stack
+            .host()
+            .async_command(into_le_conn_update(self.handle, params))
+            .await
+        {
             Ok(()) => {
                 if self.l2cap {
                     // Use L2CAP signaling to update connection parameters
                     let param = ConnParamUpdateRes { result: 0 };
-                    stack.host.send_conn_param_update_res(self.handle, &param).await
+                    stack.host().send_conn_param_update_res(self.handle, &param).await
                 } else {
                     let interval_min: bt_hci::param::Duration<1_250> = bt_hci_duration(params.min_connection_interval);
                     let interval_max: bt_hci::param::Duration<1_250> = bt_hci_duration(params.max_connection_interval);
                     let timeout: bt_hci::param::Duration<10_000> = bt_hci_duration(params.supervision_timeout);
                     stack
-                        .host
+                        .host()
                         .async_command(LeRemoteConnectionParameterRequestReply::new(
                             self.handle,
                             interval_min,
@@ -439,10 +447,10 @@ impl ConnectionParamsRequest {
         self.responded = true;
         if self.l2cap {
             let param = ConnParamUpdateRes { result: 1 };
-            stack.host.send_conn_param_update_res(self.handle, &param).await
+            stack.host().send_conn_param_update_res(self.handle, &param).await
         } else {
             stack
-                .host
+                .host()
                 .async_command(LeRemoteConnectionParameterRequestNegativeReply::new(
                     self.handle,
                     RemoteConnectionParamsRejectReason::UnacceptableConnParameters,
@@ -769,7 +777,7 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         T: ControllerCmdSync<ReadRssi>,
     {
         let handle = self.handle();
-        let ret = stack.host.command(ReadRssi::new(handle)).await?;
+        let ret = stack.host().command(ReadRssi::new(handle)).await?;
         Ok(ret.rssi)
     }
 
@@ -806,7 +814,7 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
             }
         }
         stack
-            .host
+            .host()
             .async_command(LeSetPhy::new(self.handle(), all_phys, mask, mask, options))
             .await?;
         Ok(())
@@ -817,7 +825,7 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
     where
         T: ControllerCmdSync<LeReadPhy>,
     {
-        let res = stack.host.command(LeReadPhy::new(self.handle())).await?;
+        let res = stack.host().command(LeReadPhy::new(self.handle())).await?;
         Ok((res.tx_phy, res.rx_phy))
     }
 
@@ -833,9 +841,13 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
     {
         let handle = self.handle();
         // First, check the local supported features to ensure that the connection update is supported.
-        let features = stack.host.command(LeReadLocalSupportedFeatures::new()).await?;
+        let features = stack.host().command(LeReadLocalSupportedFeatures::new()).await?;
         if length <= 27 || features.supports_le_data_packet_length_extension() {
-            match stack.host.command(LeSetDataLength::new(handle, length, time_us)).await {
+            match stack
+                .host()
+                .command(LeSetDataLength::new(handle, length, time_us))
+                .await
+            {
                 Ok(_) => Ok(()),
                 Err(BleHostError::BleHost(crate::Error::Hci(bt_hci::param::Error::UNKNOWN_CONN_IDENTIFIER))) => {
                     Err(crate::Error::Disconnected.into())
@@ -858,9 +870,9 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
     {
         let handle = self.handle();
         // First, check the local supported features to ensure that the connection update is supported.
-        let features = stack.host.command(LeReadLocalSupportedFeatures::new()).await?;
+        let features = stack.host().command(LeReadLocalSupportedFeatures::new()).await?;
         if features.supports_conn_parameters_request_procedure() || self.role() == LeConnRole::Central {
-            match stack.host.async_command(into_le_conn_update(handle, params)).await {
+            match stack.host().async_command(into_le_conn_update(handle, params)).await {
                 Ok(_) => return Ok(()),
                 Err(BleHostError::BleHost(crate::Error::Hci(bt_hci::param::Error::UNKNOWN_CONN_IDENTIFIER))) => {
                     return Err(crate::Error::Disconnected.into());
@@ -890,7 +902,7 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
                 latency: params.max_latency,
                 timeout: timeout.as_u16(),
             };
-            stack.host.send_conn_param_update_req(handle, &param).await?;
+            stack.host().send_conn_param_update_req(handle, &param).await?;
         }
         Ok(())
     }
@@ -911,7 +923,7 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         let frame_space_min_dur = bt_hci_duration(frame_space_min);
         let frame_space_max_dur = bt_hci_duration(frame_space_max);
         match stack
-            .host
+            .host()
             .command(LeFrameSpaceUpdate::new(
                 handle,
                 frame_space_min_dur,
@@ -945,7 +957,7 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         let min_ce = bt_hci_duration(conn_rate_params.min_ce_length);
         let max_ce = bt_hci_duration(conn_rate_params.max_ce_length);
         match stack
-            .host
+            .host()
             .command(LeConnectionRateRequest::new(
                 handle,
                 min_interval,

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -1015,7 +1015,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
             crate::security_manager::SecurityEventData::TimerChange => (),
             #[cfg(feature = "security")]
             crate::security_manager::SecurityEventData::BondAdded(handle, identity) => {
-                host.resolving_list_state
+                host.resolving_list_state()
                     .borrow_mut()
                     .push(crate::host::ResolvingListUpdate::Add(identity));
                 // Update the connection's stored peer identity to reflect the identity

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -126,18 +126,10 @@ impl ResolvingListSignal {
     }
 }
 
-/// A BLE Host.
-///
-/// The BleHost holds the runtime state of the host, and is the entry point
-/// for all interactions with the controller.
-///
-/// The host performs connection management, l2cap channel management, and
-/// multiplexes events and data across connections and l2cap channels.
-pub(crate) struct BleHost<'d, T, P: PacketPool> {
+pub(crate) struct HostState<'d, P: PacketPool> {
     initialized: OnceLock<InitialState>,
     metrics: RefCell<HostMetrics>,
     pub(crate) address: Option<Address>,
-    pub(crate) controller: T,
     pub(crate) connections: ConnectionManager<'d, P>,
     pub(crate) channels: ChannelManager<'d, P>,
     pub(crate) advertise_state: AdvState<'d>,
@@ -155,6 +147,61 @@ pub(crate) struct BleHost<'d, T, P: PacketPool> {
     #[cfg(feature = "scan")]
     pub(crate) scan_timeout: Signal<NoopRawMutex, ()>,
 }
+
+impl<'d, P: PacketPool> HostState<'d, P> {
+    pub(crate) fn new(
+        connections: &'d RefCell<[ConnectionStorage<P::Packet>]>,
+        channels: &'d RefCell<[ChannelStorage<P::Packet>]>,
+        advertise_handles: &'d RefCell<[AdvHandleState]>,
+        #[cfg(feature = "security")] bond_storage: &'d RefCell<heapless::VecView<crate::BondInformation>>,
+    ) -> Self {
+        Self {
+            address: None,
+            initialized: OnceLock::new(),
+            metrics: RefCell::new(HostMetrics::default()),
+            connections: ConnectionManager::new(
+                connections,
+                #[cfg(feature = "security")]
+                bond_storage,
+            ),
+            channels: ChannelManager::new(channels),
+            advertise_state: AdvState::new(advertise_handles),
+            advertise_command_state: CommandState::new(),
+            scan_command_state: CommandState::new(),
+            connect_command_state: CommandState::new(),
+            #[cfg(feature = "security")]
+            command_request_gate: Mutex::new(()),
+            #[cfg(feature = "security")]
+            rpa_timeout: Cell::new(embassy_time::Duration::from_secs(900)),
+            #[cfg(all(feature = "security", feature = "central"))]
+            rpa_expires_at: Cell::new(Instant::from_ticks(0)),
+            #[cfg(feature = "security")]
+            resolving_list_state: RefCell::new(ResolvingListSignal::new()),
+            #[cfg(feature = "scan")]
+            scan_timeout: Signal::new(),
+        }
+    }
+}
+
+/// A BLE Host.
+///
+/// The BleHost holds the runtime state of the host, and is the entry point
+/// for all interactions with the controller.
+///
+/// The host performs connection management, l2cap channel management, and
+/// multiplexes events and data across connections and l2cap channels.
+pub(crate) struct BleHost<'d, T, P: PacketPool> {
+    controller: &'d T,
+    state: &'d HostState<'d, P>,
+}
+
+impl<'d, T, P: PacketPool> Clone for BleHost<'d, T, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'d, T, P: PacketPool> Copy for BleHost<'d, T, P> {}
 
 #[derive(Clone, Copy)]
 pub(crate) struct InitialState {
@@ -258,58 +305,74 @@ pub struct HostMetrics {
 
 impl<'d, T, P> BleHost<'d, T, P>
 where
-    T: Controller,
     P: PacketPool,
 {
     /// Create a new instance of the BLE host.
     ///
     /// The host requires a HCI driver (a particular HCI-compatible controller implementing the required traits), and
     /// a reference to resources that are created outside the host but which the host is the only accessor of.
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
-        controller: T,
-        connections: &'d RefCell<[ConnectionStorage<P::Packet>]>,
-        channels: &'d RefCell<[ChannelStorage<P::Packet>]>,
-        advertise_handles: &'d RefCell<[AdvHandleState]>,
-        #[cfg(feature = "security")] bond_storage: &'d RefCell<heapless::VecView<crate::BondInformation>>,
-    ) -> Self {
-        Self {
-            address: None,
-            initialized: OnceLock::new(),
-            metrics: RefCell::new(HostMetrics::default()),
-            controller,
-            connections: ConnectionManager::new(
-                connections,
-                #[cfg(feature = "security")]
-                bond_storage,
-            ),
-            channels: ChannelManager::new(channels),
-            advertise_state: AdvState::new(advertise_handles),
-            advertise_command_state: CommandState::new(),
-            scan_command_state: CommandState::new(),
-            connect_command_state: CommandState::new(),
-            #[cfg(feature = "security")]
-            command_request_gate: Mutex::new(()),
-            #[cfg(feature = "security")]
-            rpa_timeout: Cell::new(embassy_time::Duration::from_secs(900)),
-            #[cfg(all(feature = "security", feature = "central"))]
-            rpa_expires_at: Cell::new(Instant::from_ticks(0)),
-            #[cfg(feature = "security")]
-            resolving_list_state: RefCell::new(ResolvingListSignal::new()),
-            #[cfg(feature = "scan")]
-            scan_timeout: Signal::new(),
-        }
+    pub(crate) fn new(controller: &'d T, state: &'d HostState<'d, P>) -> Self {
+        Self { controller, state }
     }
 
+    pub(crate) fn address(&self) -> Option<Address> {
+        self.state.address
+    }
+
+    pub(crate) fn connect_command_state(&self) -> &CommandState<bool> {
+        &self.state.connect_command_state
+    }
+
+    pub(crate) fn advertise_command_state(&self) -> &CommandState<bool> {
+        &self.state.advertise_command_state
+    }
+
+    pub(crate) fn scan_command_state(&self) -> &'d CommandState<bool> {
+        &self.state.scan_command_state
+    }
+
+    pub(crate) fn connections(&self) -> &'d ConnectionManager<'d, P> {
+        &self.state.connections
+    }
+
+    pub(crate) fn channels(&self) -> &'d ChannelManager<'d, P> {
+        &self.state.channels
+    }
+
+    pub(crate) fn advertise_state(&self) -> &AdvState<'d> {
+        &self.state.advertise_state
+    }
+
+    #[cfg(feature = "scan")]
+    pub(crate) fn scan_timeout(&self) -> &'d Signal<NoopRawMutex, ()> {
+        &self.state.scan_timeout
+    }
+
+    #[cfg(feature = "security")]
+    pub(crate) fn resolving_list_state(&self) -> &RefCell<ResolvingListSignal> {
+        &self.state.resolving_list_state
+    }
+
+    #[cfg(feature = "security")]
+    pub(crate) fn rpa_timeout(&self) -> &Cell<Duration> {
+        &self.state.rpa_timeout
+    }
+}
+
+impl<'d, T, P> BleHost<'d, T, P>
+where
+    T: Controller,
+    P: PacketPool,
+{
     /// Poll whether any command should be cancelled or the resolving list should be synced.
     fn poll_cancelled(&self, cx: &mut Context<'_>) -> Poll<CancelledCommandState> {
-        if let Poll::Ready(ctx) = self.connect_command_state.poll_cancelled(cx) {
+        if let Poll::Ready(ctx) = self.state.connect_command_state.poll_cancelled(cx) {
             return Poll::Ready(CancelledCommandState::Connect(ctx));
         }
-        if let Poll::Ready(ctx) = self.advertise_command_state.poll_cancelled(cx) {
+        if let Poll::Ready(ctx) = self.state.advertise_command_state.poll_cancelled(cx) {
             return Poll::Ready(CancelledCommandState::Advertise(ctx));
         }
-        if let Poll::Ready(ctx) = self.scan_command_state.poll_cancelled(cx) {
+        if let Poll::Ready(ctx) = self.state.scan_command_state.poll_cancelled(cx) {
             return Poll::Ready(CancelledCommandState::Scan(ctx));
         }
 
@@ -319,11 +382,11 @@ where
         }
 
         #[cfg(feature = "security")]
-        if self.connect_command_state.is_idle()
-            && self.advertise_command_state.is_idle()
-            && self.scan_command_state.is_idle()
+        if self.state.connect_command_state.is_idle()
+            && self.state.advertise_command_state.is_idle()
+            && self.state.scan_command_state.is_idle()
         {
-            if let Poll::Ready(update) = self.resolving_list_state.borrow_mut().poll_changed(cx) {
+            if let Poll::Ready(update) = self.state.resolving_list_state.borrow_mut().poll_changed(cx) {
                 return Poll::Ready(CancelledCommandState::SyncResolvingList(update));
             }
         }
@@ -334,42 +397,42 @@ where
     /// Check whether BLE address privacy is enabled.
     #[cfg(feature = "security")]
     pub(crate) fn is_privacy_enabled(&self) -> bool {
-        self.connections.security_manager.get_local_irk().is_some()
+        self.state.connections.security_manager.get_local_irk().is_some()
     }
 
     /// Get the appropriate own address kind based on the host address and privacy state.
     pub(crate) fn own_addr_kind(&self) -> AddrKind {
         #[cfg(feature = "security")]
         if self.is_privacy_enabled() {
-            return if self.address.is_some() {
+            return if self.state.address.is_some() {
                 AddrKind::RESOLVABLE_PRIVATE_OR_RANDOM
             } else {
                 AddrKind::RESOLVABLE_PRIVATE_OR_PUBLIC
             };
         }
-        self.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC)
+        self.state.address.map(|a| a.kind).unwrap_or(AddrKind::PUBLIC)
     }
 
     /// Atomically mark an address-using procedure active relative to RPA rotation.
     pub(crate) async fn request_operation<CTX: Clone + Copy>(&self, state: &CommandState<CTX>, ctx: CTX) {
         #[cfg(feature = "security")]
-        let _guard = self.command_request_gate.lock().await;
+        let _guard = self.state.command_request_gate.lock().await;
         state.request(ctx).await;
     }
 
     #[cfg(all(feature = "security", feature = "central"))]
     fn is_rpa_rotation_ready(&self) -> bool {
         self.is_privacy_enabled()
-            && self.connect_command_state.is_idle()
-            && !self.advertise_command_state.is_active_with(|extended| !extended)
-            && self.scan_command_state.is_idle()
-            && Instant::now() >= self.rpa_expires_at.get()
+            && self.state.connect_command_state.is_idle()
+            && !self.state.advertise_command_state.is_active_with(|extended| !extended)
+            && self.state.scan_command_state.is_idle()
+            && Instant::now() >= self.state.rpa_expires_at.get()
     }
 
     #[cfg(all(feature = "security", feature = "central"))]
     async fn wait_for_rpa_expiration(&self) {
-        while Instant::now() < self.rpa_expires_at.get() {
-            Timer::at(self.rpa_expires_at.get()).await
+        while Instant::now() < self.state.rpa_expires_at.get() {
+            Timer::at(self.state.rpa_expires_at.get()).await
         }
         if !self.is_rpa_rotation_ready() {
             // A command is still active, so rely on poll_cancelled to wake the runner loop instead
@@ -382,15 +445,17 @@ where
     where
         T: ControllerCmdSync<LeSetRandomAddr>,
     {
-        let _guard = self.command_request_gate.lock().await;
+        let _guard = self.state.command_request_gate.lock().await;
         if !self.is_rpa_rotation_ready() {
             return Ok(());
         }
-        let Some(rpa) = self.connections.security_manager.generate_local_rpa() else {
+        let Some(rpa) = self.state.connections.security_manager.generate_local_rpa() else {
             return Ok(());
         };
-        LeSetRandomAddr::new(rpa).exec(&self.controller).await?;
-        self.rpa_expires_at.set(Instant::now() + self.rpa_timeout.get());
+        LeSetRandomAddr::new(rpa).exec(self.controller).await?;
+        self.state
+            .rpa_expires_at
+            .set(Instant::now() + self.state.rpa_timeout.get());
         trace!("[host] rotated private address");
         Ok(())
     }
@@ -406,19 +471,19 @@ where
             + ControllerCmdSync<LeSetPrivacyMode>,
         T::Error: crate::fmt::Format,
     {
-        let _guard = self.command_request_gate.lock().await;
-        if !(self.connect_command_state.is_idle()
-            && self.advertise_command_state.is_idle()
-            && self.scan_command_state.is_idle())
+        let _guard = self.state.command_request_gate.lock().await;
+        if !(self.state.connect_command_state.is_idle()
+            && self.state.advertise_command_state.is_idle()
+            && self.state.scan_command_state.is_idle())
         {
             return Ok(());
         }
 
-        let local_irk = self.connections.security_manager.get_local_irk();
+        let local_irk = self.state.connections.security_manager.get_local_irk();
         let local_irk_bytes = local_irk.map(|k| k.to_le_bytes()).unwrap_or_default();
 
         // Disable address resolution while modifying the list
-        LeSetAddrResolutionEnable::new(false).exec(&self.controller).await?;
+        LeSetAddrResolutionEnable::new(false).exec(self.controller).await?;
 
         let res = match update {
             ResolvingListUpdate::FullSync => self.full_resolving_list_sync(local_irk).await,
@@ -431,7 +496,7 @@ where
 
                     // Remove first in case this is an update (device already in list)
                     let _ = LeRemoveDeviceFromResolvingList::new(peer_addr_kind, identity.addr.addr)
-                        .exec(&self.controller)
+                        .exec(self.controller)
                         .await;
 
                     if let Err(e) = LeAddDeviceToResolvingList::new(
@@ -440,7 +505,7 @@ where
                         peer_irk_bytes,
                         local_irk_bytes,
                     )
-                    .exec(&self.controller)
+                    .exec(self.controller)
                     .await
                     {
                         warn!("[host] failed to add device to resolving list: {:?}", e);
@@ -448,7 +513,7 @@ where
 
                     if let Err(e) =
                         LeSetPrivacyMode::new(peer_addr_kind, identity.addr.addr, bt_hci::param::PrivacyMode::Device)
-                            .exec(&self.controller)
+                            .exec(self.controller)
                             .await
                     {
                         warn!("[host] failed to set privacy mode: {:?}", e);
@@ -462,7 +527,7 @@ where
                 debug!("[host] incremental resolving list remove");
 
                 if let Err(e) = LeRemoveDeviceFromResolvingList::new(peer_addr_kind, identity.addr.addr)
-                    .exec(&self.controller)
+                    .exec(self.controller)
                     .await
                 {
                     warn!("[host] failed to remove device from resolving list: {:?}", e);
@@ -472,7 +537,7 @@ where
         };
 
         // Always re-enable address resolution
-        if let Err(e) = LeSetAddrResolutionEnable::new(true).exec(&self.controller).await {
+        if let Err(e) = LeSetAddrResolutionEnable::new(true).exec(self.controller).await {
             warn!("[host] failed to re-enable address resolution: {:?}", e);
             return res.and(Err(e.into()));
         }
@@ -495,7 +560,7 @@ where
         debug!("[host] full resolving list sync");
 
         // Clear resolving list
-        LeClearResolvingList::new().exec(&self.controller).await?;
+        LeClearResolvingList::new().exec(self.controller).await?;
 
         let local_irk_bytes = local_irk.map(|k| k.to_le_bytes()).unwrap_or_default();
 
@@ -504,7 +569,7 @@ where
         if local_irk.is_some() {
             if let Err(e) =
                 LeAddDeviceToResolvingList::new(AddrKind::PUBLIC, BdAddr::default(), [0u8; 16], local_irk_bytes)
-                    .exec(&self.controller)
+                    .exec(self.controller)
                     .await
             {
                 warn!("[host] failed to add default resolving list entry: {:?}", e);
@@ -513,7 +578,7 @@ where
 
         // Add entries for all bonded peers with IRKs
         let mut i = 0;
-        while let Some(bond) = self.connections.security_manager.get_bond(i) {
+        while let Some(bond) = self.state.connections.security_manager.get_bond(i) {
             i += 1;
             if let Some(peer_irk) = bond.identity.irk {
                 let peer_addr_kind = bond.identity.addr.kind;
@@ -524,7 +589,7 @@ where
                     peer_irk_bytes,
                     local_irk_bytes,
                 )
-                .exec(&self.controller)
+                .exec(self.controller)
                 .await
                 {
                     warn!("[host] failed to add device to resolving list: {:?}", e);
@@ -536,7 +601,7 @@ where
                     bond.identity.addr.addr,
                     bt_hci::param::PrivacyMode::Device,
                 )
-                .exec(&self.controller)
+                .exec(self.controller)
                 .await
                 {
                     warn!("[host] failed to set privacy mode: {:?}", e);
@@ -550,7 +615,7 @@ where
 
     /// Returns true if the host has been initialized by the Runner.
     pub(crate) fn is_initialized(&self) -> bool {
-        self.initialized.try_get().is_some()
+        self.state.initialized.try_get().is_some()
     }
 
     /// Run a HCI command and return the response.
@@ -559,8 +624,8 @@ where
         C: SyncCmd,
         T: ControllerCmdSync<C>,
     {
-        let _ = self.initialized.get().await;
-        let ret = cmd.exec(&self.controller).await?;
+        let _ = self.state.initialized.get().await;
+        let ret = cmd.exec(self.controller).await?;
         Ok(ret)
     }
 
@@ -570,9 +635,14 @@ where
         C: AsyncCmd,
         T: ControllerCmdAsync<C>,
     {
-        let _ = self.initialized.get().await;
-        cmd.exec(&self.controller).await?;
+        let _ = self.state.initialized.get().await;
+        cmd.exec(self.controller).await?;
         Ok(())
+    }
+
+    #[cfg(feature = "iso")]
+    pub(crate) async fn write_iso_data(&self, packet: &bt_hci::data::IsoPacket<'_>) -> Result<(), T::Error> {
+        self.controller.write_iso_data(packet).await
     }
 
     fn handle_connection(
@@ -586,7 +656,7 @@ where
     ) -> bool {
         match status.to_result() {
             Ok(_) => {
-                if let Err(err) = self.connections.connect_with_rpas(
+                if let Err(err) = self.state.connections.connect_with_rpas(
                     handle,
                     peer_addr,
                     role,
@@ -608,27 +678,27 @@ where
                         "[host] connection with handle {:?} established to {}",
                         handle, peer_addr
                     );
-                    let mut m = self.metrics.borrow_mut();
+                    let mut m = self.state.metrics.borrow_mut();
                     m.connect_events = m.connect_events.wrapping_add(1);
                 }
             }
             Err(bt_hci::param::Error::ADV_TIMEOUT) => {
-                self.advertise_state.reset();
+                self.state.advertise_state.reset();
             }
             Err(bt_hci::param::Error::UNKNOWN_CONN_IDENTIFIER) => {
                 warn!("[host] connect cancelled");
-                self.connect_command_state.canceled();
+                self.state.connect_command_state.canceled();
             }
             Err(e) => {
                 warn!("Error connection complete event: {:?}", e);
-                self.connect_command_state.canceled();
+                self.state.connect_command_state.canceled();
             }
         }
         true
     }
 
     fn handle_acl(&self, acl: AclPacket<'_>, event_handler: &dyn EventHandler) -> Result<(), Error> {
-        self.connections.received(acl.handle())?;
+        self.state.connections.received(acl.handle())?;
         let handle = acl.handle();
         let (header, pdu) = match acl.boundary_flag() {
             AclPacketBoundary::FirstFlushable => {
@@ -653,7 +723,7 @@ where
 
                 // Fast-path for complete signalling packets
                 if header.channel == L2CAP_CID_LE_U_SIGNAL && data.len() == header.length as usize {
-                    return self.channels.signal(acl.handle(), data, &self.connections);
+                    return self.state.channels.signal(acl.handle(), data, &self.state.connections);
                 }
 
                 trace!(
@@ -669,16 +739,17 @@ where
                     #[cfg(feature = "l2cap-sdu-reassembly-optimization")]
                     if header.channel >= L2CAP_CID_DYN_START {
                         // This is the start of the frame, so make sure to adjust the credits.
-                        self.channels.received(header.channel, 1)?;
-                        self.channels.check_pdu_len(header.channel, header.length)?;
+                        self.state.channels.received(header.channel, 1)?;
+                        self.state.channels.check_pdu_len(header.channel, header.length)?;
 
-                        self.connections
+                        self.state
+                            .connections
                             .reassembly(acl.handle(), |p| {
                                 let r = if !p.in_progress() {
                                     // Init the new assembly assuming the length of the SDU.
                                     let (first, payload) = data.split_at(2);
                                     let len: u16 = u16::from_le_bytes([first[0], first[1]]);
-                                    self.channels.check_sdu_len(header.channel, len)?;
+                                    self.state.channels.check_sdu_len(header.channel, len)?;
                                     let Some(packet) = P::allocate() else {
                                         warn!("[host] no memory for packets on channel {}", header.channel);
                                         return Err(Error::OutOfMemory);
@@ -695,20 +766,20 @@ where
                                     Ok(())
                                 }
                             })
-                            .inspect_err(|_| self.channels.disconnect_by_cid(header.channel))?;
+                            .inspect_err(|_| self.state.channels.disconnect_by_cid(header.channel))?;
                         return Ok(());
                     }
 
                     // For dynamic channels, validate PDU length against MPS before reassembly.
                     if header.channel >= L2CAP_CID_DYN_START {
-                        self.channels.check_pdu_len(header.channel, header.length)?;
+                        self.state.channels.check_pdu_len(header.channel, header.length)?;
                     }
 
                     let Some(packet) = P::allocate() else {
                         warn!("[host] no memory for packets on channel {}", header.channel);
                         return Err(Error::OutOfMemory);
                     };
-                    self.connections.reassembly(acl.handle(), |p| {
+                    self.state.connections.reassembly(acl.handle(), |p| {
                         p.init(header.channel, header.length, packet)?;
                         let r = p.update(data)?;
                         if r.is_some() {
@@ -727,16 +798,17 @@ where
                     #[cfg(feature = "l2cap-sdu-reassembly-optimization")]
                     if header.channel >= L2CAP_CID_DYN_START {
                         // This is a complete L2CAP K-frame, so make sure to adjust the credits.
-                        self.channels.received(header.channel, 1)?;
-                        self.channels.check_pdu_len(header.channel, header.length)?;
+                        self.state.channels.received(header.channel, 1)?;
+                        self.state.channels.check_pdu_len(header.channel, header.length)?;
 
                         if let Some((state, pdu)) = self
+                            .state
                             .connections
                             .reassembly(acl.handle(), |p| {
                                 if !p.in_progress() {
                                     let (first, payload) = data.split_at(2);
                                     let len: u16 = u16::from_le_bytes([first[0], first[1]]);
-                                    self.channels.check_sdu_len(header.channel, len)?;
+                                    self.state.channels.check_sdu_len(header.channel, len)?;
                                     let Some(packet) = P::allocate() else {
                                         warn!("[host] no memory for packets on channel {}", header.channel);
                                         return Err(Error::OutOfMemory);
@@ -747,7 +819,7 @@ where
                                     p.update(data)
                                 }
                             })
-                            .inspect_err(|_| self.channels.disconnect_by_cid(header.channel))?
+                            .inspect_err(|_| self.state.channels.disconnect_by_cid(header.channel))?
                         {
                             result.replace((state, pdu));
                         } else {
@@ -760,14 +832,14 @@ where
                     } else {
                         // For dynamic channels, validate PDU length against MPS before reassembly.
                         if header.channel >= L2CAP_CID_DYN_START {
-                            self.channels.check_pdu_len(header.channel, header.length)?;
+                            self.state.channels.check_pdu_len(header.channel, header.length)?;
                         }
 
                         let Some(packet) = P::allocate() else {
                             warn!("[host] no memory for packets on channel {}", header.channel);
                             return Err(Error::OutOfMemory);
                         };
-                        let result = self.connections.reassembly(acl.handle(), |p| {
+                        let result = self.state.connections.reassembly(acl.handle(), |p| {
                             p.init(header.channel, header.length, packet)?;
                             p.update(data)
                         })?;
@@ -782,7 +854,7 @@ where
             AclPacketBoundary::Continuing => {
                 trace!("[host] inbound l2cap len = {}", acl.data().len(),);
                 // Get the existing fragment
-                if let Some((header, p)) = self.connections.reassembly(acl.handle(), |p| {
+                if let Some((header, p)) = self.state.connections.reassembly(acl.handle(), |p| {
                     if !p.in_progress() {
                         warn!(
                             "[host] unexpected continuation fragment of length {} for handle {}: {:?}",
@@ -812,7 +884,7 @@ where
                 // gatt to be enabled.
                 let a = att::Att::decode(pdu.as_ref());
                 if let Ok(att::Att::Client(AttClient::Request(att::AttReq::ExchangeMtu { mtu }))) = a {
-                    let mtu = self.connections.exchange_att_mtu(acl.handle(), mtu);
+                    let mtu = self.state.connections.exchange_att_mtu(acl.handle(), mtu);
 
                     let rsp = att::Att::Server(AttServer::Response(att::AttRsp::ExchangeMtu { mtu }));
                     let l2cap = L2capHeader {
@@ -827,20 +899,22 @@ where
 
                     debug!("[host] agreed att MTU of {}", mtu);
                     let len = w.len();
-                    self.connections.try_outbound(acl.handle(), Pdu::new(packet, len))?;
+                    self.state
+                        .connections
+                        .try_outbound(acl.handle(), Pdu::new(packet, len))?;
                 } else if let Ok(att::Att::Server(AttServer::Response(att::AttRsp::ExchangeMtu { mtu }))) = a {
                     debug!("[host] remote agreed att MTU of {}", mtu);
-                    self.connections.exchange_att_mtu(acl.handle(), mtu);
+                    self.state.connections.exchange_att_mtu(acl.handle(), mtu);
                     #[cfg(feature = "gatt")]
-                    self.connections.post_gatt_client(acl.handle(), pdu)?;
+                    self.state.connections.post_gatt_client(acl.handle(), pdu)?;
                 } else {
                     #[cfg(feature = "gatt")]
                     match a {
                         Ok(att::Att::Client(AttClient::Confirmation(_))) => {
-                            self.connections.signal_indication_confirmation(acl.handle());
+                            self.state.connections.signal_indication_confirmation(acl.handle());
                         }
                         Ok(att::Att::Client(_)) => {
-                            self.connections.post_gatt(acl.handle(), pdu)?;
+                            self.state.connections.post_gatt(acl.handle(), pdu)?;
                         }
                         Ok(att::Att::Server(AttServer::Unsolicited(att::AttUns::Indicate { .. }))) => {
                             // Per BLE spec, ATT_HANDLE_VALUE_CFM must always be sent in response
@@ -855,13 +929,13 @@ where
                             w.write_hci(&l2cap)?;
                             w.write(cfm)?;
                             let len = w.len();
-                            self.connections.try_outbound(acl.handle(), Pdu::new(buf, len))?;
+                            self.state.connections.try_outbound(acl.handle(), Pdu::new(buf, len))?;
 
                             // Also queue the indication for the GATT client if possible
-                            let _ = self.connections.post_gatt_client(acl.handle(), pdu);
+                            let _ = self.state.connections.post_gatt_client(acl.handle(), pdu);
                         }
                         Ok(att::Att::Server(_)) => {
-                            if let Err(e) = self.connections.post_gatt_client(acl.handle(), pdu) {
+                            if let Err(e) = self.state.connections.post_gatt_client(acl.handle(), pdu) {
                                 return Err(Error::OutOfMemory);
                             }
                         }
@@ -884,7 +958,9 @@ where
                                 w.write_hci(&l2cap)?;
                                 w.write(rsp)?;
                                 let len = w.len();
-                                self.connections.try_outbound(acl.handle(), Pdu::new(packet, len))?;
+                                self.state
+                                    .connections
+                                    .try_outbound(acl.handle(), Pdu::new(packet, len))?;
                             }
                         }
                     }
@@ -912,7 +988,9 @@ where
                             w.write(rsp)?;
 
                             let len = w.len();
-                            self.connections.try_outbound(acl.handle(), Pdu::new(packet, len))?;
+                            self.state
+                                .connections
+                                .try_outbound(acl.handle(), Pdu::new(packet, len))?;
                             warn!("[host] got attribute request but 'gatt' feature is not enabled.");
                             return Ok(());
                         } else {
@@ -923,13 +1001,16 @@ where
                 }
             }
             L2CAP_CID_LE_U_SIGNAL => {
-                self.channels.signal(handle, pdu.as_ref(), &self.connections)?;
+                self.state
+                    .channels
+                    .signal(handle, pdu.as_ref(), &self.state.connections)?;
             }
             L2CAP_CID_LE_U_SECURITY_MANAGER => {
-                self.connections
+                self.state
+                    .connections
                     .handle_security_channel(acl.handle(), pdu, event_handler)?;
             }
-            other if other >= L2CAP_CID_DYN_START => match self.channels.dispatch(header.channel, pdu) {
+            other if other >= L2CAP_CID_DYN_START => match self.state.channels.dispatch(header.channel, pdu) {
                 Ok(_) => {}
                 Err(e) => {
                     warn!("Error dispatching l2cap packet to channel: {:?}", e);
@@ -989,15 +1070,15 @@ where
     // This function cannot be used to send an SDU split among multiple k-frames.
     pub(crate) async fn l2cap_pdu(&self, handle: ConnHandle) -> Result<L2capSender<'_, T, P>, BleHostError<T::Error>> {
         // Take into account l2cap header.
-        let initial_state = self.initialized.get().await;
+        let initial_state = self.state.initialized.get().await;
         let acl_max = initial_state.acl_max as u16;
         if acl_max == 0 {
             return Err(Error::NoPermits.into());
         }
 
-        let acl_send_lock = poll_fn(|cx| self.connections.poll_acquire_acl_send_lock(handle, Some(cx))).await?;
+        let acl_send_lock = poll_fn(|cx| self.state.connections.poll_acquire_acl_send_lock(handle, Some(cx))).await?;
         Ok(L2capSender {
-            controller: &self.controller,
+            controller: self.controller,
             handle,
             acl_send_lock,
             fragment_size: acl_max,
@@ -1014,13 +1095,13 @@ where
         sdu_len: u16,
         mps: u16,
     ) -> Result<L2capSender<'_, T, P>, BleHostError<T::Error>> {
-        let initial_state = self.initialized.try_get().ok_or(Error::NoPermits)?;
+        let initial_state = self.state.initialized.try_get().ok_or(Error::NoPermits)?;
         let acl_max = initial_state.acl_max;
         if acl_max == 0 {
             return Err(Error::NoPermits.into());
         }
 
-        let acl_send_lock = match self.connections.poll_acquire_acl_send_lock(handle, None) {
+        let acl_send_lock = match self.state.connections.poll_acquire_acl_send_lock(handle, None) {
             Poll::Ready(res) => res?,
             Poll::Pending => {
                 return Err(Error::Busy.into());
@@ -1048,7 +1129,7 @@ where
         }
 
         Ok(L2capSender {
-            controller: &self.controller,
+            controller: self.controller,
             handle,
             acl_send_lock,
             fragment_size: acl_max as u16,
@@ -1061,7 +1142,10 @@ where
         handle: ConnHandle,
         param: &ConnParamUpdateReq,
     ) -> Result<(), BleHostError<T::Error>> {
-        self.channels.send_conn_param_update_req(handle, self, param).await
+        self.state
+            .channels
+            .send_conn_param_update_req(handle, self, param)
+            .await
     }
 
     pub(crate) async fn send_conn_param_update_res(
@@ -1069,23 +1153,26 @@ where
         handle: ConnHandle,
         param: &ConnParamUpdateRes,
     ) -> Result<(), BleHostError<T::Error>> {
-        self.channels.send_conn_param_update_res(handle, self, param).await
+        self.state
+            .channels
+            .send_conn_param_update_res(handle, self, param)
+            .await
     }
 
     /// Read current host metrics
     pub(crate) fn metrics<F: FnOnce(&HostMetrics) -> R, R>(&self, f: F) -> R {
-        let m = self.metrics.borrow();
+        let m = self.state.metrics.borrow();
         f(&m)
     }
 
     /// Log status information of the host
     pub(crate) fn log_status(&self, verbose: bool) {
-        let m = self.metrics.borrow();
+        let m = self.state.metrics.borrow();
         debug!("[host] connect events: {}", m.connect_events);
         debug!("[host] disconnect events: {}", m.disconnect_events);
         debug!("[host] rx errors: {}", m.rx_errors);
-        self.connections.log_status(verbose);
-        self.channels.log_status(verbose);
+        self.state.connections.log_status(verbose);
+        self.state.channels.log_status(verbose);
     }
 }
 
@@ -1098,17 +1185,17 @@ pub struct Runner<'d, C, P: PacketPool> {
 
 /// The receiver part of the host runner.
 pub struct RxRunner<'d, C, P: PacketPool> {
-    host: &'d BleHost<'d, C, P>,
+    host: BleHost<'d, C, P>,
 }
 
 /// The control part of the host runner.
 pub struct ControlRunner<'d, C, P: PacketPool> {
-    host: &'d BleHost<'d, C, P>,
+    host: BleHost<'d, C, P>,
 }
 
 /// The transmit part of the host runner.
 pub struct TxRunner<'d, C, P: PacketPool> {
-    host: &'d BleHost<'d, C, P>,
+    host: BleHost<'d, C, P>,
 }
 
 /// Event handler.
@@ -1143,7 +1230,7 @@ struct DummyHandler;
 impl EventHandler for DummyHandler {}
 
 impl<'d, C: Controller, P: PacketPool> Runner<'d, C, P> {
-    pub(crate) fn new(host: &'d BleHost<'d, C, P>) -> Self {
+    pub(crate) fn new(host: BleHost<'d, C, P>) -> Self {
         Self {
             rx: RxRunner { host },
             control: ControlRunner { host },
@@ -1273,8 +1360,8 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                         match e {
                             Error::InvalidState | Error::Disconnected => {
                                 warn!("[host] requesting {:?} to be disconnected", acl.handle());
-                                host.connections.log_status(true);
-                                host.connections.request_handle_disconnect(
+                                host.state.connections.log_status(true);
+                                host.state.connections.request_handle_disconnect(
                                     acl.handle(),
                                     DisconnectReason::RemoteUserTerminatedConn,
                                 );
@@ -1282,7 +1369,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                             _ => {}
                         }
 
-                        let mut m = host.metrics.borrow_mut();
+                        let mut m = host.state.metrics.borrow_mut();
                         m.rx_errors = m.rx_errors.wrapping_add(1);
                     }
                 },
@@ -1314,7 +1401,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                                 DisconnectReason::RemoteDeviceTerminatedConnLowResources,
                                             ))
                                             .await;
-                                        host.connect_command_state.canceled();
+                                        host.state.connect_command_state.canceled();
                                     }
                                 }
                                 LeEventKind::LeEnhancedConnectionComplete => {
@@ -1343,16 +1430,16 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                                 DisconnectReason::RemoteDeviceTerminatedConnLowResources,
                                             ))
                                             .await;
-                                        host.connect_command_state.canceled();
+                                        host.state.connect_command_state.canceled();
                                     }
                                 }
                                 LeEventKind::LeScanTimeout => {
                                     #[cfg(feature = "scan")]
-                                    host.scan_timeout.signal(());
+                                    host.state.scan_timeout.signal(());
                                 }
                                 LeEventKind::LeAdvertisingSetTerminated => {
                                     let set = unwrap!(LeAdvertisingSetTerminated::from_hci_bytes_complete(event.data));
-                                    host.advertise_state.terminate(set.adv_handle);
+                                    host.state.advertise_state.terminate(set.adv_handle);
                                 }
                                 LeEventKind::LeExtendedAdvertisingReport => {
                                     #[cfg(feature = "scan")]
@@ -1370,14 +1457,14 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                     }
                                 }
                                 LeEventKind::LeLongTermKeyRequest => {
-                                    host.connections.handle_security_hci_le_event(event)?;
+                                    host.state.connections.handle_security_hci_le_event(event)?;
                                 }
                                 LeEventKind::LePhyUpdateComplete => {
                                     let event = unwrap!(LePhyUpdateComplete::from_hci_bytes_complete(event.data));
                                     if let Err(e) = event.status.to_result() {
                                         warn!("[host] error updating phy for {:?}: {:?}", event.handle, e);
                                     } else {
-                                        let _ = host.connections.post_handle_event(
+                                        let _ = host.state.connections.post_handle_event(
                                             event.handle,
                                             ConnectionEvent::PhyUpdated {
                                                 tx_phy: event.tx_phy,
@@ -1395,7 +1482,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                             event.handle, e
                                         );
                                     } else {
-                                        let _ = host.connections.post_handle_event(
+                                        let _ = host.state.connections.post_handle_event(
                                             event.handle,
                                             ConnectionEvent::ConnectionParamsUpdated {
                                                 conn_interval: Duration::from_micros(event.conn_interval.as_micros()),
@@ -1409,7 +1496,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                 }
                                 LeEventKind::LeDataLengthChange => {
                                     let event = unwrap!(LeDataLengthChange::from_hci_bytes_complete(event.data));
-                                    let _ = host.connections.post_handle_event(
+                                    let _ = host.state.connections.post_handle_event(
                                         event.handle,
                                         ConnectionEvent::DataLengthUpdated {
                                             max_tx_octets: event.max_tx_octets,
@@ -1425,7 +1512,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                     if let Err(e) = event.status.to_result() {
                                         warn!("[host] error updating frame space for {:?}: {:?}", event.handle, e);
                                     } else {
-                                        let _ = host.connections.post_handle_event(
+                                        let _ = host.state.connections.post_handle_event(
                                             event.handle,
                                             ConnectionEvent::FrameSpaceUpdated {
                                                 frame_space: Duration::from_micros(event.frame_space.as_micros()),
@@ -1441,7 +1528,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                     if let Err(e) = event.status.to_result() {
                                         warn!("[host] error in connection rate change for {:?}: {:?}", event.handle, e);
                                     } else {
-                                        let _ = host.connections.post_handle_event(
+                                        let _ = host.state.connections.post_handle_event(
                                             event.handle,
                                             ConnectionEvent::ConnectionRateChanged {
                                                 conn_interval: Duration::from_micros(event.conn_interval.as_micros()),
@@ -1476,6 +1563,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                         false,
                                     );
                                     let _ = host
+                                        .state
                                         .connections
                                         .post_handle_event(event.handle, ConnectionEvent::RequestConnectionParams(req));
                                 }
@@ -1512,9 +1600,9 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                 None
                             }
                             .unwrap_or(Status::UNSPECIFIED);
-                            let _ = host.connections.disconnected(handle, reason);
-                            let _ = host.channels.disconnected(handle);
-                            let mut m = host.metrics.borrow_mut();
+                            let _ = host.state.connections.disconnected(handle, reason);
+                            let _ = host.state.channels.disconnected(handle);
+                            let mut m = host.state.metrics.borrow_mut();
                             m.disconnect_events = m.disconnect_events.wrapping_add(1);
                         }
                         EventKind::NumberOfCompletedPackets => {
@@ -1523,7 +1611,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                             for entry in c.completed_packets.iter() {
                                 match (entry.handle(), entry.num_completed_packets()) {
                                     (Ok(handle), Ok(completed)) => {
-                                        let _ = host.connections.confirm_sent(handle, completed as usize);
+                                        let _ = host.state.connections.confirm_sent(handle, completed as usize);
                                         event_handler.on_packets_completed(completed as usize);
                                     }
                                     (Ok(handle), Err(e)) => {
@@ -1538,7 +1626,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                             event_handler.on_vendor(&vendor);
                         }
                         EventKind::EncryptionChangeV1 | EventKind::EncryptionKeyRefreshComplete => {
-                            host.connections.handle_security_hci_event(event)?;
+                            host.state.connections.handle_security_hci_event(event)?;
                         }
                         // Ignore
                         _ => {}
@@ -1594,30 +1682,32 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
         C::Error: crate::fmt::Format,
     {
         let host = &self.host;
-        Reset::new().exec(&host.controller).await?;
+        Reset::new().exec(host.controller).await?;
 
         #[cfg(feature = "security")]
         {
             let mut seed = [0u8; 32];
             for chunk in seed.chunks_mut(8) {
-                let bytes: [u8; 8] = LeRand::new().exec(&host.controller).await?;
+                let bytes: [u8; 8] = LeRand::new().exec(host.controller).await?;
                 chunk.copy_from_slice(&bytes);
             }
-            host.connections.security_manager.set_random_generator_seed(seed);
+            host.state.connections.security_manager.set_random_generator_seed(seed);
         }
 
         {
-            let addr = host.address.map(|a| a.addr);
+            let addr = host.state.address.map(|a| a.addr);
 
             #[cfg(all(feature = "security", feature = "central"))]
-            let addr = host.connections.security_manager.generate_local_rpa().or(addr);
+            let addr = host.state.connections.security_manager.generate_local_rpa().or(addr);
 
             if let Some(addr) = addr {
-                LeSetRandomAddr::new(addr).exec(&host.controller).await?;
+                LeSetRandomAddr::new(addr).exec(host.controller).await?;
 
                 #[cfg(all(feature = "security", feature = "central"))]
                 if host.is_privacy_enabled() {
-                    host.rpa_expires_at.set(Instant::now() + host.rpa_timeout.get());
+                    host.state
+                        .rpa_expires_at
+                        .set(Instant::now() + host.state.rpa_timeout.get());
                 }
             }
         }
@@ -1632,11 +1722,11 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                 .enable_encryption_change_v1(true)
                 .enable_encryption_key_refresh_complete(true),
         )
-        .exec(&host.controller)
+        .exec(host.controller)
         .await?;
 
         if let Err(e) = SetEventMaskPage2::new(EventMaskPage2::new().enable_encryption_change_v2(true))
-            .exec(&host.controller)
+            .exec(host.controller)
             .await
         {
             match e {
@@ -1663,7 +1753,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
         #[cfg(feature = "connection-params-update")]
         let mask = mask.enable_le_remote_conn_parameter_request(true);
 
-        LeSetEventMask::new(mask).exec(&host.controller).await?;
+        LeSetEventMask::new(mask).exec(host.controller).await?;
 
         info!(
             "[host] using packet pool with MTU {} capacity {}",
@@ -1671,15 +1761,16 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
             P::capacity(),
         );
 
-        let ret = LeReadFilterAcceptListSize::new().exec(&host.controller).await?;
+        let ret = LeReadFilterAcceptListSize::new().exec(host.controller).await?;
         info!("[host] filter accept list size: {}", ret);
 
-        let ret = LeReadBufferSize::new().exec(&host.controller).await?;
+        let ret = LeReadBufferSize::new().exec(host.controller).await?;
         info!(
             "[host] setting txq to {}, fragmenting at {}",
             ret.total_num_le_acl_data_packets as usize, ret.le_acl_data_packet_length as usize
         );
-        host.connections
+        host.state
+            .connections
             .set_link_credits(ret.total_num_le_acl_data_packets as usize);
 
         {
@@ -1689,7 +1780,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                 "[host] configuring host buffers ({} packets of size {})",
                 ACL_N, ACL_LEN,
             );
-            if let Err(_e) = HostBufferSize::new(ACL_LEN, 0, ACL_N, 0).exec(&host.controller).await {
+            if let Err(_e) = HostBufferSize::new(ACL_LEN, 0, ACL_N, 0).exec(host.controller).await {
                 warn!("[host] error configuring host buffers (continuing)");
             }
         }
@@ -1704,7 +1795,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                 }
         */
 
-        let _ = host.initialized.init(InitialState {
+        let _ = host.state.initialized.init(InitialState {
             acl_max: ret.le_acl_data_packet_length as usize,
             acl_total: ret.total_num_le_acl_data_packets as usize,
         });
@@ -1714,18 +1805,21 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
         if *device_address.raw() != [0, 0, 0, 0, 0, 0] {
             let device_address = Address::new(AddrKind::PUBLIC, device_address);
             info!("[host] Device Address {}", device_address);
-            if host.address.is_none() {
+            if host.state.address.is_none() {
                 #[cfg(feature = "security")]
-                host.connections.security_manager.set_local_address(device_address);
+                host.state
+                    .connections
+                    .security_manager
+                    .set_local_address(device_address);
             }
         }
 
         // Set default RPA timeout in controller
         #[cfg(feature = "security")]
         {
-            let timeout_secs = host.rpa_timeout.get().as_secs();
+            let timeout_secs = host.state.rpa_timeout.get().as_secs();
             LeSetResolvablePrivateAddrTimeout::new(bt_hci::param::Duration::from_secs(timeout_secs as u32))
-                .exec(&host.controller)
+                .exec(host.controller)
                 .await?;
             info!("[host] RPA timeout set to {}s", timeout_secs);
         }
@@ -1733,19 +1827,19 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
         // Initialize privacy: sync resolving list
         #[cfg(feature = "security")]
         if host.is_privacy_enabled() {
-            host.resolving_list_state.borrow_mut().clear();
+            host.state.resolving_list_state.borrow_mut().clear();
             host.sync_resolving_list(ResolvingListUpdate::FullSync).await?;
             info!("[host] privacy initialized");
         }
 
         loop {
             match select5(
-                poll_fn(|cx| host.connections.poll_disconnecting(Some(cx))),
-                poll_fn(|cx| host.channels.poll_disconnecting(Some(cx))),
+                poll_fn(|cx| host.state.connections.poll_disconnecting(Some(cx))),
+                poll_fn(|cx| host.state.channels.poll_disconnecting(Some(cx))),
                 poll_fn(|cx| host.poll_cancelled(cx)),
                 #[cfg(feature = "security")]
                 {
-                    host.connections.poll_security_events()
+                    host.state.connections.poll_security_events()
                 },
                 #[cfg(not(feature = "security"))]
                 {
@@ -1795,7 +1889,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                             warn!("[host] error cancelling connection: {:?}", err);
                         }
                         // Signal to ensure no one is stuck
-                        host.connect_command_state.canceled();
+                        host.state.connect_command_state.canceled();
                     }
                     CancelledCommandState::Advertise(ext) => {
                         trace!("[host] disabling advertising");
@@ -1804,7 +1898,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                         } else {
                             host.command(LeSetAdvEnable::new(false)).await?
                         }
-                        host.advertise_command_state.canceled();
+                        host.state.advertise_command_state.canceled();
                     }
                     CancelledCommandState::Scan(ext) => {
                         trace!("[host] disabling scanning");
@@ -1820,7 +1914,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                         } else {
                             host.command(LeSetScanEnable::new(false, false)).await?;
                         }
-                        host.scan_command_state.canceled();
+                        host.state.scan_command_state.canceled();
                     }
                     #[cfg(feature = "security")]
                     CancelledCommandState::SyncResolvingList(update) => {
@@ -1835,7 +1929,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                     #[cfg(feature = "security")]
                     {
                         let event_data = request.unwrap_or(SecurityEventData::Timeout);
-                        host.connections.handle_security_event(host, event_data).await?;
+                        host.state.connections.handle_security_event(host, event_data).await?;
                     }
                 }
                 Either5::Fifth(()) => {
@@ -1853,9 +1947,9 @@ impl<'d, C: Controller, P: PacketPool> TxRunner<'d, C, P> {
     /// Run the transmit loop for the host.
     pub async fn run(&mut self) -> Result<(), BleHostError<C::Error>> {
         let host = &self.host;
-        let params = host.initialized.get().await;
+        let params = host.state.initialized.get().await;
         loop {
-            let (conn, pdu) = host.connections.outbound().await;
+            let (conn, pdu) = host.state.connections.outbound().await;
             match host.l2cap_pdu(conn).await {
                 Ok(mut sender) => match sender.send(pdu.as_ref()).await {
                     Ok(()) => {}

--- a/host/src/iso.rs
+++ b/host/src/iso.rs
@@ -9,11 +9,11 @@ use crate::{BleHostError, PacketPool};
 
 /// A type for running isochronous-stream HCI commands and data.
 pub struct Iso<'stack, C, P: PacketPool> {
-    host: &'stack BleHost<'stack, C, P>,
+    host: BleHost<'stack, C, P>,
 }
 
 impl<'stack, C: Controller, P: PacketPool> Iso<'stack, C, P> {
-    pub(crate) fn new(host: &'stack BleHost<'stack, C, P>) -> Self {
+    pub(crate) fn new(host: BleHost<'stack, C, P>) -> Self {
         Self { host }
     }
 
@@ -38,6 +38,6 @@ impl<'stack, C: Controller, P: PacketPool> Iso<'stack, C, P> {
 
     /// Write a raw HCI ISO data packet to the controller.
     pub async fn send(&self, packet: &IsoPacket<'_>) -> Result<(), C::Error> {
-        self.host.controller.write_iso_data(packet).await
+        self.host.write_iso_data(packet).await
     }
 }

--- a/host/src/l2cap.rs
+++ b/host/src/l2cap.rs
@@ -127,7 +127,11 @@ impl<'d, P: PacketPool> L2capPendingConnection<'d, P> {
         config: &L2capChannelConfig,
     ) -> Result<L2capChannel<'d, P>, BleHostError<T::Error>> {
         let index = self.into_index();
-        stack.host.channels.accept_pending(index, config, stack.host).await
+        stack
+            .host()
+            .channels()
+            .accept_pending(index, config, stack.host())
+            .await
     }
 
     /// Reject the connection with the given result code.
@@ -137,7 +141,11 @@ impl<'d, P: PacketPool> L2capPendingConnection<'d, P> {
         result: LeCreditConnResultCode,
     ) -> Result<(), BleHostError<T::Error>> {
         let index = self.index.take().unwrap();
-        stack.host.channels.reject_pending(index, result, stack.host).await
+        stack
+            .host()
+            .channels()
+            .reject_pending(index, result, stack.host())
+            .await
     }
 }
 
@@ -211,9 +219,9 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
     ) -> Result<(), BleHostError<T::Error>> {
         let mut p_buf = P::allocate().ok_or(Error::OutOfMemory)?;
         stack
-            .host
-            .channels
-            .send(self.index, buf, p_buf.as_mut(), stack.host)
+            .host()
+            .channels()
+            .send(self.index, buf, p_buf.as_mut(), stack.host())
             .await
     }
 
@@ -230,9 +238,9 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
     ) -> Result<(), BleHostError<T::Error>> {
         let mut p_buf = P::allocate().ok_or(Error::OutOfMemory)?;
         stack
-            .host
-            .channels
-            .try_send(self.index, buf, p_buf.as_mut(), stack.host)
+            .host()
+            .channels()
+            .try_send(self.index, buf, p_buf.as_mut(), stack.host())
     }
 
     /// Receive data on this channel and copy it into the buffer.
@@ -243,7 +251,7 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         stack: &Stack<'_, T, P>,
         buf: &mut [u8],
     ) -> Result<usize, BleHostError<T::Error>> {
-        stack.host.channels.receive(self.index, buf, stack.host).await
+        stack.host().channels().receive(self.index, buf, stack.host()).await
     }
 
     /// Receive the next SDU available on this channel.
@@ -253,7 +261,7 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         &mut self,
         stack: &Stack<'_, T, P>,
     ) -> Result<Sdu<P::Packet>, BleHostError<T::Error>> {
-        stack.host.channels.receive_sdu(self.index, stack.host).await
+        stack.host().channels().receive_sdu(self.index, stack.host()).await
     }
 
     /// Read metrics of the l2cap channel.
@@ -274,7 +282,7 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         connection.set_l2cap_listening(true);
         L2capChannelListener {
             conn: connection.clone(),
-            host: stack.host,
+            host: stack.host(),
         }
     }
 
@@ -286,9 +294,9 @@ impl<'d, P: PacketPool> L2capChannel<'d, P> {
         config: &L2capChannelConfig,
     ) -> Result<Self, BleHostError<T::Error>> {
         stack
-            .host
-            .channels
-            .create(connection.handle(), spsm, config, stack.host)
+            .host()
+            .channels()
+            .create(connection.handle(), spsm, config, stack.host())
             .await
     }
 
@@ -349,7 +357,7 @@ impl<'d, P: PacketPool> L2capChannelReader<'d, P> {
         stack: &Stack<'_, T, P>,
         buf: &mut [u8],
     ) -> Result<usize, BleHostError<T::Error>> {
-        stack.host.channels.receive(self.index, buf, stack.host).await
+        stack.host().channels().receive(self.index, buf, stack.host()).await
     }
 
     /// Receive the next SDU available on this channel.
@@ -359,7 +367,7 @@ impl<'d, P: PacketPool> L2capChannelReader<'d, P> {
         &mut self,
         stack: &Stack<'_, T, P>,
     ) -> Result<Sdu<P::Packet>, BleHostError<T::Error>> {
-        stack.host.channels.receive_sdu(self.index, stack.host).await
+        stack.host().channels().receive_sdu(self.index, stack.host()).await
     }
 
     /// Read metrics of the l2cap channel.
@@ -415,9 +423,9 @@ impl<'d, P: PacketPool> L2capChannelWriter<'d, P> {
     ) -> Result<(), BleHostError<T::Error>> {
         let mut p_buf = P::allocate().ok_or(Error::OutOfMemory)?;
         stack
-            .host
-            .channels
-            .send(self.index, buf, p_buf.as_mut(), stack.host)
+            .host()
+            .channels()
+            .send(self.index, buf, p_buf.as_mut(), stack.host())
             .await
     }
 
@@ -434,9 +442,9 @@ impl<'d, P: PacketPool> L2capChannelWriter<'d, P> {
     ) -> Result<(), BleHostError<T::Error>> {
         let mut p_buf = P::allocate().ok_or(Error::OutOfMemory)?;
         stack
-            .host
-            .channels
-            .try_send(self.index, buf, p_buf.as_mut(), stack.host)
+            .host()
+            .channels()
+            .try_send(self.index, buf, p_buf.as_mut(), stack.host())
     }
 
     /// Read metrics of the l2cap channel.
@@ -462,7 +470,7 @@ impl<'d, P: PacketPool> L2capChannelWriter<'d, P> {
 /// yet been returned by [`next`](Self::next) or [`accept`](Self::accept).
 pub struct L2capChannelListener<'d, T: Controller, P: PacketPool> {
     conn: Connection<'d, P>,
-    host: &'d BleHost<'d, T, P>,
+    host: BleHost<'d, T, P>,
 }
 
 impl<'d, T: Controller, P: PacketPool> L2capChannelListener<'d, T, P> {
@@ -471,8 +479,8 @@ impl<'d, T: Controller, P: PacketPool> L2capChannelListener<'d, T, P> {
     /// Returns a [`L2capPendingConnection`] that can be inspected, then accepted or rejected.
     pub async fn next(&self) -> Result<L2capPendingConnection<'d, P>, Error> {
         self.host
-            .channels
-            .next_pending(self.conn.handle(), &self.host.connections)
+            .channels()
+            .next_pending(self.conn.handle(), self.host.connections())
             .await
     }
 
@@ -483,7 +491,7 @@ impl<'d, T: Controller, P: PacketPool> L2capChannelListener<'d, T, P> {
     pub async fn accept(&self, config: &L2capChannelConfig) -> Result<L2capChannel<'d, P>, BleHostError<T::Error>> {
         let pending = self.next().await?;
         let index = pending.into_index();
-        self.host.channels.accept_pending(index, config, self.host).await
+        self.host.channels().accept_pending(index, config, self.host).await
     }
 
     /// Get a reference to the connection this listener is bound to.
@@ -496,7 +504,7 @@ impl<T: Controller, P: PacketPool> Drop for L2capChannelListener<'_, T, P> {
     fn drop(&mut self) {
         self.conn.set_l2cap_listening(false);
         self.host
-            .channels
-            .reject_all_pending(self.conn.handle(), &self.host.connections);
+            .channels()
+            .reject_all_pending(self.conn.handle(), self.host.connections());
     }
 }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -610,14 +610,13 @@ pub trait PacketPool: 'static {
 /// The l2cap packet pool is used by the host to handle inbound data, by allocating space for
 /// incoming packets and dispatching to the appropriate connection and channel.
 pub struct HostResources<
-    C: Controller,
     P: PacketPool,
     const CONNS: usize,
     const CHANNELS: usize,
     const ADV_SETS: usize = 1,
     const BONDS: usize = 10,
 > {
-    host: MaybeUninit<ManuallyDrop<BleHost<'static, C, P>>>,
+    state: MaybeUninit<ManuallyDrop<host::HostState<'static, P>>>,
     connections: MaybeUninit<RefCell<[ConnectionStorage<P::Packet>; CONNS]>>,
     channels: MaybeUninit<RefCell<[ChannelStorage<P::Packet>; CHANNELS]>>,
     advertise_handles: MaybeUninit<RefCell<[AdvHandleState; ADV_SETS]>>,
@@ -625,33 +624,21 @@ pub struct HostResources<
     bond_storage: MaybeUninit<RefCell<Vec<BondInformation, BONDS>>>,
 }
 
-impl<
-        C: Controller,
-        P: PacketPool,
-        const CONNS: usize,
-        const CHANNELS: usize,
-        const ADV_SETS: usize,
-        const BONDS: usize,
-    > Default for HostResources<C, P, CONNS, CHANNELS, ADV_SETS, BONDS>
+impl<P: PacketPool, const CONNS: usize, const CHANNELS: usize, const ADV_SETS: usize, const BONDS: usize> Default
+    for HostResources<P, CONNS, CHANNELS, ADV_SETS, BONDS>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<
-        C: Controller,
-        P: PacketPool,
-        const CONNS: usize,
-        const CHANNELS: usize,
-        const ADV_SETS: usize,
-        const BONDS: usize,
-    > HostResources<C, P, CONNS, CHANNELS, ADV_SETS, BONDS>
+impl<P: PacketPool, const CONNS: usize, const CHANNELS: usize, const ADV_SETS: usize, const BONDS: usize>
+    HostResources<P, CONNS, CHANNELS, ADV_SETS, BONDS>
 {
     /// Create a new instance of host resources.
     pub const fn new() -> Self {
         Self {
-            host: MaybeUninit::uninit(),
+            state: MaybeUninit::uninit(),
             connections: MaybeUninit::uninit(),
             channels: MaybeUninit::uninit(),
             advertise_handles: MaybeUninit::uninit(),
@@ -673,7 +660,7 @@ pub fn new<
     const BONDS: usize,
 >(
     controller: C,
-    resources: &'resources mut HostResources<C, P, CONNS, CHANNELS, ADV_SETS, BONDS>,
+    resources: &'resources mut HostResources<P, CONNS, CHANNELS, ADV_SETS, BONDS>,
 ) -> StackBuilder<'resources, C, P> {
     let connections: &'resources RefCell<[ConnectionStorage<P::Packet>]> = resources
         .connections
@@ -692,30 +679,34 @@ pub fn new<
         resources.bond_storage.write(RefCell::new(Vec::new()));
 
     // SAFETY: Narrows the host field's lifetime from `'static` to `'resources`. Sound because:
-    // - BleHost is covariant in 'd so the types differ only in a lifetime (identical layout).
+    // - HostState is covariant in 'd so the types differ only in a lifetime (identical layout).
     // - The returned StackBuilder/Stack exclusively borrows the HostResources for 'resources,
     //   preventing re-entry into this function while the narrowed-lifetime data is live.
-    // - The host field is private, MaybeUninit (no auto-drop), and only ever accessed by this
+    // - The `state` field is private, MaybeUninit (no auto-drop), and only ever accessed by this
     //   function (which overwrites via write()), so the narrowed lifetime can never be observed
-    //   through the original `'static` type — even if the StackBuilder/Stack is mem::forget'd.
-    let host: &'resources mut MaybeUninit<ManuallyDrop<BleHost<'resources, C, P>>> =
-        unsafe { core::mem::transmute(&mut resources.host) };
+    //   through the original `'static` type — even if the StackBuilder/Stack is forgotten.
+    let host_state: &'resources mut MaybeUninit<ManuallyDrop<host::HostState<'resources, P>>> =
+        unsafe { core::mem::transmute(&mut resources.state) };
 
-    let host: &'resources mut ManuallyDrop<BleHost<'resources, C, P>> = host.write(ManuallyDrop::new(BleHost::new(
-        controller,
-        connections,
-        channels,
-        advertise_handles,
-        #[cfg(feature = "security")]
-        bond_storage,
-    )));
+    let host_state: &'resources mut ManuallyDrop<host::HostState<'resources, P>> =
+        host_state.write(ManuallyDrop::new(host::HostState::new(
+            connections,
+            channels,
+            advertise_handles,
+            #[cfg(feature = "security")]
+            bond_storage,
+        )));
 
-    StackBuilder { host: Some(host) }
+    StackBuilder {
+        host_state: Some(host_state),
+        controller: Some(controller),
+    }
 }
 
 /// Contains the host stack
 pub struct Stack<'stack, C, P: PacketPool> {
-    host: &'stack mut ManuallyDrop<BleHost<'stack, C, P>>,
+    host_state: &'stack mut ManuallyDrop<host::HostState<'stack, P>>,
+    controller: C,
     runner_taken: Cell<bool>,
 }
 
@@ -723,9 +714,9 @@ impl<'stack, C, P: PacketPool> Drop for Stack<'stack, C, P> {
     fn drop(&mut self) {
         // SAFETY: host was fully initialized in new() and has not been dropped.
         // Stack is the sole owner responsible for dropping BleHost.
-        // All shared &BleHost references (in Runner, Central, etc.) have already
+        // All shared &HostState references (in Runner, Central, etc.) have already
         // been dropped (reverse drop order), so no aliasing conflict.
-        unsafe { ManuallyDrop::drop(self.host) }
+        unsafe { ManuallyDrop::drop(self.host_state) }
     }
 }
 
@@ -733,36 +724,40 @@ impl<'stack, C, P: PacketPool> Drop for Stack<'stack, C, P> {
 ///
 /// Call [`build()`](StackBuilder::build) to finalize configuration and obtain the [`Stack`].
 pub struct StackBuilder<'stack, C, P: PacketPool> {
-    host: Option<&'stack mut ManuallyDrop<BleHost<'stack, C, P>>>,
+    pub(crate) host_state: Option<&'stack mut ManuallyDrop<host::HostState<'stack, P>>>,
+    controller: Option<C>,
 }
 
 impl<'stack, C, P: PacketPool> Drop for StackBuilder<'stack, C, P> {
     fn drop(&mut self) {
-        if let Some(host) = &mut self.host {
+        if let Some(host_state) = &mut self.host_state {
             // SAFETY: host was fully initialized in new() and has not been dropped.
             // `build()` was never called, leaving StackBuilder as the sole owner
             // responsible for dropping BleHost.
-            unsafe { ManuallyDrop::drop(host) }
+            unsafe { ManuallyDrop::drop(host_state) }
         }
     }
 }
 
 impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
-    fn host(&mut self) -> &mut BleHost<'stack, C, P> {
-        self.host.as_mut().unwrap()
+    fn host_state(&mut self) -> &mut host::HostState<'stack, P> {
+        self.host_state.as_mut().unwrap()
     }
 
     /// Register an L2CAP SPSM (Simplified Protocol/Service Multiplexer) for accepting incoming connections.
     pub fn register_l2cap_spsm(mut self, spsm: u16) -> Self {
-        self.host().channels.register_spsm(spsm);
+        self.host_state().channels.register_spsm(spsm);
         self
     }
 
     /// Set the random address used by this host.
     pub fn set_random_address(mut self, address: Address) -> Self {
-        self.host().address.replace(address);
+        self.host_state().address.replace(address);
         #[cfg(feature = "security")]
-        self.host().connections.security_manager.set_local_address(address);
+        self.host_state()
+            .connections
+            .security_manager
+            .set_local_address(address);
         self
     }
 
@@ -781,7 +776,7 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
     /// resolving list updates to take effect.
     #[cfg(feature = "security")]
     pub fn enable_privacy(mut self, irk: IdentityResolvingKey) -> Self {
-        self.host().connections.security_manager.set_local_irk(irk);
+        self.host_state().connections.security_manager.set_local_irk(irk);
         self
     }
 
@@ -794,7 +789,7 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
     /// Default is 900 seconds (15 minutes) per the BLE specification.
     #[cfg(feature = "security")]
     pub fn set_rpa_timeout(mut self, timeout: Duration) -> Self {
-        self.host().rpa_timeout.set(timeout);
+        self.host_state().rpa_timeout.set(timeout);
         self
     }
 
@@ -803,7 +798,7 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
     /// Only relevant if the feature `security` is enabled.
     #[cfg(feature = "security")]
     pub fn set_io_capabilities(mut self, io_capabilities: IoCapabilities) -> Self {
-        self.host()
+        self.host_state()
             .connections
             .security_manager
             .set_io_capabilities(io_capabilities);
@@ -818,7 +813,7 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
     /// Only relevant if the feature `legacy-pairing` is enabled.
     #[cfg(feature = "legacy-pairing")]
     pub fn set_secure_connections_only(mut self, enabled: bool) -> Self {
-        self.host()
+        self.host_state()
             .connections
             .security_manager
             .set_secure_connections_only(enabled);
@@ -833,9 +828,16 @@ impl<'stack, C: Controller, P: PacketPool> StackBuilder<'stack, C, P> {
     /// [`Stack::peripheral()`].
     pub fn build(mut self) -> Stack<'stack, C, P> {
         Stack {
-            host: self.host.take().unwrap(),
+            host_state: self.host_state.take().unwrap(),
+            controller: self.controller.take().unwrap(),
             runner_taken: Cell::new(false),
         }
+    }
+}
+
+impl<'stack, C, P: PacketPool> Stack<'stack, C, P> {
+    fn host(&self) -> BleHost<'_, C, P> {
+        BleHost::new(&self.controller, self.host_state)
     }
 }
 
@@ -848,7 +850,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
             !self.runner_taken.replace(true),
             "runner() can only be called once per Stack"
         );
-        Runner::new(self.host)
+        Runner::new(self.host())
     }
 
     /// Obtain a [`Central`](central::Central) handle for the central BLE role.
@@ -857,7 +859,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// Concurrent connect operations are serialized internally.
     #[cfg(feature = "central")]
     pub fn central(&self) -> Central<'_, C, P> {
-        Central::new(self.host)
+        Central::new(self.host())
     }
 
     /// Obtain a [`Peripheral`](peripheral::Peripheral) handle for the peripheral BLE role.
@@ -866,7 +868,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// Concurrent advertise operations are serialized internally.
     #[cfg(feature = "peripheral")]
     pub fn peripheral(&self) -> Peripheral<'_, C, P> {
-        Peripheral::new(self.host)
+        Peripheral::new(self.host())
     }
 
     /// Obtain an [`Iso`](iso::Iso) handle for isochronous-stream (CIS/BIS) HCI commands and data.
@@ -874,7 +876,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// This is a lightweight handle that can be created multiple times.
     #[cfg(feature = "iso")]
     pub fn iso(&self) -> iso::Iso<'_, C, P> {
-        iso::Iso::new(self.host)
+        iso::Iso::new(self.host())
     }
 
     /// Set the IO capabilities used by the security manager.
@@ -882,7 +884,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// Only relevant if the feature `security` is enabled.
     #[cfg(feature = "security")]
     pub fn set_io_capabilities(&self, io_capabilities: IoCapabilities) {
-        self.host
+        self.host_state
             .connections
             .security_manager
             .set_io_capabilities(io_capabilities);
@@ -896,7 +898,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// Only relevant if the feature `legacy-pairing` is enabled.
     #[cfg(feature = "legacy-pairing")]
     pub fn set_secure_connections_only(&self, enabled: bool) {
-        self.host
+        self.host_state
             .connections
             .security_manager
             .set_secure_connections_only(enabled);
@@ -915,9 +917,9 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     where
         C: ControllerCmdSync<LeSetResolvablePrivateAddrTimeout>,
     {
-        self.host.rpa_timeout.set(timeout);
-        if self.host.is_initialized() {
-            self.host
+        self.host().rpa_timeout().set(timeout);
+        if self.host().is_initialized() {
+            self.host()
                 .command(LeSetResolvablePrivateAddrTimeout::new(
                     bt_hci::param::Duration::from_secs(timeout.as_secs() as u32),
                 ))
@@ -932,7 +934,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
         T: SyncCmd,
         C: ControllerCmdSync<T>,
     {
-        self.host.command(cmd).await
+        self.host().command(cmd).await
     }
 
     /// Run an async HCI command where the response will generate an event later.
@@ -941,7 +943,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
         T: AsyncCmd,
         C: ControllerCmdAsync<T>,
     {
-        self.host.async_command(cmd).await
+        self.host().async_command(cmd).await
     }
 
     /// Read the minimum supported connection interval from the controller.
@@ -951,17 +953,19 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     where
         C: ControllerCmdSync<LeReadMinimumSupportedConnectionInterval>,
     {
-        self.host.command(LeReadMinimumSupportedConnectionInterval::new()).await
+        self.host()
+            .command(LeReadMinimumSupportedConnectionInterval::new())
+            .await
     }
 
     /// Read current host metrics
     pub fn metrics<F: FnOnce(&HostMetrics) -> R, R>(&self, f: F) -> R {
-        self.host.metrics(f)
+        self.host().metrics(f)
     }
 
     /// Log status information of the host
     pub fn log_status(&self, verbose: bool) {
-        self.host.log_status(verbose);
+        self.host().log_status(verbose);
     }
 
     #[cfg(feature = "security")]
@@ -970,19 +974,19 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// The returned data should be transferred to the peer device via an out-of-band
     /// channel (NFC, QR code, etc.) before pairing begins.
     pub fn get_local_oob_data(&self) -> OobData {
-        self.host.connections.security_manager.get_local_oob_data()
+        self.host_state.connections.security_manager.get_local_oob_data()
     }
 
     #[cfg(feature = "security")]
     /// Get the local address configured on the security manager.
     pub fn get_local_address(&self) -> Option<Address> {
-        self.host.connections.security_manager.get_local_address()
+        self.host_state.connections.security_manager.get_local_address()
     }
 
     /// Check whether BLE address privacy is enabled.
     #[cfg(feature = "security")]
     pub fn is_privacy_enabled(&self) -> bool {
-        self.host.is_privacy_enabled()
+        self.host().is_privacy_enabled()
     }
 
     #[cfg(feature = "security")]
@@ -995,14 +999,14 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     pub fn add_bond_information(&self, bond_information: BondInformation) -> Result<(), Error> {
         let identity = bond_information.identity;
         let result = self
-            .host
-            .connections
+            .host()
+            .connections()
             .security_manager
             .add_bond_information(bond_information);
         #[cfg(feature = "security")]
         if result.is_ok() {
-            self.host
-                .resolving_list_state
+            self.host()
+                .resolving_list_state()
                 .borrow_mut()
                 .push(crate::host::ResolvingListUpdate::Add(identity));
         }
@@ -1017,11 +1021,15 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// connecting are all idle. Applications should ensure periodic idle windows to allow
     /// resolving list updates to take effect.
     pub fn remove_bond_information(&self, identity: Identity) -> Result<(), Error> {
-        let result = self.host.connections.security_manager.remove_bond_information(identity);
+        let result = self
+            .host()
+            .connections()
+            .security_manager
+            .remove_bond_information(identity);
         #[cfg(feature = "security")]
         if result.is_ok() {
-            self.host
-                .resolving_list_state
+            self.host()
+                .resolving_list_state()
                 .borrow_mut()
                 .push(crate::host::ResolvingListUpdate::Remove(identity));
         }
@@ -1031,22 +1039,22 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     #[cfg(feature = "security")]
     /// Access bonded devices
     pub fn with_bond_information<R>(&self, f: impl FnOnce(&[BondInformation]) -> R) -> R {
-        f(&self.host.connections.security_manager.get_bond_information())
+        f(&self.host_state.connections.security_manager.get_bond_information())
     }
 
     /// Get a connection by its peer address
     pub fn get_connection_by_peer_address(&self, peer_address: Address) -> Option<Connection<'_, P>> {
-        self.host.connections.get_connection_by_peer_address(peer_address)
+        self.host_state.connections.get_connection_by_peer_address(peer_address)
     }
 
     /// Get a connection by its handle
     pub fn get_connected_handle(&self, handle: ConnHandle) -> Option<Connection<'_, P>> {
-        self.host.connections.get_connected_handle(handle)
+        self.host_state.connections.get_connected_handle(handle)
     }
 
     /// Iterate over all currently connected connections.
     pub fn connections(&self) -> connection_manager::ConnectedIter<'_, P> {
-        self.host.connections.connections()
+        self.host_state.connections.connections()
     }
 }
 

--- a/host/src/peripheral.rs
+++ b/host/src/peripheral.rs
@@ -17,11 +17,11 @@ use crate::{bt_hci_duration, bt_hci_ext_duration, Address, BleHostError, Error, 
 
 /// Type which implements the BLE peripheral role.
 pub struct Peripheral<'d, C, P: PacketPool> {
-    host: &'d BleHost<'d, C, P>,
+    host: BleHost<'d, C, P>,
 }
 
 impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
-    pub(crate) fn new(host: &'d BleHost<'d, C, P>) -> Self {
+    pub(crate) fn new(host: BleHost<'d, C, P>) -> Self {
         Self { host }
     }
 
@@ -62,12 +62,12 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
 
         // Ensure no other advertise ongoing.
         let drop = crate::host::OnDrop::new(|| {
-            host.advertise_command_state.cancel(false);
+            host.advertise_command_state().cancel(false);
         });
-        host.request_operation(&host.advertise_command_state, false).await;
+        host.request_operation(host.advertise_command_state(), false).await;
 
         // Clear current advertising terminations
-        host.advertise_state.reset();
+        host.advertise_state().reset();
 
         let data: RawAdvertisement = data.into();
         if !data.props.legacy_adv() {
@@ -120,7 +120,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
         }];
 
         trace!("[host] enabling advertising");
-        host.advertise_state.start(&advset[..]);
+        host.advertise_state().start(&advset[..]);
         host.command(LeSetAdvEnable::new(true)).await?;
         drop.defuse();
         Ok(Advertiser {
@@ -200,19 +200,19 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
         // Check host supports the required advertisement sets
         {
             let result = host.command(LeReadNumberOfSupportedAdvSets::new()).await?;
-            if result < sets.len() as u8 || host.advertise_state.len() < sets.len() {
+            if result < sets.len() as u8 || host.advertise_state().len() < sets.len() {
                 return Err(Error::InsufficientSpace.into());
             }
         }
 
         // Ensure no other advertise ongoing.
         let drop = crate::host::OnDrop::new(|| {
-            host.advertise_command_state.cancel(true);
+            host.advertise_command_state().cancel(true);
         });
-        host.request_operation(&host.advertise_command_state, true).await;
+        host.request_operation(host.advertise_command_state(), true).await;
 
         // Clear current advertising terminations
-        host.advertise_state.reset();
+        host.advertise_state().reset();
 
         for (i, set) in sets.iter().enumerate() {
             let handle = AdvHandle::new(i as u8);
@@ -223,7 +223,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
             let random_addr = if let Some(addr) = set.address {
                 Some(addr)
             } else {
-                host.address.as_ref().map(|a| a.addr)
+                host.address().as_ref().map(|a| a.addr)
             };
 
             host.command(LeSetExtAdvParams::new(
@@ -274,7 +274,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
         }
 
         trace!("[host] enabling extended advertising");
-        host.advertise_state.start(handles);
+        host.advertise_state().start(handles);
         host.command(LeSetExtAdvEnable::new(true, handles)).await?;
         drop.defuse();
         Ok(Advertiser {
@@ -332,7 +332,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
     ///
     /// Accepts the next pending connection if there are any.
     pub fn try_accept(&mut self) -> Option<Connection<'d, P>> {
-        if let Poll::Ready(conn) = self.host.connections.poll_accept(LeConnRole::Peripheral, &[], None) {
+        if let Poll::Ready(conn) = self.host.connections().poll_accept(LeConnRole::Peripheral, &[], None) {
             Some(conn)
         } else {
             None
@@ -342,7 +342,7 @@ impl<'d, C: Controller, P: PacketPool> Peripheral<'d, C, P> {
 
 /// Handle to an active advertiser which can accept connections.
 pub struct Advertiser<'d, C, P: PacketPool> {
-    host: &'d BleHost<'d, C, P>,
+    host: BleHost<'d, C, P>,
     extended: bool,
     done: bool,
 }
@@ -353,8 +353,8 @@ impl<'d, C: Controller, P: PacketPool> Advertiser<'d, C, P> {
     /// Returns Error::Timeout if advertiser stopped.
     pub async fn accept(mut self) -> Result<Connection<'d, P>, Error> {
         let result = match select(
-            self.host.connections.accept(LeConnRole::Peripheral, &[]),
-            self.host.advertise_state.wait(),
+            self.host.connections().accept(LeConnRole::Peripheral, &[]),
+            self.host.advertise_state().wait(),
         )
         .await
         {
@@ -369,9 +369,9 @@ impl<'d, C: Controller, P: PacketPool> Advertiser<'d, C, P> {
 impl<C, P: PacketPool> Drop for Advertiser<'_, C, P> {
     fn drop(&mut self) {
         if !self.done {
-            self.host.advertise_command_state.cancel(self.extended);
+            self.host.advertise_command_state().cancel(self.extended);
         } else {
-            self.host.advertise_command_state.canceled();
+            self.host.advertise_command_state().canceled();
         }
     }
 }

--- a/host/src/scan.rs
+++ b/host/src/scan.rs
@@ -44,11 +44,11 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
             + ControllerCmdSync<LeClearFilterAcceptList>
             + ControllerCmdSync<LeAddDeviceToFilterAcceptList>,
     {
-        let host = &self.central.host;
+        let host = self.central.host;
         let drop = crate::host::OnDrop::new(|| {
-            host.scan_command_state.cancel(true);
+            host.scan_command_state().cancel(true);
         });
-        host.request_operation(&host.scan_command_state, true).await;
+        host.request_operation(host.scan_command_state(), true).await;
         self.central.set_accept_filter(config.filter_accept_list).await?;
 
         let scanning = ScanningPhy {
@@ -69,7 +69,7 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
         ))
         .await?;
 
-        host.scan_timeout.reset();
+        host.scan_timeout().reset();
         host.command(LeSetExtScanEnable::new(
             true,
             config.filter_duplicates,
@@ -79,13 +79,13 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
         .await?;
         drop.defuse();
         Ok(ScanSession {
-            command_state: &self.central.host.scan_command_state,
+            command_state: self.central.host.scan_command_state(),
             deadline: if config.timeout.as_ticks() == 0 {
                 None
             } else {
                 Some(Instant::now() + config.timeout)
             },
-            timeout: &host.scan_timeout,
+            timeout: host.scan_timeout(),
             done: false,
         })
     }
@@ -102,9 +102,9 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
     {
         let host = self.central.host;
         let drop = crate::host::OnDrop::new(|| {
-            host.scan_command_state.cancel(false);
+            host.scan_command_state().cancel(false);
         });
-        host.request_operation(&host.scan_command_state, false).await;
+        host.request_operation(host.scan_command_state(), false).await;
 
         if !config.filter_accept_list.is_empty() {
             self.central.set_accept_filter(config.filter_accept_list).await?;
@@ -131,13 +131,13 @@ impl<'d, 'stack, C: Controller, P: PacketPool> Scanner<'d, 'stack, C, P> {
         host.command(LeSetScanEnable::new(true, filter_duplicates)).await?;
         drop.defuse();
         Ok(ScanSession {
-            command_state: &self.central.host.scan_command_state,
+            command_state: self.central.host.scan_command_state(),
             deadline: if config.timeout.as_ticks() == 0 {
                 None
             } else {
                 Some(Instant::now() + config.timeout)
             },
-            timeout: &host.scan_timeout,
+            timeout: host.scan_timeout(),
             done: false,
         })
     }

--- a/host/tests/gatt.rs
+++ b/host/tests/gatt.rs
@@ -31,7 +31,7 @@ async fn gatt_client_server() {
     let peripheral = local.spawn_local(async move {
         let controller_peripheral = common::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
             .build();
@@ -128,8 +128,7 @@ async fn gatt_client_server() {
     // Spawn central
     let central = local.spawn_local(async move {
         let controller_central = common::create_controller(&central).await;
-        let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
-            HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_central, &mut resources).build();
         let mut runner = stack.runner();
         let mut central = stack.central();

--- a/host/tests/gatt_derive.rs
+++ b/host/tests/gatt_derive.rs
@@ -73,7 +73,7 @@ async fn gatt_client_server() {
     let peripheral = local.spawn_local(async move {
         let controller_peripheral = common::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
             .build();
@@ -161,7 +161,7 @@ async fn gatt_client_server() {
     // Spawn central
     let central = local.spawn_local(async move {
         let controller_central = common::create_controller(&central).await;
-        let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_central, &mut resources).build();
         let mut runner = stack.runner();
         let mut central = stack.central();

--- a/host/tests/l2cap.rs
+++ b/host/tests/l2cap.rs
@@ -25,7 +25,7 @@ async fn l2cap_connection_oriented_channels() {
     let peripheral = local.spawn_local(async move {
         let controller_peripheral = common::create_controller(&peripheral).await;
 
-        let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
         let stack = trouble_host::new(controller_peripheral, &mut resources)
             .set_random_address(peripheral_address)
             .register_l2cap_spsm(0xf2)
@@ -90,8 +90,7 @@ async fn l2cap_connection_oriented_channels() {
     // Spawn central
     let central = local.spawn_local(async move {
         let controller_central = common::create_controller(&central).await;
-        let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
-            HostResources::new();
+        let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
 
         let stack = trouble_host::new(controller_central, &mut resources).build();
         let mut runner = stack.runner();

--- a/tester/app/src/lib.rs
+++ b/tester/app/src/lib.rs
@@ -335,7 +335,7 @@ where
     info!("Pre-server phase complete, building stack and creating server");
 
     // Build the stack, applying deferred GAP settings to the builder
-    let mut resources: HostResources<_, DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
     let mut builder = trouble_host::new(controller, &mut resources).set_random_address(config.address);
 
     if let Some(ref listener_config) = pre.l2cap_listener {


### PR DESCRIPTION
Fixes #645.

This moves the `Controller` out of `HostResources` and into `Stack`. `BleHost` becomes a (`Copy`able) wrapper around references to `HostState` and `Controller`. This removes the controller generic from the `HostResources` struct which allows it to be statically allocated in cases where the concrete controller type is not known (for example when a higher level implementation is generic on the controller type). The drawbacks are:
- `Stack` increases in size by the size of the `Controller` impl.
- All types that held a `BleHost` reference increase in size by one pointer.
- `BleHost` state is now behind a pointer which incurs a pointer dereference when accessing any of the state.