### PR TITLE
fix(host): make bonding and encrypted links usable against real peers

### DIFF
--- a/examples/esp32/Cargo.lock
+++ b/examples/esp32/Cargo.lock
@@ -2301,6 +2301,7 @@ version = "0.1.0"
 dependencies = [
  "embassy-embedded-hal",
  "embassy-executor",
+ "embedded-storage",
  "esp-alloc",
  "esp-backtrace",
  "esp-bootloader-esp-idf",

--- a/examples/esp32/Cargo.toml
+++ b/examples/esp32/Cargo.toml
@@ -19,6 +19,8 @@ trouble-host = { path = "../../host", features = ["default-packet-pool-mtu-255"]
 # for 'ble_bas_peripheral_bonding'
 embassy-embedded-hal = "0.6.0"
 esp-storage = { version = "0.9.0" }
+# `ble_bas_peripheral_bonding` reaches for the `ReadNorFlash`/`NorFlash` traits directly
+embedded-storage = "0.3.1"
 
 [features]
 default = ["esp32c3"]

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -277,6 +277,18 @@ pub enum ConnectionEvent {
     /// The peer has lost its bond (received pairing request for a bonded peer).
     BondLost,
     #[cfg(feature = "security")]
+    /// The peer tried to resume encryption with a key this device does not have, and was refused.
+    ///
+    /// The mirror of [`ConnectionEvent::BondLost`]: there the bond we hold was rejected, here the
+    /// bond the peer holds is one we cannot honour — after a factory reset, a bond-store wipe, or
+    /// an eviction from a full store.
+    ///
+    /// The link is kept, because re-pairing needs a connection to happen over and a peer that
+    /// notices the refusal will start it. Nothing enforces that, though: a peer that neither
+    /// re-pairs nor disconnects leaves the link up and the slot occupied, so an application that
+    /// cares should apply its own policy — a timeout, a prompt, or [`Connection::disconnect()`].
+    LongTermKeyMissing,
+    #[cfg(feature = "security")]
     /// The link is now encrypted. Fires once per encryption-enable transition,
     /// for both fresh pairings and resumed bonded sessions. For pairings, this
     /// fires alongside `PairingComplete`.

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -943,9 +943,10 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
     ) -> Result<(), crate::BleHostError<C::Error>>
     where
         C: crate::ControllerCmdSync<bt_hci::cmd::le::LeLongTermKeyRequestReply>
+            + crate::ControllerCmdSync<bt_hci::cmd::le::LeLongTermKeyRequestNegativeReply>
             + crate::ControllerCmdAsync<bt_hci::cmd::le::LeEnableEncryption>,
     {
-        use bt_hci::cmd::le::{LeEnableEncryption, LeLongTermKeyRequestReply};
+        use bt_hci::cmd::le::{LeEnableEncryption, LeLongTermKeyRequestNegativeReply, LeLongTermKeyRequestReply};
 
         match _event {
             crate::security_manager::SecurityEventData::SendLongTermKey(handle, ediv, rand) => {
@@ -969,12 +970,27 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                             .command(LeLongTermKeyRequestReply::new(handle, ltk.to_le_bytes()))
                             .await?;
                     } else {
-                        warn!("[host] Long term key request reply failed, no long term key");
-                        // Send disconnect event to the controller
-                        self.request_handle_disconnect(handle, DisconnectReason::AuthenticationFailure);
+                        warn!("[host] Long term key request, no long term key: rejecting");
+                        // Answer the controller so it sends LL_REJECT_IND and the peer's
+                        // encryption procedure fails immediately. Staying silent leaves the
+                        // peer with no way to tell "wrong key" from "slow peer", so it waits
+                        // out a timeout measured in tens of seconds. The link survives the
+                        // rejection — [Vol 6] Part B, 5.1.3.1 lets both Link Layers resume
+                        // unencrypted PDUs afterwards, except for a start that followed an
+                        // Encryption Pause — so a central that learns the key is gone can
+                        // drop the bond and re-pair over the same connection.
+                        if host
+                            .command(LeLongTermKeyRequestNegativeReply::new(handle))
+                            .await
+                            .is_err()
+                        {
+                            warn!("[host] Long term key request negative reply failed");
+                            self.request_handle_disconnect(handle, DisconnectReason::AuthenticationFailure);
+                        }
                     }
                 } else {
-                    warn!("[host] Long term key request reply failed, unknown peer")
+                    warn!("[host] Long term key request, unknown peer: rejecting");
+                    let _ = host.command(LeLongTermKeyRequestNegativeReply::new(handle)).await;
                 }
             }
             crate::security_manager::SecurityEventData::EnableEncryption(handle, bond_info) => {

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -1050,6 +1050,11 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                         {
                             warn!("[host] Long term key request negative reply failed");
                             self.request_handle_disconnect(handle, DisconnectReason::AuthenticationFailure);
+                        } else {
+                            // Tell the application. Keeping the link is a bet that the peer will
+                            // re-pair over it, and only the application can decide what to do if
+                            // it does not.
+                            let _ = self.post_handle_event(handle, ConnectionEvent::LongTermKeyMissing);
                         }
                     }
                 } else {

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -11,6 +11,7 @@ use embassy_sync::channel::Channel;
 use embassy_sync::waitqueue::WakerRegistration;
 #[cfg(feature = "security")]
 use embassy_time::TimeoutError;
+use heapless::Deque;
 
 use crate::connection::{ConnParams, Connection, ConnectionEvent, SecurityLevel};
 use crate::host::EventHandler;
@@ -91,11 +92,20 @@ impl PrepareWriteState {
     }
 }
 
+/// How many links may be waiting to be disconnected without a connection slot behind them.
+///
+/// These only accumulate while every slot is occupied and the controller keeps establishing
+/// links, and each entry is drained by the control runner as soon as it is scheduled.
+const UNTRACKED_DISCONNECT_QUEUE_SIZE: usize = 4;
+
 struct State {
     central_waker: WakerRegistration,
     peripheral_waker: WakerRegistration,
     disconnect_waker: WakerRegistration,
     default_link_credits: usize,
+    /// Links to disconnect that have no connection slot to record the request in — a connection
+    /// the host refused because it had nowhere to put it.
+    untracked_disconnects: Deque<(ConnHandle, DisconnectReason), UNTRACKED_DISCONNECT_QUEUE_SIZE>,
 }
 
 type EventChannel = Channel<NoopRawMutex, ConnectionEvent, { config::CONNECTION_EVENT_QUEUE_SIZE }>;
@@ -120,6 +130,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 peripheral_waker: WakerRegistration::new(),
                 disconnect_waker: WakerRegistration::new(),
                 default_link_credits: 0,
+                untracked_disconnects: Deque::new(),
             }),
             connections,
             outbound: Channel::new(),
