### PR TITLE
Calculate client notification buffer from the packet pool MTU

### DIFF
--- a/host/build.rs
+++ b/host/build.rs
@@ -181,6 +181,21 @@ fn main() {
         writeln!(&mut data, "pub const {}: usize = {};", name, cfg.value).unwrap();
     }
 
+    // A notification holds at most `ATT_MTU - 3` bytes, and `ATT_MTU` here is `PacketPool::MTU - 4`.
+    // When the default-packet-pool-mtu-* is not set, use 512, which is the largest allowed value.
+    let pool = &configs["DEFAULT_PACKET_POOL_MTU"];
+    let notification_mtu = if pool.seen_feature || pool.seen_env {
+        pool.value.saturating_sub(7).min(512)
+    } else {
+        512
+    };
+    writeln!(
+        &mut data,
+        "pub const GATT_CLIENT_NOTIFICATION_MTU: usize = {};",
+        notification_mtu
+    )
+    .unwrap();
+
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let out_file = out_dir.join("config.rs").to_string_lossy().to_string();
     fs::write(out_file, data).unwrap();

--- a/host/src/config.rs
+++ b/host/src/config.rs
@@ -72,6 +72,11 @@ pub const GATT_CLIENT_NOTIFICATION_MAX_SUBSCRIBERS: usize = raw::GATT_CLIENT_NOT
 /// Default: 1.
 pub const GATT_CLIENT_NOTIFICATION_QUEUE_SIZE: usize = raw::GATT_CLIENT_NOTIFICATION_QUEUE_SIZE;
 
+/// Payload capacity of each queued GATT client notification.
+///
+/// Default: `min(PacketPool::MTU - 7, 512)` when `default-packet-pool-mtu-*` is enabled, else 512.
+pub const GATT_CLIENT_NOTIFICATION_MTU: usize = raw::GATT_CLIENT_NOTIFICATION_MTU;
+
 /// Maximum buffer size per connection for client-specific attribute values, such as CCCDs.
 ///
 /// Default: 64.

--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -1018,6 +1018,7 @@ impl<'lst, const MTU: usize> NotificationListener<'lst, MTU> {
 
 const MAX_NOTIF: usize = config::GATT_CLIENT_NOTIFICATION_MAX_SUBSCRIBERS;
 const NOTIF_QSIZE: usize = config::GATT_CLIENT_NOTIFICATION_QUEUE_SIZE;
+const NOTIF_MTU: usize = config::GATT_CLIENT_NOTIFICATION_MTU;
 
 /// BT Core Spec Vol 3, Part F, Section 3.3.3: ATT transaction timeout.
 pub(crate) const ATT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -1030,7 +1031,7 @@ pub struct GattClient<'reference, T: Controller, P: PacketPool, const MAX_SERVIC
     response_channel: Channel<NoopRawMutex, (ConnHandle, Pdu<P::Packet>), 1>,
 
     // TODO: Wait for something like https://github.com/rust-lang/rust/issues/132980 (min_generic_const_args) to allow using P::MTU
-    notifications: PubSubChannel<NoopRawMutex, Notification<512>, NOTIF_QSIZE, MAX_NOTIF, 1>,
+    notifications: PubSubChannel<NoopRawMutex, Notification<NOTIF_MTU>, NOTIF_QSIZE, MAX_NOTIF, 1>,
 }
 
 /// A notification payload.
@@ -1837,7 +1838,7 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
         &self,
         characteristic: &Characteristic<T>,
         indication: bool,
-    ) -> Result<NotificationListener<'_, 512>, BleHostError<C::Error>> {
+    ) -> Result<NotificationListener<'_, NOTIF_MTU>, BleHostError<C::Error>> {
         let properties = u16::to_le_bytes(if indication { 0x02 } else { 0x01 });
 
         // set the CCCD
@@ -1863,7 +1864,7 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
     pub fn listen<T: AsGatt + ?Sized>(
         &self,
         characteristic: &Characteristic<T>,
-    ) -> Result<NotificationListener<'_, 512>, BleHostError<C::Error>> {
+    ) -> Result<NotificationListener<'_, NOTIF_MTU>, BleHostError<C::Error>> {
         match self.notifications.dyn_subscriber() {
             Ok(listener) => Ok(NotificationListener {
                 listener,
@@ -1880,7 +1881,7 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
     ///
     /// Returns a catch-all listener that receives notifications for ALL handles.
     /// Use [`Notification::handle()`] to determine which characteristic the notification is for.
-    pub fn listen_all(&self) -> Result<NotificationListener<'_, 512>, BleHostError<C::Error>> {
+    pub fn listen_all(&self) -> Result<NotificationListener<'_, NOTIF_MTU>, BleHostError<C::Error>> {
         match self.notifications.dyn_subscriber() {
             Ok(listener) => Ok(NotificationListener { listener, handle: None }),
             Err(embassy_sync::pubsub::Error::MaximumSubscribersReached) => {
@@ -1913,8 +1914,8 @@ impl<'reference, C: Controller, P: PacketPool, const MAX_SERVICES: usize> GattCl
 
         let handle = value_handle;
 
-        // TODO: Wait for something like https://github.com/rust-lang/rust/issues/132980 (min_generic_const_args) to allow using P::MTU
-        let mut data = [0u8; 512];
+        // TODO: make it `P::MTU` in the future — see the note on `GattClient::notifications`.
+        let mut data = [0u8; NOTIF_MTU];
         let to_copy = data.len().min(value_attr.len());
         data[..to_copy].copy_from_slice(&value_attr[..to_copy]);
         let n = Notification {


### PR DESCRIPTION
Now the notification buffer size is fixed 512 bytes, which takes lots of RAM. This makes it very hard to use trouble on a chip which doesn't have enough RAM(for example, nRF52820 has only 32KB ram).

The future solution is to use `P::MTU` to calculate the buffer size, but this requires features like `min_generic_const_args`, which I don't think this feature will be stablized any soon. So this PR adds a temporary solution:

1. When the default packet pool is enabled, the notification buffer size is calculated from the default packet pool size
2. When the default packet pool is disabled, the notification buffer size remains 512 bytes