### PR TITLE
feat: nrf52810 examples (peripheral only)

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -39,6 +39,7 @@ cargo batch \
     --- build --release --manifest-path examples/nrf52/Cargo.toml --target thumbv7em-none-eabihf --features nrf52840 \
     --- build --release --manifest-path examples/nrf52/Cargo.toml --target thumbv7em-none-eabihf --features nrf52840,security \
     --- build --release --manifest-path examples/nrf52/Cargo.toml --target thumbv7em-none-eabihf --features nrf52833 \
+    --- build --release --manifest-path examples/nrf52/Cargo.toml --target thumbv7em-none-eabi --no-default-features --features nrf52810 \
     --- build --release --manifest-path examples/nrf52/Cargo.toml --target thumbv7em-none-eabihf --features nrf52832 --artifact-dir examples/tests/bins/nrf52 \
     --- build --release --manifest-path examples/nrf54/Cargo.toml --target thumbv8m.main-none-eabihf --features nrf54l15 \
     --- build --release --manifest-path benchmarks/nrf-sdc/Cargo.toml --target thumbv7em-none-eabihf --features nrf52840 \

--- a/examples/apps/Cargo.toml
+++ b/examples/apps/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-trouble-host = { path = "../../host", features = ["derive", "scan"] }
+trouble-host = { path = "../../host", default-features = false, features = ["derive", "gatt", "peripheral", "default-packet-pool"] }
 bt-hci = "0.10"
 embassy-futures = "0.1.1"
 embassy-sync = { version = "0.8" }
