### PR TITLE
fix(connection): wait for the real LeConnectionUpdateComplete status

### DIFF
--- a/host/src/channel_manager.rs
+++ b/host/src/channel_manager.rs
@@ -722,10 +722,14 @@ impl<'d, P: PacketPool> ChannelManager<'d, P> {
                 }
                 L2capSignalCode::CONN_PARAM_UPDATE_RES => {
                     let res = ConnParamUpdateRes::from_hci_bytes_complete(signal_data)?;
-                    debug!(
-                        "[l2cap][conn = {:?}] connection param update response: {}",
-                        conn, res.result,
-                    );
+                    if res.result == 0 {
+                        debug!("[l2cap][conn = {:?}] connection param update accepted", conn);
+                    } else {
+                        warn!(
+                            "[l2cap][conn = {:?}] connection param update rejected result={}",
+                            conn, res.result
+                        );
+                    }
                     Ok(())
                 }
                 _ => {

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -873,7 +873,22 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
         let features = stack.host().command(LeReadLocalSupportedFeatures::new()).await?;
         if features.supports_conn_parameters_request_procedure() || self.role() == LeConnRole::Central {
             match stack.host().async_command(into_le_conn_update(handle, params)).await {
-                Ok(_) => return Ok(()),
+                Ok(_) => {
+                    // The final outcome is reported later via
+                    // [`LeEventKind::LeConnectionUpdateComplete`], wait for that.
+                    let status = core::future::poll_fn(|cx| self.manager.poll_conn_param_update(handle, cx)).await;
+                    match status.to_result() {
+                        Ok(()) => return Ok(()),
+                        Err(bt_hci::param::Error::UNKNOWN_CONN_IDENTIFIER) => {
+                            return Err(crate::Error::Disconnected.into());
+                        }
+                        Err(bt_hci::param::Error::UNSUPPORTED_REMOTE_FEATURE) => {
+                            // Fall through to the L2CAP fallback below, same as the immediate
+                            // command-status-level rejection arm.
+                        }
+                        Err(e) => return Err(BleHostError::BleHost(crate::Error::Hci(e))),
+                    }
+                }
                 Err(BleHostError::BleHost(crate::Error::Hci(bt_hci::param::Error::UNKNOWN_CONN_IDENTIFIER))) => {
                     return Err(crate::Error::Disconnected.into());
                 }

--- a/host/src/connection_manager.rs
+++ b/host/src/connection_manager.rs
@@ -511,6 +511,7 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
                 storage.link_credits = default_credits;
                 storage.acl_send_locked = false;
                 storage.att_mtu = None;
+                storage.conn_param_update_status = None;
                 storage.handle = handle;
                 #[cfg(feature = "security")]
                 let identity = self
@@ -628,6 +629,36 @@ impl<'d, P: PacketPool> ConnectionManager<'d, P> {
 
     pub(crate) const fn default_att_mtu(&self) -> u16 {
         (P::MTU - 4) as u16
+    }
+
+    pub(crate) fn notify_conn_param_update(&self, handle: ConnHandle, status: Status) {
+        for storage in self.connections.borrow_mut().iter_mut() {
+            match storage.state {
+                ConnectionState::Connecting | ConnectionState::Connected if storage.handle == handle => {
+                    storage.conn_param_update_status = Some(status);
+                    storage.conn_param_update_waker.wake();
+                    return;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    pub(crate) fn poll_conn_param_update(&self, handle: ConnHandle, cx: &mut Context<'_>) -> Poll<Status> {
+        for storage in self.connections.borrow_mut().iter_mut() {
+            match storage.state {
+                ConnectionState::Connecting | ConnectionState::Connected if storage.handle == handle => {
+                    if let Some(status) = storage.conn_param_update_status.take() {
+                        return Poll::Ready(status);
+                    }
+                    storage.conn_param_update_waker.register(cx.waker());
+                    return Poll::Pending;
+                }
+                _ => {}
+            }
+        }
+
+        Poll::Ready(Status::UNKNOWN_CONN_IDENTIFIER)
     }
 
     pub(crate) fn confirm_sent(&self, handle: ConnHandle, packets: usize) -> Result<(), Error> {
@@ -1145,6 +1176,8 @@ pub struct ConnectionStorage<P> {
     pub link_credit_waker: WakerRegistration,
     pub acl_send_locked: bool,
     pub acl_send_lock_waker: WakerRegistration,
+    pub conn_param_update_status: Option<Status>,
+    pub conn_param_update_waker: WakerRegistration,
     pub refcount: u8,
     #[cfg(feature = "connection-metrics")]
     pub metrics: Metrics,
@@ -1265,6 +1298,8 @@ impl<P> ConnectionStorage<P> {
             link_credit_waker: WakerRegistration::new(),
             acl_send_locked: false,
             acl_send_lock_waker: WakerRegistration::new(),
+            conn_param_update_status: None,
+            conn_param_update_waker: WakerRegistration::new(),
             refcount: 0,
             #[cfg(feature = "connection-metrics")]
             metrics: Metrics::new(),

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -1476,6 +1476,7 @@ impl<'d, C: Controller, P: PacketPool> RxRunner<'d, C, P> {
                                 LeEventKind::LeConnectionUpdateComplete => {
                                     let event =
                                         unwrap!(LeConnectionUpdateComplete::from_hci_bytes_complete(event.data));
+                                    host.connections().notify_conn_param_update(event.handle, event.status);
                                     if let Err(e) = event.status.to_result() {
                                         warn!(
                                             "[host] error updating connection parameters for {:?}: {:?}",


### PR DESCRIPTION
Previously, `Connection::update_connection_params()` was not awaiting for the LL procedure's outcome, which in cases where `UNSUPPORTED_REMOTE_FEATURE` was returned, the connection would timeout within 1-17 seconds in practice (* See Testing). This is because `trouble` does not detect the latter and therefore does not perform the L2CAP fallback logic. BlueZ parameters are probably too strict for the peripheral I am using.

With this change, the L2CAP fallback would happen and BlueZ would end up respecting it eliminating `Connection Timeout` incidents.

### Testing

- Peripheral: ESP32-C6 running `esp-hal` a patched variant of version 1.1.0.
- Central: GNU/Linux `6.17.0-124040-tuxedo #40~24.04.1tux1`, BlueZ 5.72, with a MediaTek MT7921/MT922 (`mt7921e`) onboard Bluetooth controller which returns `Unsupported Remote Feature` for the LL procedure.

Caveat: this PR is based on `main` which bumped `bt-hci` to 0.9. Since `esp-hal` doesn't support that version yet, I backported my fix to an older version and validated my changes against that instead. It would be nice if `trouble` and `esp-hal` play nicely to simplify the integration of `bt-hci` updates.