### PR TITLE
feat(host): set host support flags for ISO and SCI based on crate feature flags

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -111,6 +111,9 @@ connection-params-update = []
 # Enable Connection Subrating host support.
 subrating = []
 
+# Enable Shorter Connection Intervals
+shorter-connection-intervals = []
+
 # Allow L2CAP SPSU values that are reserved for future use
 allow-reserved-l2cap-psu = []
 

--- a/host/src/host.rs
+++ b/host/src/host.rs
@@ -15,6 +15,8 @@ use bt_hci::cmd::controller_baseband::{
 use bt_hci::cmd::info::ReadBdAddr;
 #[cfg(feature = "subrating")]
 use bt_hci::cmd::le::LeSetHostFeature;
+#[cfg(feature = "shorter-connection-intervals")]
+use bt_hci::cmd::le::LeSetHostFeatureV2;
 #[cfg(feature = "security")]
 use bt_hci::cmd::le::{
     LeAddDeviceToResolvingList, LeClearResolvingList, LeRand, LeRemoveDeviceFromResolvingList,
@@ -1277,7 +1279,9 @@ impl<'d, C: Controller, P: PacketPool> Runner<'d, C, P> {
             + ControllerCmdSync<LeReadBufferSize>
             + ControllerCmdSync<ReadBdAddr>
             + crate::SecurityCmds
-            + crate::SubratingCmds,
+            + crate::IsoStreamCmds
+            + crate::SubratingCmds
+            + crate::ShortConnIntervalCmds,
         C::Error: crate::fmt::Format,
     {
         let dummy = DummyHandler;
@@ -1306,7 +1310,9 @@ impl<'d, C: Controller, P: PacketPool> Runner<'d, C, P> {
             + ControllerCmdSync<LeReadBufferSize>
             + ControllerCmdSync<ReadBdAddr>
             + crate::SecurityCmds
-            + crate::SubratingCmds,
+            + crate::IsoStreamCmds
+            + crate::SubratingCmds
+            + crate::ShortConnIntervalCmds,
         C::Error: crate::fmt::Format,
     {
         let control_fut = self.control.run();
@@ -1714,7 +1720,9 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
             + ControllerCmdSync<LeReadBufferSize>
             + ControllerCmdSync<ReadBdAddr>
             + crate::SecurityCmds
-            + crate::SubratingCmds,
+            + crate::IsoStreamCmds
+            + crate::SubratingCmds
+            + crate::ShortConnIntervalCmds,
         C::Error: crate::fmt::Format,
     {
         let host = &self.host;
@@ -1792,7 +1800,28 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
         #[cfg(feature = "connection-params-update")]
         let mask = mask.enable_le_remote_conn_parameter_request(true);
 
+        #[cfg(feature = "shorter-connection-intervals")]
+        let mask = mask.enable_le_connection_rate_change(true);
+
         LeSetEventMask::new(mask).exec(host.controller).await?;
+
+        // Without the Connection Isochronous Stream (Host Support) bit set, a peer central is not allowed to
+        // create or accept a CIS.
+        #[cfg(feature = "iso")]
+        {
+            const LE_FEATURE_CIS_HOST: u8 = 32;
+            if let Err(e) = LeSetHostFeature::new(LE_FEATURE_CIS_HOST, 1)
+                .exec(host.controller)
+                .await
+            {
+                match e {
+                    cmd::Error::Hci(bt_hci::param::Error::UNSUPPORTED | bt_hci::param::Error::UNKNOWN_CMD) => {
+                        warn!("[host] connection isochronous streams are not supported")
+                    }
+                    e => Err(e)?,
+                }
+            }
+        }
 
         // Without the Connection Subrating (Host Support) bit set, a peer central is not allowed to
         // start the Connection Subrate Update procedure on us.
@@ -1806,6 +1835,24 @@ impl<'d, C: Controller, P: PacketPool> ControlRunner<'d, C, P> {
                 match e {
                     cmd::Error::Hci(bt_hci::param::Error::UNSUPPORTED | bt_hci::param::Error::UNKNOWN_CMD) => {
                         warn!("[host] connection subrating is not supported")
+                    }
+                    e => Err(e)?,
+                }
+            }
+        }
+
+        // Without the Shorter Connection Intervals (Host Support) bit set, a peer central is not allowed to
+        // start the Connection Rate Change procedure on us.
+        #[cfg(feature = "shorter-connection-intervals")]
+        {
+            const LE_FEATURE_SHORTER_CONNECTION_INTERVALS_HOST: u16 = 73;
+            if let Err(e) = LeSetHostFeatureV2::new(LE_FEATURE_SHORTER_CONNECTION_INTERVALS_HOST, 1)
+                .exec(host.controller)
+                .await
+            {
+                match e {
+                    cmd::Error::Hci(bt_hci::param::Error::UNSUPPORTED | bt_hci::param::Error::UNKNOWN_CMD) => {
+                        warn!("[host] shorter connection intervals are not supported")
                     }
                     e => Err(e)?,
                 }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -10,6 +10,8 @@ use core::mem::{ManuallyDrop, MaybeUninit};
 
 use advertise::AdvertisementDataError;
 use bt_hci::cmd::le::LeReadMinimumSupportedConnectionInterval;
+#[cfg(feature = "shorter-connection-intervals")]
+use bt_hci::cmd::le::LeSetHostFeatureV2;
 use bt_hci::cmd::status::ReadRssi;
 use bt_hci::cmd::{AsyncCmd, SyncCmd};
 use bt_hci::param::{AddrKind, BdAddr, ConnHandle};
@@ -505,6 +507,20 @@ pub trait SecurityCmds: bt_hci::controller::Controller {}
 #[cfg(not(feature = "security"))]
 impl<C: bt_hci::controller::Controller> SecurityCmds for C {}
 
+/// Auto-implemented when the `iso` feature is enabled.
+#[cfg(feature = "iso")]
+pub trait IsoStreamCmds: bt_hci::controller::Controller + ControllerCmdSync<LeSetHostFeature> {}
+
+#[cfg(feature = "iso")]
+impl<C: bt_hci::controller::Controller + ControllerCmdSync<LeSetHostFeature>> IsoStreamCmds for C {}
+
+/// Auto-implemented when `iso` is not enabled.
+#[cfg(not(feature = "iso"))]
+pub trait IsoStreamCmds: bt_hci::controller::Controller {}
+
+#[cfg(not(feature = "iso"))]
+impl<C: bt_hci::controller::Controller> IsoStreamCmds for C {}
+
 /// Auto-implemented when the `subrating` feature is enabled.
 #[cfg(feature = "subrating")]
 pub trait SubratingCmds: bt_hci::controller::Controller + ControllerCmdSync<LeSetHostFeature> {}
@@ -518,6 +534,20 @@ pub trait SubratingCmds: bt_hci::controller::Controller {}
 
 #[cfg(not(feature = "subrating"))]
 impl<C: bt_hci::controller::Controller> SubratingCmds for C {}
+
+/// Auto-implemented when `shorter-connection-intervals` isenabled.
+#[cfg(feature = "shorter-connection-intervals")]
+pub trait ShortConnIntervalCmds: bt_hci::controller::Controller + ControllerCmdSync<LeSetHostFeatureV2> {}
+
+#[cfg(feature = "shorter-connection-intervals")]
+impl<C: bt_hci::controller::Controller + ControllerCmdSync<LeSetHostFeatureV2>> ShortConnIntervalCmds for C {}
+
+/// Auto-implemented when `shorter-connection-intervals` is not enabled.
+#[cfg(not(feature = "shorter-connection-intervals"))]
+pub trait ShortConnIntervalCmds: bt_hci::controller::Controller {}
+
+#[cfg(not(feature = "shorter-connection-intervals"))]
+impl<C: bt_hci::controller::Controller> ShortConnIntervalCmds for C {}
 
 /// Trait that defines the controller implementation required by the host.
 ///
@@ -554,6 +584,8 @@ pub trait Controller:
     + ControllerCmdSync<ReadBdAddr>
     + SecurityCmds
     + SubratingCmds
+    + IsoStreamCmds
+    + ShortConnIntervalCmds
 {
 }
 
@@ -588,7 +620,9 @@ impl<
             + for<'t> ControllerCmdSync<LeSetScanResponseData>
             + ControllerCmdSync<ReadBdAddr>
             + SecurityCmds
-            + SubratingCmds,
+            + SubratingCmds
+            + IsoStreamCmds
+            + ShortConnIntervalCmds,
     > Controller for C
 {
 }


### PR DESCRIPTION
This PR adds host feature support flags for Connected Isochronous Streams (ISO, bit 32) and Shorter Connection Intervals (SCI, bit 73 via LeSetHostFeatureV2), gated behind feature flags alongside subrating.

It introduces blanked traits (IsoStreamCmds, ShortConnIntervalCmds) to gate trait bounds depending on the feature flags.

I noticed that the functions Runner::run, Runner::run_with_handler, ControlRunner::run all have a long where clause and could use trouble::Controller instead. Is that on purpose or could it be refactored to make the code more readable?