@@ -344,13 +355,49 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         }
     }
 
+    /// True while any slot holds this handle in a state other than fully disconnected — including
+    /// the states that mean a teardown is already under way.
+    fn is_handle_tracked(&self, handle: ConnHandle) -> bool {
+        self.connections
+            .borrow()
+            .iter()
+            .any(|storage| storage.handle == handle && storage.state != ConnectionState::Disconnected)
+    }
+
     pub(crate) fn request_handle_disconnect(&self, handle: ConnHandle, reason: DisconnectReason) {
         if let Some(mut entry) = self.connection_by_handle_mut(handle) {
             if entry.state == ConnectionState::Connected && handle == entry.handle {
                 entry.state = ConnectionState::DisconnectRequest(reason);
                 self.state.borrow_mut().disconnect_waker.wake();
             }
+            return;
         }
+        self.request_untracked_disconnect(handle, reason);
+    }
+
+    /// Request a disconnect for a link that has no connection slot behind it.
+    ///
+    /// The state a tracked link uses to carry the request lives in its `ConnectionStorage`, so a
+    /// handle with no entry — a connection the host refused because every slot was taken — has
+    /// nowhere to record it and would otherwise be left up forever, untracked by the host and
+    /// occupying a link in the controller. Queue it separately instead.
+    fn request_untracked_disconnect(&self, handle: ConnHandle, reason: DisconnectReason) {
+        if self.is_handle_tracked(handle) {
+            // A slot holds this handle in a state that already carries a teardown of its own.
+            return;
+        }
+        let mut state = self.state.borrow_mut();
+        if state.untracked_disconnects.iter().any(|(h, _)| *h == handle) {
+            return;
+        }
+        if state.untracked_disconnects.push_back((handle, reason)).is_err() {
+            warn!(
+                "[link] no room to queue a disconnect for untracked handle {:?}, link will stay up",
+                handle
+            );
+            return;
+        }
+        state.disconnect_waker.wake();
     }
 
     pub(crate) fn poll_disconnecting<'m>(
@@ -361,11 +408,28 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
         if let Some(cx) = cx {
             state.disconnect_waker.register(cx.waker());
         }
