### PR TITLE
feat: expose an event-driven host startup readiness wait

### DIFF
--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -48,10 +48,12 @@ use bt_hci::param::{
 };
 use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
 use embassy_futures::select::{select3, select5, Either3, Either5};
+#[cfg(any(feature = "scan", all(feature = "security", feature = "central")))]
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 #[cfg(all(feature = "security", feature = "central"))]
 use embassy_sync::mutex::Mutex;
 use embassy_sync::once_lock::OnceLock;
+#[cfg(feature = "scan")]
 use embassy_sync::signal::Signal;
 use embassy_sync::waitqueue::WakerRegistration;
 use embassy_time::Duration;
@@ -126,7 +128,7 @@ impl ResolvingListSignal {
 
 pub(crate) struct HostState<'d, P: PacketPool> {
     initialized: OnceLock<InitialState>,
-    pub(crate) ready: Signal<NoopRawMutex, ()>,
+    pub(crate) ready: OnceLock<()>,
     metrics: RefCell<HostMetrics>,
     pub(crate) address: Option<Address>,
     pub(crate) connections: ConnectionManager<'d, P>,
@@ -157,7 +159,7 @@ impl<'d, P: PacketPool> HostState<'d, P> {
         Self {
             address: None,
             initialized: OnceLock::new(),
-            ready: Signal::new(),
+            ready: OnceLock::new(),
             metrics: RefCell::new(HostMetrics::default()),
             connections: ConnectionManager::new(
                 connections,
@@ -1832,7 +1834,7 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
             info!("[host] privacy initialized");
         }
 
-        host.state.ready.signal(());
+        let _ = host.state.ready.init(());
         info!("[host] ready");
 
         loop {

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -48,12 +48,12 @@ use bt_hci::param::{
 };
 use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
 use embassy_futures::select::{select3, select5, Either3, Either5};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 #[cfg(any(feature = "scan", all(feature = "security", feature = "central")))]
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 #[cfg(all(feature = "security", feature = "central"))]
 use embassy_sync::mutex::Mutex;
 use embassy_sync::once_lock::OnceLock;
-#[cfg(feature = "scan")]
 use embassy_sync::signal::Signal;
 use embassy_sync::waitqueue::WakerRegistration;
 use embassy_time::Duration;
@@ -128,6 +128,7 @@ impl ResolvingListSignal {
 
 pub(crate) struct HostState<'d, P: PacketPool> {
     initialized: OnceLock<InitialState>,
+    pub(crate) ready: Signal<CriticalSectionRawMutex, ()>,
     metrics: RefCell<HostMetrics>,
     pub(crate) address: Option<Address>,
     pub(crate) connections: ConnectionManager<'d, P>,
@@ -158,6 +159,7 @@ impl<'d, P: PacketPool> HostState<'d, P> {
         Self {
             address: None,
             initialized: OnceLock::new(),
+            ready: Signal::new(),
             metrics: RefCell::new(HostMetrics::default()),
             connections: ConnectionManager::new(
                 connections,
@@ -1831,6 +1833,9 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
             host.sync_resolving_list(ResolvingListUpdate::FullSync).await?;
             info!("[host] privacy initialized");
         }
+
+        host.state.ready.signal(());
+        info!("[host] ready");
 
         loop {
             match select5(

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -48,8 +48,6 @@ use bt_hci::param::{
 };
 use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
 use embassy_futures::select::{select3, select5, Either3, Either5};
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-#[cfg(any(feature = "scan", all(feature = "security", feature = "central")))]
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 #[cfg(all(feature = "security", feature = "central"))]
 use embassy_sync::mutex::Mutex;
@@ -128,7 +126,7 @@ impl ResolvingListSignal {
 
 pub(crate) struct HostState<'d, P: PacketPool> {
     initialized: OnceLock<InitialState>,
-    pub(crate) ready: Signal<CriticalSectionRawMutex, ()>,
+    pub(crate) ready: Signal<NoopRawMutex, ()>,
     metrics: RefCell<HostMetrics>,
     pub(crate) address: Option<Address>,
     pub(crate) connections: ConnectionManager<'d, P>,

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -845,6 +845,9 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// Wait for the host runner to complete controller startup before starting
     /// a role operation such as advertising, scanning, or connecting.
     pub async fn wait_ready(&self) {
+        if self.host_state.ready.signaled() {
+            return;
+        }
         self.host_state.ready.wait().await;
     }
 

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -845,10 +845,7 @@ impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
     /// Wait for the host runner to complete controller startup before starting
     /// a role operation such as advertising, scanning, or connecting.
     pub async fn wait_ready(&self) {
-        if self.host_state.ready.signaled() {
-            return;
-        }
-        self.host_state.ready.wait().await;
+        let _ = self.host_state.ready.get().await;
     }
 
     /// Obtain a [`Runner`] to drive the BLE host.

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -842,6 +842,12 @@ impl<'stack, C, P: PacketPool> Stack<'stack, C, P> {
 }
 
 impl<'stack, C: Controller, P: PacketPool> Stack<'stack, C, P> {
+    /// Wait for the host runner to complete controller startup before starting
+    /// a role operation such as advertising, scanning, or connecting.
+    pub async fn wait_ready(&self) {
+        self.host_state.ready.wait().await;
+    }
+
     /// Obtain a [`Runner`] to drive the BLE host.
     ///
     /// The runner must be polled (e.g. via [`Runner::run()`]) to drive the BLE host.


### PR DESCRIPTION
## Summary

Add `Stack::wait_ready()` so applications can await completion of the `ControlRunner` startup sequence before starting role operations such as advertising, scanning, or connecting.

This avoids application-side timing gates. In particular, it allows an application to run the host runner and a role task concurrently without letting advertising (or other HCI commands) contend with the host's initial command sequence.

The readiness notification is emitted only after controller startup commands, the device-address read, and optional privacy initialization complete.

## Motivation

The host already tracks initialization internally via `HostState::initialized`, a `OnceLock<InitialState>` that is populated partway through `ControlRunner` startup. That lock is crate-private and is intended for internal use (for example, gating `BleHost::command()` and the TX runner), not as an application-facing readiness API.

It is also the wrong synchronization point for role tasks:

- `initialized` is set before the address read and optional privacy setup finish.
- `OnceLock::get().await` blocks until that earlier milestone, not until the host is fully ready for role operations.
- It offers no public, event-driven way for application tasks to coordinate with startup completion.

Without a dedicated readiness API, applications have no reliable way to know when startup is done and have resorted to fixed delays. `Stack::wait_ready()` exposes an explicit, signal-based synchronization point that matches when `ControlRunner` actually finishes startup.

## Example

```rust
let runner = stack.runner();
let mut peripheral = stack.peripheral();

join(
    runner.run(),
    async {
        stack.wait_ready().await;
        peripheral.advertise(&Default::default(), advertisement).await?;
        Ok::<(), BleHostError<_>>(())
    },
)
.await;
```