### PR TITLE
Handle SMP packets received before the connection is accepted

### DIFF
--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -908,7 +908,14 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         {
             for storage in self.connections.borrow().iter() {
                 match storage.state {
-                    ConnectionState::Connected if storage.handle == handle => {
+                    // Also handle SMP while the connection is still `Connecting`.
+                    // A central can send its Pairing Request as soon as the link is
+                    // up, before the peripheral has `accept()`ed the connection; if
+                    // we only match `Connected` here that packet is silently dropped
+                    // and pairing never starts.
+                    ConnectionState::Connected | ConnectionState::Connecting
+                        if storage.handle == handle =>
+                    {
                         if storage.smp_timeout {
                             warn!("Ignoring security channel packet after SMP timeout");
                             return Ok(());

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -913,9 +913,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                     // up, before the peripheral has `accept()`ed the connection; if
                     // we only match `Connected` here that packet is silently dropped
                     // and pairing never starts.
-                    ConnectionState::Connected | ConnectionState::Connecting
-                        if storage.handle == handle =>
-                    {
+                    ConnectionState::Connected | ConnectionState::Connecting if storage.handle == handle => {
                         if storage.smp_timeout {
                             warn!("Ignoring security channel packet after SMP timeout");
                             return Ok(());


### PR DESCRIPTION
A peripheral can fail to pair if the central sends its Pairing Request very early in the connection.

The security channel handler only forwards SMP packets to the security manager for connections in the `Connected` state — that is, after the application has `accept()`ed the connection. But a central often sends its Pairing Request as soon as the link is up, before `accept()` has had a chance to run, while the connection is still `Connecting`. In that window the packet is silently dropped, so the peripheral never sends a Pairing Response and the central eventually times out with an authentication failure.

This is easy to hit with BlueZ as the central (it pairs immediately on connect) and on slower peripherals where `accept()` isn't polled the instant the link comes up.

The fix matches `Connecting` as well as `Connected` in `handle_security_channel`. The handler operates on the connection storage and the live link handle, so it doesn't need the accepted `Connection` object — other state checks in this file already treat `Connecting | Connected` the same way.

Tested on an nRF52840 peripheral with a BlueZ central: before the change the Pairing Request was dropped and `Device1.Pair` timed out; after it, the pairing proceeds and the link reaches an encrypted state.