+        // Links the host never got to track come first: they hold a connection in the controller
+        // that nothing else will ever release.
+        while let Some((handle, reason)) = state.untracked_disconnects.pop_front() {
+            // Controllers reuse handles. If a slot has since taken this one over, the link behind
+            // the queued request is gone and the entry now refers to somebody else's connection —
+            // one that carries its own disconnect state. Dropping it here would take down a
+            // perfectly good link.
+            if self.is_handle_tracked(handle) {
+                continue;
+            }
+            return Poll::Ready(DisconnectRequest {
+                index: None,
+                handle,
+                reason,
+                connections: self.connections,
+            });
+        }
         core::mem::drop(state);
         for (idx, storage) in self.connections.borrow().iter().enumerate() {
             if let ConnectionState::DisconnectRequest(reason) = storage.state {
                 return Poll::Ready(DisconnectRequest {
-                    index: idx,
+                    index: Some(idx),
                     handle: storage.handle,
                     reason,
                     connections: self.connections,
@@ -1121,7 +1185,8 @@ impl<'d, P: PacketPool> Iterator for ConnectedIter<'d, P> {
 }
 
 pub struct DisconnectRequest<'a, P> {
-    index: usize,
+    /// The connection slot carrying this request, or `None` for a link the host never tracked.
+    index: Option<usize>,
     handle: ConnHandle,
     reason: DisconnectReason,
     connections: &'a RefCell<[ConnectionStorage<P>]>,
@@ -1137,8 +1202,12 @@ impl<P> DisconnectRequest<'_, P> {
     }
 
     pub fn confirm(self) {
+        // Nothing to transition for an untracked link: the disconnect command was the whole of it.
+        let Some(index) = self.index else {
+            return;
+        };
         let mut connections = self.connections.borrow_mut();
-        let storage = &mut connections[self.index];
+        let storage = &mut connections[index];
         // Only transition if still in DisconnectRequest. The HCI
         // disconnect_complete handler (`disconnected()`) may race ahead and
         // set state = Disconnected; in that case we must NOT overwrite it
@@ -1832,5 +1901,80 @@ pub(crate) mod tests {
         handle.disconnect();
 
         assert!(!mgr.is_handle_connected(ConnHandle::new(3)));
+    }
+
+    /// Fill every slot, so the next connection cannot be tracked, and check that asking for it to
+    /// be disconnected actually produces a request.
+    ///
+    /// A rejected connection has no `ConnectionStorage` to record the request in, so it used to be
+    /// dropped on the floor: the controller kept a link the host had no idea about, and nothing
+    /// would ever tear it down.
+    #[test]
+    fn untracked_handle_is_disconnected() {
+        let mgr = setup();
+
+        for handle in 0..3 {
+            unwrap!(mgr.connect(
+                ConnHandle::new(handle),
+                Address::new(AddrKind::RANDOM, BdAddr::new(ADDR_1)),
+                LeConnRole::Peripheral,
+                ConnParams::new(),
+            ));
+        }
+
+        assert!(
+            mgr.connect(
+                ConnHandle::new(9),
+                Address::new(AddrKind::RANDOM, BdAddr::new(ADDR_2)),
+                LeConnRole::Peripheral,
+                ConnParams::new(),
+            )
+            .is_err(),
+            "no slot should be left for a fourth connection"
+        );
+
+        mgr.request_handle_disconnect(
+            ConnHandle::new(9),
+            DisconnectReason::RemoteDeviceTerminatedConnLowResources,
+        );
+
+        let Poll::Ready(request) = mgr.poll_disconnecting(None) else {
+            panic!("a refused connection must still be disconnected");
+        };
+        assert_eq!(request.handle(), ConnHandle::new(9));
+        assert_eq!(
+            request.reason(),
+            DisconnectReason::RemoteDeviceTerminatedConnLowResources
+        );
+        request.confirm();
+
+        assert!(
+            mgr.poll_disconnecting(None).is_pending(),
+            "the request must not be repeated once confirmed"
+        );
+    }
+
+    /// Controllers reuse connection handles. A queued disconnect must not take down the link that
+    /// inherited the handle in the meantime.
+    #[test]
+    fn queued_disconnect_yields_to_a_reused_handle() {
+        let mgr = setup();
+
+        mgr.request_handle_disconnect(
+            ConnHandle::new(9),
+            DisconnectReason::RemoteDeviceTerminatedConnLowResources,
+        );
+
+        unwrap!(mgr.connect(
+            ConnHandle::new(9),
+            Address::new(AddrKind::RANDOM, BdAddr::new(ADDR_1)),
+            LeConnRole::Peripheral,
+            ConnParams::new(),
+        ));
+
+        assert!(
+            mgr.poll_disconnecting(None).is_pending(),
+            "a tracked connection must not be disconnected by a stale queued request"
+        );
     }
 }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -532,10 +532,16 @@ impl<'stack, P: PacketPool> ReadEvent<'stack, '_, P> {
         // packet-pool buffer and then post-hoc truncated, which can split an
         // entry in half and produce a malformed PDU.
         let mtu = self.data.connection.get_att_mtu() as usize;
-        let len = payload.len().saturating_sub(offset).min(mtu - 1);
 
         payload.write(rsp)?;
-        payload.append(&data.as_gatt()[offset..][..len])?;
+        // Everything from the blob offset on, bounded by what the peer will accept (the ATT MTU,
+        // less the opcode already written) and by what is left in the buffer. `get` rather than
+        // an index: `offset` comes from the peer, and a ReadBlob past the end of the value must
+        // not panic.
+        let value = data.as_gatt();
+        let value = value.get(offset..).unwrap_or(&[]);
+        let len = value.len().min(mtu.saturating_sub(1)).min(payload.available());
+        payload.append(&value[..len])?;
         header.write(payload.len() as u16)?;
         header.write(4_u16)?;
 
@@ -2237,5 +2243,95 @@ mod tests {
             0,
             "rejected Execute Write must clear the prepare queue",
         );
+    }
+
+    /// Build a Read request PDU (ATT payload only, no L2CAP header).
+    fn build_read_pdu(handle: u16) -> (<DefaultPacketPool as PacketPool>::Packet, usize) {
+        let att = Att::Client(AttClient::Request(AttReq::Read { handle }));
+        let mut packet = DefaultPacketPool::allocate().unwrap();
+        let mut w = WriteCursor::new(packet.as_mut());
+        w.write(att).unwrap();
+        let len = w.len();
+        (packet, len)
+    }
+
+    /// Build a ReadBlob request PDU (ATT payload only, no L2CAP header).
+    fn build_read_blob_pdu(handle: u16, offset: u16) -> (<DefaultPacketPool as PacketPool>::Packet, usize) {
+        let att = Att::Client(AttClient::Request(AttReq::ReadBlob { handle, offset }));
+        let mut packet = DefaultPacketPool::allocate().unwrap();
+        let mut w = WriteCursor::new(packet.as_mut());
+        w.write(att).unwrap();
+        let len = w.len();
+        (packet, len)
+    }
+
+    /// Regression test: `accept_unprocessed` must actually send the value it is given.
+    ///
+    /// It sized the value against `payload.len()`, which is bytes *written* to a cursor that had
+    /// just been split and so was always 0 — making the read response an opcode and nothing else,
+    /// for every input. Observed on air as a peer receiving "0 B of 12 B" for every read.
+    #[test]
+    fn test_accept_unprocessed_returns_the_value() {
+        let _ = env_logger::try_init();
+
+        const MAX_ATTRIBUTES: usize = 32;
+        const CONNECTIONS_MAX: usize = 3;
+        const VALUE: [u8; 12] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+        let mut table: AttributeTable<'_, NoopRawMutex, MAX_ATTRIBUTES> = AttributeTable::new();
+        let handle = {
+            let mut svc = table.add_service(Service {
+                uuid: Uuid::new_short(0x1234),
+            });
+            svc.add_characteristic_ro::<[u8; 12], _>(Uuid::new_short(0x5678), &VALUE)
+                .build()
+                .handle
+        };
+        let server = AttributeServer::<_, DefaultPacketPool, MAX_ATTRIBUTES, CONNECTIONS_MAX>::new(table);
+
+        let mgr = setup();
+        assert!(mgr.poll_accept(LeConnRole::Peripheral, &[], None).is_pending());
+        unwrap!(mgr.connect(
+            ConnHandle::new(0),
+            Address::new(AddrKind::RANDOM, BdAddr::new(ADDR_1)),
+            LeConnRole::Peripheral,
+            ConnParams::new(),
+        ));
+        let Poll::Ready(conn) = mgr.poll_accept(LeConnRole::Peripheral, &[], None) else {
+            panic!("expected connection to be accepted");
+        };
+        conn.set_att_mtu(23);
+
+        // A plain Read returns the whole value after the opcode.
+        let (packet, len) = build_read_pdu(handle);
+        let GattEvent::Read(read) = GattEvent::new(GattData::new(Pdu::new(packet, len), conn.clone()), &server) else {
+            panic!("expected a read event");
+        };
+        let reply = read.accept_unprocessed(&VALUE).unwrap();
+        let att = reply.att_payload().expect("accept_unprocessed must produce a PDU");
+        assert_eq!(att[0], att::ATT_READ_RSP);
+        assert_eq!(&att[1..], &VALUE, "the value must survive the round trip");
+        core::mem::forget(reply);
+
+        // A ReadBlob returns the value from the offset on.
+        let (packet, len) = build_read_blob_pdu(handle, 5);
+        let GattEvent::Read(read) = GattEvent::new(GattData::new(Pdu::new(packet, len), conn.clone()), &server) else {
+            panic!("expected a read event");
+        };
+        let reply = read.accept_unprocessed(&VALUE).unwrap();
+        let att = reply.att_payload().expect("accept_unprocessed must produce a PDU");
+        assert_eq!(att[0], att::ATT_READ_BLOB_RSP);
+        assert_eq!(&att[1..], &VALUE[5..]);
+        core::mem::forget(reply);
+
+        // A ReadBlob past the end of the value is empty, not a panic.
+        let (packet, len) = build_read_blob_pdu(handle, 99);
+        let GattEvent::Read(read) = GattEvent::new(GattData::new(Pdu::new(packet, len), conn.clone()), &server) else {
+            panic!("expected a read event");
+        };
+        let reply = read.accept_unprocessed(&VALUE).unwrap();
+        let att = reply.att_payload().expect("accept_unprocessed must produce a PDU");
+        assert_eq!(att.len(), 1, "an out-of-range blob offset yields just the opcode");
+        core::mem::forget(reply);
     }
 }

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -130,6 +130,12 @@ pub enum GattConnectionEvent<'stack, 'server, P: PacketPool> {
     /// The peer has lost its bond.
     BondLost,
     #[cfg(feature = "security")]
+    /// The peer tried to resume encryption with a key this device does not have, and was refused.
+    ///
+    /// See [`ConnectionEvent::LongTermKeyMissing`]: the link is kept so the peer can re-pair over
+    /// it, and applying a policy if it does not is up to the application.
+    LongTermKeyMissing,
+    #[cfg(feature = "security")]
     /// The link is now encrypted.
     Encrypted {
         /// Security level achieved by the encryption.
@@ -267,6 +273,9 @@ impl<'stack, 'server, P: PacketPool> GattConnection<'stack, 'server, P> {
 
                 #[cfg(feature = "security")]
                 ConnectionEvent::BondLost => GattConnectionEvent::BondLost,
+
+                #[cfg(feature = "security")]
+                ConnectionEvent::LongTermKeyMissing => GattConnectionEvent::LongTermKeyMissing,
 
                 #[cfg(feature = "security")]
                 ConnectionEvent::Encrypted { security_level, bond } => {

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -525,9 +525,11 @@ impl<'stack, P: PacketPool> ReadEvent<'stack, '_, P> {
 
     /// Accept the event without server processing.
     pub fn accept_unprocessed<T: AsGatt + ?Sized>(mut self, data: &T) -> Result<Reply<'stack, P>, Error> {
-        let (rsp, offset) = match self.data.incoming() {
-            AttClient::Request(AttReq::Read { .. }) => (att::ATT_READ_RSP, 0),
-            AttClient::Request(AttReq::ReadBlob { offset, .. }) => (att::ATT_READ_BLOB_RSP, offset as usize),
+        let (req, rsp, handle, offset) = match self.data.incoming() {
+            AttClient::Request(AttReq::Read { handle }) => (att::ATT_READ_REQ, att::ATT_READ_RSP, handle, 0),
+            AttClient::Request(AttReq::ReadBlob { handle, offset }) => {
+                (att::ATT_READ_BLOB_REQ, att::ATT_READ_BLOB_RSP, handle, offset as usize)
+            }
             _ => unreachable!(),
         };
         self.data.pdu = None;
@@ -542,15 +544,25 @@ impl<'stack, P: PacketPool> ReadEvent<'stack, '_, P> {
         // entry in half and produce a malformed PDU.
         let mtu = self.data.connection.get_att_mtu() as usize;
 
-        payload.write(rsp)?;
-        // Everything from the blob offset on, bounded by what the peer will accept (the ATT MTU,
-        // less the opcode already written) and by what is left in the buffer. `get` rather than
-        // an index: `offset` comes from the peer, and a ReadBlob past the end of the value must
-        // not panic.
         let value = data.as_gatt();
-        let value = value.get(offset..).unwrap_or(&[]);
-        let len = value.len().min(mtu.saturating_sub(1)).min(payload.available());
-        payload.append(&value[..len])?;
+        match value.get(offset..) {
+            // Everything from the blob offset on, bounded by what the peer will accept (the ATT
+            // MTU, less the opcode) and by what is left in the buffer.
+            Some(value) => {
+                payload.write(rsp)?;
+                let len = value.len().min(mtu.saturating_sub(1)).min(payload.available());
+                payload.append(&value[..len])?;
+            }
+            // [Vol 3] Part F, 3.4.4.5: an offset past the end of the value is an Invalid Offset
+            // error. An offset *equal* to the length is not — that is the empty Read Blob Response
+            // ending a blob read, and `get` returns an empty slice for it.
+            None => {
+                payload.write(att::ATT_ERROR_RSP)?;
+                payload.write(req)?;
+                payload.write(handle)?;
+                payload.write(att::AttErrorCode::INVALID_OFFSET)?;
+            }
+        }
         header.write(payload.len() as u16)?;
         header.write(4_u16)?;
 
@@ -2333,14 +2345,34 @@ mod tests {
         assert_eq!(&att[1..], &VALUE[5..]);
         core::mem::forget(reply);
 
-        // A ReadBlob past the end of the value is empty, not a panic.
+        // A ReadBlob at exactly the end of the value is the empty response that ends a blob read.
+        let (packet, len) = build_read_blob_pdu(handle, VALUE.len() as u16);
+        let GattEvent::Read(read) = GattEvent::new(GattData::new(Pdu::new(packet, len), conn.clone()), &server) else {
+            panic!("expected a read event");
+        };
+        let reply = read.accept_unprocessed(&VALUE).unwrap();
+        let att = reply.att_payload().expect("accept_unprocessed must produce a PDU");
+        assert_eq!(att, &[att::ATT_READ_BLOB_RSP], "offset == len is an empty response");
+        core::mem::forget(reply);
+
+        // A ReadBlob past the end of the value is an Invalid Offset error, not a panic.
         let (packet, len) = build_read_blob_pdu(handle, 99);
         let GattEvent::Read(read) = GattEvent::new(GattData::new(Pdu::new(packet, len), conn.clone()), &server) else {
             panic!("expected a read event");
         };
         let reply = read.accept_unprocessed(&VALUE).unwrap();
         let att = reply.att_payload().expect("accept_unprocessed must produce a PDU");
-        assert_eq!(att.len(), 1, "an out-of-range blob offset yields just the opcode");
+        assert_eq!(
+            att,
+            &[
+                att::ATT_ERROR_RSP,
+                att::ATT_READ_BLOB_REQ,
+                handle as u8,
+                (handle >> 8) as u8,
+                0x07, // AttErrorCode::INVALID_OFFSET
+            ],
+            "an out-of-range blob offset is an error response",
+        );
         core::mem::forget(reply);
     }
 }

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -48,9 +48,9 @@ use bt_hci::param::{
 };
 use bt_hci::{ControllerToHostPacket, FromHciBytes, WriteHci};
 use embassy_futures::select::{select3, select5, Either3, Either5};
-#[cfg(any(feature = "scan", all(feature = "security", feature = "central")))]
+#[cfg(any(feature = "scan", feature = "security"))]
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
-#[cfg(all(feature = "security", feature = "central"))]
+#[cfg(feature = "security")]
 use embassy_sync::mutex::Mutex;
 use embassy_sync::once_lock::OnceLock;
 #[cfg(feature = "scan")]

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -1457,7 +1457,18 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                     }
                                 }
                                 LeEventKind::LeLongTermKeyRequest => {
-                                    host.state.connections.handle_security_hci_le_event(event)?;
+                                    // A full security event queue is back pressure, not a host
+                                    // fault: the control runner is the only drainer and it may be
+                                    // mid-command. Dropping the request stalls one encryption
+                                    // attempt until the peer times out; propagating it would take
+                                    // every connection down with the runner.
+                                    match host.state.connections.handle_security_hci_le_event(event) {
+                                        Ok(()) => {}
+                                        Err(Error::OutOfMemory) => {
+                                            warn!("[host] security event queue full, dropping long term key request");
+                                        }
+                                        Err(e) => return Err(e.into()),
+                                    }
                                 }
                                 LeEventKind::LePhyUpdateComplete => {
                                     let event = unwrap!(LePhyUpdateComplete::from_hci_bytes_complete(event.data));
@@ -1626,7 +1637,17 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                             event_handler.on_vendor(&vendor);
                         }
                         EventKind::EncryptionChangeV1 | EventKind::EncryptionKeyRefreshComplete => {
-                            host.state.connections.handle_security_hci_event(event)?;
+                            // An encryption event for a handle that is already gone is expected,
+                            // not a host-level fault: nothing orders one against the Disconnection
+                            // Complete for the same link. A MIC failure, which the spec reports as
+                            // a disconnection ([Vol 6] Part B, 5.1.3.1), can still be followed by a
+                            // trailing Encryption Change with nothing left to find. Propagating that
+                            // would tear down the whole runner over a routine condition, and no
+                            // EventHandler hook sits between here and the application.
+                            match host.state.connections.handle_security_hci_event(event) {
+                                Ok(()) | Err(Error::Disconnected) => {}
+                                Err(e) => return Err(e.into()),
+                            }
                         }
                         // Ignore
                         _ => {}

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -1395,12 +1395,15 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                         #[cfg(feature = "security")]
                                         ResolvablePrivateAddrs::none(),
                                     ) {
-                                        let _ = host
-                                            .command(Disconnect::new(
-                                                e.handle,
-                                                DisconnectReason::RemoteDeviceTerminatedConnLowResources,
-                                            ))
-                                            .await;
+                                        // Queue the disconnect for the control runner rather than
+                                        // issuing it here. `Controller::read` is what dispatches
+                                        // `CommandComplete` to a waiting command and this loop is
+                                        // its only caller, so awaiting a command from inside it
+                                        // deadlocks on a completion only it could have read.
+                                        host.state.connections.request_handle_disconnect(
+                                            e.handle,
+                                            DisconnectReason::RemoteDeviceTerminatedConnLowResources,
+                                        );
                                         host.state.connect_command_state.canceled();
                                     }
                                 }
@@ -1424,12 +1427,15 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                             peer: Some(e.peer_resolvable_private_addr).filter(|a| *a.raw() != [0; 6]),
                                         },
                                     ) {
-                                        let _ = host
-                                            .command(Disconnect::new(
-                                                e.handle,
-                                                DisconnectReason::RemoteDeviceTerminatedConnLowResources,
-                                            ))
-                                            .await;
+                                        // Queue the disconnect for the control runner rather than
+                                        // issuing it here. `Controller::read` is what dispatches
+                                        // `CommandComplete` to a waiting command and this loop is
+                                        // its only caller, so awaiting a command from inside it
+                                        // deadlocks on a completion only it could have read.
+                                        host.state.connections.request_handle_disconnect(
+                                            e.handle,
+                                            DisconnectReason::RemoteDeviceTerminatedConnLowResources,
+                                        );
                                         host.state.connect_command_state.canceled();
                                     }
                                 }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -472,6 +472,7 @@ use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
 pub trait SecurityCmds:
     bt_hci::controller::Controller
     + ControllerCmdSync<LeLongTermKeyRequestReply>