@@ -25,6 +25,13 @@ serde = { version = "1.0.228", default-features = false, features = ["derive"], 
 fixed = "=1.31.0"
 
 [features]
+default = ["central", "scan", "extended-advertising"]
+# Enable the central-role example apps
+central = ["trouble-host/central"]
+# Enable the scanner example app
+scan = ["central", "trouble-host/scan"]
+# Enable the extended-advertising example app
+extended-advertising = ["trouble-host/extended-advertising"]
 defmt = [
     "dep:defmt",
     "trouble-host/defmt",

--- a/examples/apps/src/lib.rs
+++ b/examples/apps/src/lib.rs
@@ -5,30 +5,36 @@ pub(crate) mod common;
 pub(crate) mod fmt;
 
 pub mod ble_advertise;
+#[cfg(feature = "extended-advertising")]
 pub mod ble_advertise_multiple;
+#[cfg(feature = "central")]
 pub mod ble_bas_central;
+#[cfg(feature = "central")]
 pub mod ble_bas_central_multiple;
-#[cfg(feature = "security")]
+#[cfg(all(feature = "security", feature = "central"))]
 pub mod ble_bas_central_sec;
 pub mod ble_bas_peripheral;
 #[cfg(feature = "security")]
 pub mod ble_bas_peripheral_sec;
 pub mod ble_beacon;
 pub mod ble_dis_peripheral;
+#[cfg(feature = "central")]
 pub mod ble_l2cap_central;
 pub mod ble_l2cap_peripheral;
+#[cfg(feature = "scan")]
 pub mod ble_scanner;
+#[cfg(feature = "central")]
 pub mod high_throughput_ble_l2cap_central;
 pub mod high_throughput_ble_l2cap_peripheral;
-#[cfg(feature = "security")]
+#[cfg(all(feature = "security", feature = "central"))]
 pub mod ble_bas_central_auth;
 #[cfg(feature = "security")]
 pub mod ble_bas_peripheral_auth;
-#[cfg(feature = "security")]
+#[cfg(all(feature = "security", feature = "central"))]
 pub mod ble_bas_central_pass_key;
 #[cfg(feature = "security")]
 pub mod ble_bas_peripheral_pass_key;
-#[cfg(feature = "security")]
+#[cfg(all(feature = "security", feature = "central"))]
 pub mod ble_bas_central_bonding;
 #[cfg(feature = "security")]
 pub mod ble_bas_peripheral_bonding;

--- a/examples/nrf52/Cargo.toml
+++ b/examples/nrf52/Cargo.toml
@@ -49,6 +49,16 @@ nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "1a6e661155cd
 nrf-mpsl = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "1a6e661155cdd1d6a86f3ae7b7fb117343781533"}
 
 [features]
+# The nRF52810 only has 24K of RAM, so the default packet pool and L2CAP queues
+# have to be scaled down to leave room for the SoftDevice Controller.
+nrf52810 = [
+    "embassy-nrf/nrf52810",
+    "nrf-sdc/nrf52810",
+    "trouble-host/l2cap-rx-queue-size-4",
+    "trouble-host/l2cap-tx-queue-size-4",
+    "trouble-host/default-packet-pool-mtu-128",
+    "trouble-host/default-packet-pool-size-8",
+]
 nrf52832 = [
     "embassy-nrf/nrf52832",
     "nrf-sdc/nrf52832",

--- a/examples/nrf52/Cargo.toml
+++ b/examples/nrf52/Cargo.toml
@@ -12,11 +12,11 @@ embassy-futures = "0.1.1"
 embassy-sync = { version = "0.8", features = ["defmt"] }
 
 futures = { version = "0.3", default-features = false, features = ["async-await"]}
-nrf-sdc = { version = "0.4", default-features = false, features = ["defmt", "peripheral", "central"] }
+nrf-sdc = { version = "0.4", default-features = false, features = ["defmt", "peripheral"] }
 nrf-mpsl = { version = "0.3", default-features = false, features = ["defmt", "critical-section-impl"] }
 bt-hci = { version = "0.10", default-features = false, features = ["defmt"] }
-trouble-host = { path = "../../host", features = ["derive", "scan", "gatt"] }
-trouble-example-apps = { version = "0.1.0", path = "../apps", features = ["defmt"] }
+trouble-host = { path = "../../host", default-features = false, features = ["derive", "gatt", "peripheral", "default-packet-pool"] }
+trouble-example-apps = { version = "0.1.0", path = "../apps", default-features = false, features = ["defmt"] }
 
 defmt = "1.0"
 defmt-rtt = "1.0"
@@ -49,6 +49,22 @@ nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "1a6e661155cd
 nrf-mpsl = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "1a6e661155cdd1d6a86f3ae7b7fb117343781533"}
 
 [features]
+default = ["central", "scan", "extended-advertising"]
+# Enable the central role. Building without it links the smaller peripheral-only
+# SoftDevice Controller library, which matters on flash-constrained parts.
+central = [
+    "nrf-sdc/central",
+    "trouble-host/central",
+    "trouble-example-apps/central",
+]
+scan = [
+    "trouble-host/scan",
+    "trouble-example-apps/scan",
+]
+extended-advertising = [
+    "trouble-host/extended-advertising",
+    "trouble-example-apps/extended-advertising",
+]
 # The nRF52810 only has 24K of RAM, so the default packet pool and L2CAP queues
 # have to be scaled down to leave room for the SoftDevice Controller.
 nrf52810 = [
@@ -76,8 +92,24 @@ security = [
 ]
 
 [[bin]]
+name = "ble_advertise_multiple"
+required-features = ["extended-advertising"]
+
+[[bin]]
+name = "ble_bas_central"
+required-features = ["central"]
+
+[[bin]]
+name = "ble_l2cap_central"
+required-features = ["central"]
+
+[[bin]]
+name = "ble_scanner"
+required-features = ["scan"]
+
+[[bin]]
 name = "ble_bas_central_sec"
-required-features = ["security"]
+required-features = ["security", "central"]
 
 [[bin]]
 name = "ble_bas_peripheral_sec"
@@ -89,7 +121,7 @@ required-features = ["security"]
 
 [[bin]]
 name = "ble_bas_central_auth"
-required-features = ["security"]
+required-features = ["security", "central"]
 
 [[bin]]
 name = "ble_bas_peripheral_pass_key"
@@ -97,11 +129,11 @@ required-features = ["security"]
 
 [[bin]]
 name = "ble_bas_central_pass_key"
-required-features = ["security"]
+required-features = ["security", "central"]
 
 [[bin]]
 name = "ble_bas_central_bonding"
-required-features = ["security", "nrf52840"]
+required-features = ["security", "nrf52840", "central"]
 
 [[bin]]
 name = "ble_bas_peripheral_bonding"

--- a/examples/nrf52/README.md
+++ b/examples/nrf52/README.md
@@ -53,4 +53,7 @@ flash, this matters on the nRF52810 which has only 192K flash.
 cargo build --release --no-default-features --features nrf52810 --target thumbv7em-none-eabi --bin ble_bas_peripheral
 ```
 
+This is required for the GATT examples on the nRF52810: with the default features they overflow
+flash by a few KB.
+
 See [microbit-bsp](https://github.com/lulf/microbit-bsp) for more examples of setting up nrf devices with trouble, specifically the BBC Microbit which is an nrf52833.

--- a/examples/nrf52/README.md
+++ b/examples/nrf52/README.md
@@ -28,6 +28,7 @@ brew install llvm
 
 We use features to turn on the appropriate configurations for the chip you are flashing to.  Currently supported chips are:
 
+- `nrf52810`
 - `nrf52832`
 - `nrf52833`
 - `nrf52840`

--- a/examples/nrf52/README.md
+++ b/examples/nrf52/README.md
@@ -43,4 +43,14 @@ cd examples/nrf52 # make sure you are in the right directory
 cargo run --release --features nrf52833 --target thumbv7em-none-eabihf --bin ble_bas_peripheral
 ```
 
+## Peripheral-only builds
+
+The `central`, `scan` and `extended-advertising` features are enabled by default. Turning them
+off links the smaller peripheral-only SoftDevice Controller library, which saves around 32K of
+flash, this matters on the nRF52810 which has only 192K flash.
+
+```bash
+cargo build --release --no-default-features --features nrf52810 --target thumbv7em-none-eabi --bin ble_bas_peripheral
+```
+
 See [microbit-bsp](https://github.com/lulf/microbit-bsp) for more examples of setting up nrf devices with trouble, specifically the BBC Microbit which is an nrf52833.

--- a/examples/nrf52/build.rs
+++ b/examples/nrf52/build.rs
@@ -14,13 +14,20 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn linker_data() -> &'static [u8] {
+    #[cfg(feature = "nrf52810")]
+    return include_bytes!("memory-nrf52810.x");
     #[cfg(feature = "nrf52832")]
     return include_bytes!("memory-nrf52832.x");
     #[cfg(feature = "nrf52833")]
     return include_bytes!("memory-nrf52833.x");
     #[cfg(feature = "nrf52840")]
     return include_bytes!("memory-nrf52840.x");
-    #[cfg(not(any(feature = "nrf52832", feature = "nrf52833", feature = "nrf52840")))]
+    #[cfg(not(any(
+        feature = "nrf52810",
+        feature = "nrf52832",
+        feature = "nrf52833",
+        feature = "nrf52840"
+    )))]
     unimplemented!("must select a target")
 }
 

