### PR TITLE
fix(esp32): pass SoftwareInterrupt to esp_rtos::start on Xtensa

### DIFF
--- a/examples/esp32/src/bin/ble_bas_central.rs
+++ b/examples/esp32/src/bin/ble_bas_central.rs
@@ -18,14 +18,9 @@ async fn main(_s: Spawner) {
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_bas_central_multiple.rs
+++ b/examples/esp32/src/bin/ble_bas_central_multiple.rs
@@ -18,14 +18,9 @@ async fn main(_s: Spawner) {
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_bas_central_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_central_sec.rs
@@ -17,14 +17,9 @@ async fn main(_s: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_bas_peripheral.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral.rs
@@ -17,14 +17,9 @@ async fn main(_s: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_bas_peripheral_bonding.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral_bonding.rs
@@ -18,14 +18,9 @@ async fn main(_s: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
+++ b/examples/esp32/src/bin/ble_bas_peripheral_sec.rs
@@ -17,14 +17,9 @@ async fn main(_s: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_l2cap_central.rs
+++ b/examples/esp32/src/bin/ble_l2cap_central.rs
@@ -17,14 +17,9 @@ async fn main(_s: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_l2cap_peripheral.rs
+++ b/examples/esp32/src/bin/ble_l2cap_peripheral.rs
@@ -17,14 +17,9 @@ async fn main(_s: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();

--- a/examples/esp32/src/bin/ble_scanner.rs
+++ b/examples/esp32/src/bin/ble_scanner.rs
@@ -17,14 +17,9 @@ async fn main(_s: Spawner) {
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
     esp_alloc::heap_allocator!(size: 72 * 1024);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(target_arch = "riscv32")]
     let software_interrupt = esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-    esp_rtos::start(
-        timg0.timer0,
-        #[cfg(target_arch = "riscv32")]
-        software_interrupt.software_interrupt0,
-    );
+    esp_rtos::start(timg0.timer0, software_interrupt.software_interrupt0);
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(bluetooth, Default::default()).unwrap();


### PR DESCRIPTION
## Summary

The ESP32 examples currently gate `SoftwareInterrupt` creation and the second argument to `esp_rtos::start()` behind `#[cfg(target_arch = "riscv32")]`:

```rust
esp_rtos::start(
    timg0.timer0,
    #[cfg(target_arch = "riscv32")]
    software_interrupt.software_interrupt0,
);
```

However, with the currently pinned `esp-hal` revision (`b7eec0f`), `esp_rtos::start()` requires the software interrupt argument on **all** architectures. As a result, the second argument is omitted on Xtensa targets (`esp32`, `esp32s3`), causing the examples to fail to compile with:

```text
error[E0061]: this function takes 2 arguments but 1 argument was supplied
```

This issue is not caught by CI because it currently only builds the RISC-V (`esp32c3`) examples.

This PR removes the `riscv32`-only gating across all nine example binaries so that the software interrupt is always created and passed to `esp_rtos::start()`.

## Testing

* ✅ Builds and links successfully for:
  * `esp32` (`xtensa-esp32-none-elf`)
  * `esp32s3` (`xtensa-esp32s3-none-elf`)
  
* ✅ Flashed `ble_bas_peripheral` to real ESP32 hardware:
  * Device advertises correctly
  * Accepts BLE connections
  * Sends GATT notifications successfully
  
* ✅ Verified no regressions on RISC-V:
  * `esp32c3` (`riscv32imc`)
  * `esp32c6` (`riscv32imac`)

## Out of Scope

The `ble_bas_peripheral_bonding --features security` example currently fails to build on both Xtensa and RISC-V for an unrelated reason. The `examples/esp32` crate does not declare `embedded-storage` as a direct dependency (it is only pulled in transitively via `esp-storage`), so the `use embedded_storage::...` import fails and `capacity()` resolves to a private field instead of the `ReadNorFlash` trait method. CI does not catch this because the bonding example requires the `security` feature, which is not built for the ESP32 target. This can be addressed separately by adding `embedded-storage = "0.3.1"` to the example's `Cargo.toml`.