+    + ControllerCmdSync<LeLongTermKeyRequestNegativeReply>
     + ControllerCmdAsync<LeEnableEncryption>
     + ControllerCmdSync<LeAddDeviceToResolvingList>
     + ControllerCmdSync<LeRemoveDeviceFromResolvingList>
@@ -487,6 +488,7 @@ pub trait SecurityCmds:
 impl<
         C: bt_hci::controller::Controller
             + ControllerCmdSync<LeLongTermKeyRequestReply>
+            + ControllerCmdSync<LeLongTermKeyRequestNegativeReply>
             + ControllerCmdAsync<LeEnableEncryption>
             + ControllerCmdSync<LeAddDeviceToResolvingList>
             + ControllerCmdSync<LeRemoveDeviceFromResolvingList>

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -176,9 +176,35 @@ impl Address {
     pub fn to_bytes(&self) -> [u8; 7] {
         let mut bytes = [0; 7];
         bytes[0] = self.kind.into_inner();
-        let mut addr_bytes = self.addr.into_inner();
-        addr_bytes.reverse();
-        bytes[1..].copy_from_slice(&addr_bytes);
+        bytes[1..].copy_from_slice(&self.addr_bytes_mso());
+        bytes
+    }
+
+    /// The `AT` byte of `AT || A` as the pairing crypto expects it: 0 for a public address,
+    /// 1 for a random one.
+    ///
+    /// Normalises the HCI identity address types the same way `PartialEq` above does. A
+    /// controller that resolved a peer's RPA reports its kind as 0x02 (Public Identity) or 0x03
+    /// (Random Static Identity), values `AT` has no encoding for; feeding one to f5/f6/c1
+    /// silently corrupts the result.
+    #[cfg(feature = "security")]
+    pub(crate) fn crypto_addr_type(&self) -> u8 {
+        self.kind.into_inner() & 1
+    }
+
+    /// `AT || A` as fed to f5 and f6, with `A` in MSO order.
+    #[cfg(feature = "security")]
+    pub(crate) fn to_crypto_bytes(self) -> [u8; 7] {
+        let mut bytes = [0; 7];
+        bytes[0] = self.crypto_addr_type();
+        bytes[1..].copy_from_slice(&self.addr_bytes_mso());
+        bytes
+    }
+
+    /// The address value in MSO order (reversed from the `BdAddr` raw, little-endian, form).
+    fn addr_bytes_mso(&self) -> [u8; 6] {
+        let mut bytes = self.addr.into_inner();
+        bytes.reverse();
         bytes
     }
 }
