### PR TITLE
Decline identity key distribution when there's no local IRK

### DIFF
--- a/host/src/security_manager/pairing/legacy_peripheral.rs
+++ b/host/src/security_manager/pairing/legacy_peripheral.rs
@@ -423,8 +423,8 @@ impl Pairing {
                 .initiator_key_distribution
                 .set_encryption_key();
         }
-        // Always agree to distribute identity key when the peer requests it
-        if peer_features.responder_key_distribution.identity_key() {
+        // Without a local IRK, decline identity key distribution instead of sending a zero IRK.
+        if peer_features.responder_key_distribution.identity_key() && ops.local_irk() != [0; 16] {
             pairing_data
                 .local_features
                 .responder_key_distribution

--- a/host/src/security_manager/pairing/peripheral.rs
+++ b/host/src/security_manager/pairing/peripheral.rs
@@ -498,9 +498,8 @@ impl Pairing {
                 .set_identity_key();
         }
 
-        // Always agree to distribute identity key when the peer requests it,
-        // even without a local IRK — we'll send a zero IRK with our identity address.
-        if peer_features.responder_key_distribution.identity_key() {
+        // Without a local IRK, decline identity key distribution instead of sending a zero IRK.
+        if peer_features.responder_key_distribution.identity_key() && ops.local_irk() != [0; 16] {
             pairing_data
                 .local_features
                 .responder_key_distribution


### PR DESCRIPTION
Windows refused to bond with a second device using all-0 IRK. This PR fixes it by not setting Identity Key bit without IRK