--- a/examples/nrf52/build.rs
+++ b/examples/nrf52/build.rs
@@ -32,6 +32,14 @@ fn linker_data() -> &'static [u8] {
 }
 
 fn main() {
+    // The multirole SoftDevice Controller leaves too little of the nRF52810's 192K of flash
+    // for the GATT examples to link. Building without the default features selects the
+    // peripheral-only library instead.
+    #[cfg(all(feature = "nrf52810", feature = "central"))]
+    println!(
+        "cargo::warning=nRF52810 with the central role enabled: the GATT examples will not fit in flash, build with --no-default-features"
+    );
+
     // Put `memory.x` in our output directory and ensure it's
     // on the linker search path.
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/examples/nrf52/memory-nrf52810.x
+++ b/examples/nrf52/memory-nrf52810.x
@@ -1,0 +1,10 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  FLASH   : ORIGIN = 0x00000000, LENGTH = 192K - 8K
+  STORAGE : ORIGIN = 0x0002E000, LENGTH = 8K
+  RAM     : ORIGIN = 0x20000000, LENGTH = 24K
+}
+
+__storage_start = ORIGIN(STORAGE);
+__storage_end = ORIGIN(STORAGE) + LENGTH(STORAGE);


### PR DESCRIPTION
As discussed in https://github.com/embassy-rs/trouble/pull/637, this adds support for building the examples for the nRF52810. Only the peripheral examples fit inside flash and RAM. This still makes the IC interesting for low-budget peripheral applications.

I think this is helpful for users who want to get started with the nRF52810.