@@ -1072,4 +1098,29 @@ pub(crate) fn bt_hci_ext_duration<const US: u16>(d: Duration) -> bt_hci::param::
 #[doc(hidden)]
 pub mod __export {
     pub use embassy_sync;
+}
+
+// The helpers under test are part of the pairing crypto and gated with it.
+#[cfg(all(test, feature = "security"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn address_to_crypto_bytes_normalises_identity_kinds() {
+        let addr = BdAddr::new([1, 2, 3, 4, 5, 6]);
+        // AT||A as fed to f5/f6/c1: the type byte is 0 for public and 1 for random, never the
+        // 0x02/0x03 identity kinds a controller reports after resolving a peer's RPA.
+        for (kind, expected_at) in [
+            (AddrKind::PUBLIC, 0),
+            (AddrKind::RANDOM, 1),
+            (AddrKind::RESOLVABLE_PRIVATE_OR_PUBLIC, 0),
+            (AddrKind::RESOLVABLE_PRIVATE_OR_RANDOM, 1),
+        ] {
+            let address = Address::new(kind, addr);
+            assert_eq!(address.crypto_addr_type(), expected_at);
+            assert_eq!(address.to_crypto_bytes(), [expected_at, 6, 5, 4, 3, 2, 1]);
+            // `to_bytes` stays faithful: it is public API and not part of the crypto path.
+            assert_eq!(address.to_bytes(), [kind.into_inner(), 6, 5, 4, 3, 2, 1]);
+        }
+    }
 }

--- a/host/src/security_manager/crypto.rs
+++ b/host/src/security_manager/crypto.rs
@@ -302,8 +302,8 @@ impl MacKey {
             .update(n2.0.to_be_bytes())
             .update(r.to_be_bytes())
             .update(io_cap.0)
-            .update(a1.to_bytes())
-            .update(a2.to_bytes());
+            .update(a1.to_crypto_bytes())
+            .update(a2.to_crypto_bytes());
         Check(m.finalize())
     }
 }
@@ -553,8 +553,8 @@ impl DHKey {
                 .update(b"btle")
                 .update(n1)
                 .update(n2)
-                .update(a1.to_bytes())
-                .update(a2.to_bytes())
+                .update(a1.to_crypto_bytes())
+                .update(a2.to_crypto_bytes())
                 .update(256_u16.to_be_bytes())
                 .finalize_key()
         };

--- a/host/src/security_manager/pairing/legacy_central.rs
+++ b/host/src/security_manager/pairing/legacy_central.rs
@@ -61,11 +61,10 @@ pub(super) enum Pairing {
 
 /// Get address type flag for c1 (0=public, 1=random)
 fn addr_type_flag(addr: &Address) -> u8 {
-    if addr.kind == AddrKind::PUBLIC {
-        0
-    } else {
-        1
-    }
+    // Not `addr.kind == AddrKind::PUBLIC`: that is `AddrKind`'s exact comparison, so a peer the
+    // controller reports as 0x02 (Public Identity) would be flagged random and corrupt the
+    // confirm value. `Address` normalises the identity kinds, `AddrKind` on its own does not.
+    addr.crypto_addr_type()
 }
 
 /// Get address bytes in MSO order for c1

--- a/host/src/security_manager/pairing/legacy_peripheral.rs
+++ b/host/src/security_manager/pairing/legacy_peripheral.rs
@@ -59,11 +59,10 @@ pub(super) enum Pairing {
 
 /// Get address type flag for c1 (0=public, 1=random)
 fn addr_type_flag(addr: &Address) -> u8 {
-    if addr.kind == AddrKind::PUBLIC {
-        0
-    } else {
-        1
-    }
+    // Not `addr.kind == AddrKind::PUBLIC`: that is `AddrKind`'s exact comparison, so a peer the
+    // controller reports as 0x02 (Public Identity) would be flagged random and corrupt the
+    // confirm value. `Address` normalises the identity kinds, `AddrKind` on its own does not.
+    addr.crypto_addr_type()
 }
 
 /// Get address bytes in MSO order for c1

--- a/tester/app/src/connection.rs
+++ b/tester/app/src/connection.rs
@@ -101,6 +101,9 @@ pub async fn run<'stack, C: crate::Controller, P: PacketPool>(
                     info!("BondLost addr={:?}", address);
                     events.send(Event::BondLost { address }).await;
                 }
+                GattConnectionEvent::LongTermKeyMissing => {
+                    info!("LongTermKeyMissing addr={:?}", address);
+                }
                 GattConnectionEvent::Encrypted { security_level, .. } => {
                     info!("Encrypted addr={:?} level={:?}", address, security_level);
                     events


### PR DESCRIPTION
# Summary

This PR contains fixes for issues found while getting a bonded, encrypted peripheral/central pair working on ESP32 hardware.

Each commit message carries its own reasoning in full — what broke, what it costs in the field, what
was ruled out — so the per-commit detail is there rather than here.

They're presented as a single PR for convenience since they're somewhat related, and three of them
can be dropped without touching the rest:

- **`fix(examples): declare embedded-storage for the esp32 bonding example`** — unrelated to the
  bugs, and touches nothing but `examples/esp32/Cargo.toml` and its lockfile.
- **`feat(security): report a refused long term key request to the application`** — adds public enum
  variants and nothing else.
- **`fix(gatt): reject an out-of-range ReadBlob with Invalid Offset`** — changes an ATT response
  that `fix(gatt): make accept_unprocessed send the value it was given` had merely made safe;
  dropping it leaves that commit correct on its own (empty response, no panic) and rewrites one
  assertion in its test.

Open to splitting them into separate PRs if needed.

## Behaviour and API changes worth flagging

- **`SecurityCmds` gains a `ControllerCmdSync<LeLongTermKeyRequestNegativeReply>` bound.** The
  command is already defined in `bt-hci` and nothing called it; controllers that implement the
  trait generically are unaffected.
- **`ConnectionEvent` and `GattConnectionEvent` gain a `LongTermKeyMissing` variant**, breaking
  exhaustive matches. `tester/app` matches exhaustively and gained a logging arm — deliberately not
  a PTS protocol event, since no test case covers this.
- **A peripheral that cannot satisfy a key request now keeps the link** rather than disconnecting.
  That is the point of the change, but it is a behaviour change: a peer that neither re-pairs nor
  disconnects now holds the slot, which is why the event above exists.
- **An out-of-range `ReadBlob` answered by `accept_unprocessed` now returns an error response**
  rather than an empty one.

## Validation

### On hardware, A/B against `main`

Two ESP32-C3 and two ESP32 (Xtensa) devkits over esp-radio, paired in various peripheral/central
combinations — each commit message names the pair used for its measurement — plus a BlueZ host
(MT7921) as an independent GATT client. Each scenario was run twice: once with this branch, once
with the same application built against `main`.

**Stale bond (`answer an unmatched LTK request with a negative reply`, `report a refused long term
key request`).** Bond the pair, wipe only the peripheral's bond store, reconnect.

|  | branch | main |
| --- | --- | --- |
| **peripheral** | `[host] Long term key request, no long term key: rejecting`<br>`GattConnectionEvent::LongTermKeyMissing`<br>`[gatt] pairing complete: Encrypted` | `[host] Long term key request reply failed, no long term key`<br>`disconnection event, reason: Authentication Failure` |
| **central** | `Encryption event error PIN or Key Missing`<br>`Link encryption with bonded key failed, initiating fresh pairing`<br>`Pairing complete: Encrypted`<br>`Read value: 2` | `Encryption event error Connection Terminated due to MIC Failure`<br>`Link encryption with bonded key failed, initiating fresh pairing`<br>`Disconnected: Authentication Failure` — application aborts |

The branch recovers over the connection it already has, in one round trip. `main` tears the link
down mid-repair, and the peer's controller reports the failure as MIC Failure rather than the
`PIN or Key Missing` that a negative reply produces.

**Refused connection (`don't await an HCI command from inside the rx runner`).** A peripheral with
one connection slot, connected and advertising again, so a second central completes a link the host
cannot track.

|  | branch | main |
| --- | --- | --- |
| **second central** | connected, then disconnected after 25 ms, reason 0x14 | connected, then disconnected after 43 ms, reason 0x14 |
| **peripheral** | `[link][connect] no available slot found for handle ConnHandle(2)`<br>`disconnection event on handle 2`<br>`disconnection event on handle 1`<br>`advertising (slot free)` | `[link][connect] no available slot found for handle ConnHandle(2)`<br>— nothing, ever again |

Both disconnect the refused link, because the HCI command is *written* before the await. Only the
branch survives it: on `main` the rx runner then blocks forever on a `CommandComplete` that only it
could have read, and the host stops — no further events, no advertising, confirmed by a scan that
no longer sees the device. The path is reachable in ordinary peripheral operation, not only in
configurations nothing normally reaches.

**Blob reads (`make accept_unprocessed send the value it was given`, `reject an out-of-range
ReadBlob`).** A 12-byte characteristic answered with `accept_unprocessed`, read from BlueZ:

| request | result |
| --- | --- |
| `read-value 0x0009` | 12 bytes: `01 02 03 04 05 06 07 08 09 0a 0b 0c` |
| `read-long-value 0x0009 5` | 7 bytes: `06 07 08 09 0a 0b 0c` |
| `read-long-value 0x0009 12` | 0 bytes |
| `read-long-value 0x0009 99` | `Read request failed: Invalid Offset (0x07)` |

Before the first of those commits the plain read returned an empty value and the out-of-range blob
panicked the host.

### With an HCI shim, A/B against `main`

The two patterns a controller will not produce on demand were verified with an HCI `Transport` shim
between the real controller and `ExternalController`, altering only the pattern under test. One is
behaviour the specification requires, the other an ordering it leaves open — both made repeatable.

**Identity address type (`normalise the address type byte fed into f5/f6/c1`).** The shim reports the
peer as 0x03 (Random (static) Identity) rather than 0x01 in connection-complete events, as a
controller does once it has resolved a peer, and zeroes the peer RPA. Fresh LE Secure Connections
pairing then fails on `main` with `PairingFailed: DHKeyCheckFailed` on every retry, and succeeds on
the branch.

**Late encryption event (`don't tear down the runner on routine security events`).** The shim, [`test/hil-late-encryption-event`](https://github.com/cdellacqua/trouble/tree/test/hil-late-encryption-event),
re-delivers a copy of the first Encryption Change right after the next Disconnection Complete, so the
handle is gone by the time the host sees it — the specification fixes no order between the two, and a
MIC failure, which it reports as a disconnection, is one way a controller reaches this state. On
`main` the runner returns `BleHost(Disconnected)` and the application's `ble_task` panics; on the
branch the host carries on advertising.
