### PR TITLE
feat(examples): add ble_sci_central and ble_sci_peripheral

### DIFF
--- a/examples/apps/Cargo.toml
+++ b/examples/apps/Cargo.toml
@@ -50,3 +50,4 @@ security = [
     "dep:serde"
 ]
 std = []
+shorter-connection-intervals = ["trouble-host/shorter-connection-intervals"]

--- a/examples/apps/src/ble_sci_central.rs
+++ b/examples/apps/src/ble_sci_central.rs
@@ -1,0 +1,181 @@
+//! BLE Shorter Connection Intervals (SCI) — Central role.
+//!
+//! Demonstrates the LE Connection Rate Request procedure, which allows
+//! negotiating sub-millisecond connection intervals (as short as 875 µs)
+//! on controllers that support the Shorter Connection Intervals feature.
+//!
+//! Unlike a subrate change (which takes only a few base connection events),
+//! a connection rate change follows the same Link Layer scheduling rules as
+//! a standard connection parameter update: the controller must wait at least
+//! 6 * (1 + peripheral_latency) connection events before it is allowed to
+//! apply the new parameters. In practice many controllers choose the first
+//! suitable anchor point after that minimum, which can add further latency.
+//!
+//! Run alongside `ble_sci_peripheral` to observe the full negotiation.
+//!
+//! # Steps
+//! 1. Central locks the connection interval at exactly 2.5 ms (min == max).
+//! 2. Peripheral tries to request an interval of 875 µs, which is below the
+//!    central's minimum of 2.5 ms. The ranges do not overlap so the LL rejects
+//!    the request.
+//! 3. Central widens the acceptable range to [875 µs, 2.5 ms].
+//! 4. Peripheral requests 875 µs again. The ranges now overlap so the LL
+//!    accepts and the connection rate changes to 875 µs.
+
+use bt_hci::controller::ControllerCmdSync;
+use embassy_futures::join::join;
+use embassy_time::{Duration, Timer};
+use trouble_host::prelude::*;
+
+const CONNECTIONS_MAX: usize = 1;
+const L2CAP_CHANNELS_MAX: usize = 2;
+
+pub async fn run<C>(controller: C)
+where
+    C: Controller + ControllerCmdSync<bt_hci::cmd::le::LeConnectionRateRequest>,
+{
+    let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
+    info!("Central address = {:?}", address);
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources)
+        .set_random_address(address)
+        .build();
+    let mut central = stack.central();
+    let mut runner = stack.runner();
+
+    // Match the address advertised by the peripheral example.
+    let target: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    let config = ConnectConfig {
+        connect_params: Default::default(),
+        scan_config: ScanConfig {
+            filter_accept_list: &[target],
+            ..Default::default()
+        },
+    };
+
+    let _ = join(runner.run(), async {
+        info!("Scanning for peripheral...");
+        let conn = central.connect(&config).await.unwrap();
+        info!("Connected!");
+
+        // Give the link layer a moment to settle.
+        Timer::after(Duration::from_millis(500)).await;
+
+        // ── Step 1 ────────────────────────────────────────────────────────────
+        // Lock the connection interval at exactly 2.5 ms by setting min == max.
+        //
+        // A connection rate change (SCI) follows the same Link Layer scheduling
+        // rules as a standard connection parameter update: the controller must
+        // wait at least 6 * (1 + peripheral_latency) connection events before
+        // applying the new parameters. With 0 peripheral latency and a default
+        // base interval this is at least 6 events. Most controllers then choose
+        // the first suitable anchor point after that minimum.
+        //
+        // This is slower than a subrate change (which takes only a few base
+        // connection events) but allows sub-millisecond intervals that are not
+        // achievable by changing only the base connection interval.
+        info!("Step 1: locking connection interval at 2.5 ms (min=max=2500 µs).");
+        let locked_params = ConnectRateParams {
+            min_connection_interval: Duration::from_micros(2500),
+            max_connection_interval: Duration::from_micros(2500),
+            subrate_min: 1, // no subrating in this example
+            subrate_max: 1,
+            max_latency: 0,
+            continuation_number: 0,
+            supervision_timeout: Duration::from_millis(2000),
+            min_ce_length: Duration::from_micros(0),
+            max_ce_length: Duration::from_micros(0),
+        };
+        conn.request_connection_rate(&stack, &locked_params)
+            .await
+            .unwrap_or_else(|e| error!("Request error: {:?}", e));
+
+        // Both sides receive ConnectionRateChanged once the LL switches over.
+        loop {
+            match conn.next().await {
+                ConnectionEvent::ConnectionRateChanged {
+                    conn_interval,
+                    subrate_factor,
+                    ..
+                } => {
+                    info!(
+                        "Step 1 confirmed: conn_interval={:?}, subrate_factor={}",
+                        conn_interval, subrate_factor
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        // Hold this interval long enough for the peripheral to observe the event
+        // and then issue its (deliberately rejected) counter-request.
+        Timer::after(Duration::from_secs(3)).await;
+
+        // ── Step 3 ────────────────────────────────────────────────────────────
+        // Widen the acceptable range to [875 µs, 2.5 ms].
+        // 875 µs is the minimum connection interval supported by SCI.
+        // Now the peripheral's request for 875 µs will fall inside [875 µs, 2.5 ms]
+        // and be accepted by the LL.
+        info!("Step 3: widening interval range to [875 µs, 2.5 ms].");
+        let wide_params = ConnectRateParams {
+            min_connection_interval: Duration::from_micros(875), // SCI minimum
+            max_connection_interval: Duration::from_micros(2500),
+            subrate_min: 1,
+            subrate_max: 1,
+            max_latency: 0,
+            continuation_number: 0,
+            supervision_timeout: Duration::from_millis(2000),
+            min_ce_length: Duration::from_micros(0),
+            max_ce_length: Duration::from_micros(0),
+        };
+        conn.request_connection_rate(&stack, &wide_params)
+            .await
+            .unwrap_or_else(|e| error!("Request error: {:?}", e));
+
+        loop {
+            match conn.next().await {
+                ConnectionEvent::ConnectionRateChanged {
+                    conn_interval,
+                    subrate_factor,
+                    ..
+                } => {
+                    info!(
+                        "Step 3 confirmed: conn_interval={:?}, subrate_factor={}",
+                        conn_interval, subrate_factor
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        // Wait for the peripheral's step 4 (its 875 µs request) to complete.
+        loop {
+            match conn.next().await {
+                ConnectionEvent::ConnectionRateChanged {
+                    conn_interval,
+                    subrate_factor,
+                    peripheral_latency,
+                    continuation_number,
+                    supervision_timeout,
+                } => {
+                    info!(
+                        "Peripheral step 4 confirmed: conn_interval={:?}, \
+                         subrate_factor={}, latency={}, continuation={}, timeout={:?}",
+                        conn_interval, subrate_factor, peripheral_latency, continuation_number, supervision_timeout
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        info!("Negotiation complete. Staying connected.");
+        loop {
+            Timer::after(Duration::from_secs(60)).await;
+        }
+    })
+    .await;
+}

--- a/examples/apps/src/ble_sci_peripheral.rs
+++ b/examples/apps/src/ble_sci_peripheral.rs
@@ -1,0 +1,226 @@
+//! BLE Shorter Connection Intervals (SCI) — Peripheral role.
+//!
+//! Demonstrates the LE Connection Rate Request procedure from the peripheral side.
+//! Run alongside `ble_sci_central` to observe the full negotiation.
+//!
+//! # Steps
+//! 1. Wait for central to lock the connection interval at 2.5 ms.
+//! 2. Peripheral requests 875 µs, which is below the central's minimum of
+//!    2.5 ms. The ranges [875 µs, 875 µs] and [2.5 ms, 2.5 ms] do not
+//!    overlap so the LL rejects the request.
+//! 3. Wait for central to widen its range to [875 µs, 2.5 ms].
+//! 4. Peripheral requests 875 µs again. The ranges now overlap so the LL
+//!    accepts and both sides receive ConnectionRateChanged.
+
+use bt_hci::cmd::le::LeSetPhy;
+use bt_hci::controller::{ControllerCmdAsync, ControllerCmdSync};
+use embassy_futures::join::join;
+use embassy_time::{Duration, Timer, WithTimeout};
+use trouble_host::prelude::*;
+
+const CONNECTIONS_MAX: usize = 1;
+const L2CAP_CHANNELS_MAX: usize = 2;
+
+pub async fn run<C>(controller: C)
+where
+    C: Controller + ControllerCmdSync<bt_hci::cmd::le::LeConnectionRateRequest> + ControllerCmdAsync<LeSetPhy>,
+{
+    let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    info!("Peripheral address = {:?}", address);
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources)
+        .set_random_address(address)
+        .build();
+    let mut peripheral = stack.peripheral();
+    let mut runner = stack.runner();
+
+    let mut adv_data = [0; 31];
+    let adv_data_len = AdStructure::encode_slice(
+        &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
+        &mut adv_data[..],
+    )
+    .unwrap();
+
+    let mut scan_data = [0; 31];
+    let scan_data_len =
+        AdStructure::encode_slice(&[AdStructure::CompleteLocalName(b"SCI")], &mut scan_data[..]).unwrap();
+
+    let _ = join(runner.run(), async {
+        info!("Advertising, waiting for connection...");
+        let advertiser = peripheral
+            .advertise(
+                &Default::default(),
+                Advertisement::ConnectableScannableUndirected {
+                    adv_data: &adv_data[..adv_data_len],
+                    scan_data: &scan_data[..scan_data_len],
+                },
+            )
+            .await
+            .unwrap();
+        let conn = advertiser.accept().await.unwrap();
+        info!("Connected! Switching to 2M PHY for shorter connection intervals...");
+        match conn.set_phy(&stack, PhyKind::Le2M).await {
+            Ok(_) => info!("PHY update requested."),
+            Err(e) => error!("PHY update failed: {:?}", e),
+        }
+
+        // Both sides receive ConnectionRateChanged once the LL switches over.
+        loop {
+            match conn.next().await {
+                ConnectionEvent::ConnectionRateChanged {
+                    conn_interval,
+                    subrate_factor,
+                    ..
+                } => {
+                    info!(
+                        "Step 1 confirmed: conn_interval={:?}, subrate_factor={}",
+                        conn_interval, subrate_factor
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        // Brief delay so the central is ready to receive our request.
+        Timer::after(Duration::from_millis(500)).await;
+
+        // ── Step 2 ────────────────────────────────────────────────────────
+        // Request 875 µs — the SCI minimum connection interval.
+        //
+        // The central's current range is [2.5 ms, 2.5 ms]. Our requested
+        // range is [875 µs, 875 µs]. The intersection is empty (875 µs <
+        // 2.5 ms), so the LL rejects the request.
+        //
+        // Unlike a subrate rejection (which immediately returns a
+        // SubratingParamsUpdated event with a sentinel value), a connection
+        // rate rejection may manifest as either no ConnectionRateChanged
+        // event (the controller silently drops the request) or as a
+        // ConnectionRateChanged with the interval unchanged. The exact
+        // behaviour is controller-implementation-defined. We use a timer
+        // to bound our wait and then proceed regardless.
+        info!(
+            "Step 2: requesting 875 µs interval (expecting rejection — \
+                 central's min is 2.5 ms, our max is 875 µs, ranges do not overlap)."
+        );
+        let rejected_params = ConnectRateParams {
+            min_connection_interval: Duration::from_micros(875),
+            max_connection_interval: Duration::from_micros(875),
+            subrate_min: 1,
+            subrate_max: 1,
+            max_latency: 0,
+            continuation_number: 0,
+            supervision_timeout: Duration::from_millis(2000),
+            min_ce_length: Duration::from_micros(0),
+            max_ce_length: Duration::from_micros(0),
+        };
+        conn.request_connection_rate(&stack, &rejected_params)
+            .await
+            .unwrap_or_else(|e| info!("Expected Request error: {:?}", e));
+
+        // Wait up to 2 s for a ConnectionRateChanged event. If the controller
+        // silently rejects the request we will time out and move on.
+        let result = async {
+            loop {
+                match conn.next().await {
+                    ConnectionEvent::ConnectionRateChanged { conn_interval, .. } => {
+                        return Some(conn_interval);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        .with_timeout(Duration::from_secs(2))
+        .await;
+
+        match result {
+            Ok(interval) => {
+                info!(
+                    "Step 2: got ConnectionRateChanged with interval={:?}. \
+                         If interval is still 2.5 ms the request was silently rejected.",
+                    interval
+                );
+            }
+            Err(_) => {
+                // No event received within 2 s: the controller rejected the
+                // request without sending a ConnectionRateChanged event.
+                info!(
+                    "Step 2: no event received — request was rejected \
+                         as expected (controller did not send ConnectionRateChanged)."
+                );
+            }
+        }
+
+        // ── Wait for Step 3 ───────────────────────────────────────────────
+        // Central will now widen its range to [875 µs, 2.5 ms]. Both sides
+        // receive ConnectionRateChanged when the switch takes effect.
+        info!("Waiting for central to widen range to [875 µs, 2.5 ms]...");
+        loop {
+            match conn.next().await {
+                ConnectionEvent::ConnectionRateChanged { conn_interval, .. } => {
+                    info!(
+                        "Central widened range; current interval={:?}",
+                        conn_interval
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        // Brief delay before our second attempt.
+        Timer::after(Duration::from_millis(500)).await;
+
+        // ── Step 4 ────────────────────────────────────────────────────────
+        // Request 875 µs again. Central's range is now [875 µs, 2.5 ms].
+        // The intersection of [875 µs, 875 µs] and [875 µs, 2.5 ms] is
+        // [875 µs, 875 µs], so the LL accepts the request.
+        info!("Step 4: requesting 875 µs again (expecting success).");
+        let accepted_params = ConnectRateParams {
+            min_connection_interval: Duration::from_micros(875),
+            max_connection_interval: Duration::from_micros(875),
+            subrate_min: 1,
+            subrate_max: 1,
+            max_latency: 0,
+            continuation_number: 0,
+            supervision_timeout: Duration::from_millis(2000),
+            min_ce_length: Duration::from_micros(0),
+            max_ce_length: Duration::from_micros(0),
+        };
+        conn.request_connection_rate(&stack, &accepted_params)
+            .await
+            .unwrap_or_else(|e| error!("Request error: {:?}", e));
+
+        loop {
+            match conn.next().await {
+                ConnectionEvent::ConnectionRateChanged {
+                    conn_interval,
+                    subrate_factor,
+                    peripheral_latency,
+                    continuation_number,
+                    supervision_timeout,
+                } => {
+                    info!(
+                        "Step 4 result: conn_interval={:?}, subrate_factor={}, \
+                             latency={}, continuation={}, timeout={:?}",
+                        conn_interval, subrate_factor, peripheral_latency, continuation_number, supervision_timeout
+                    );
+                    if conn_interval.as_micros() <= 900 {
+                        info!("Success! 875 µs interval accepted.");
+                    } else {
+                        warn!("Unexpected interval={:?}.", conn_interval);
+                    }
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        info!("Negotiation complete. Staying connected.");
+        loop {
+            Timer::after(Duration::from_secs(60)).await;
+        }
+    })
+    .await;
+}

--- a/examples/apps/src/lib.rs
+++ b/examples/apps/src/lib.rs
@@ -37,6 +37,10 @@ pub mod ble_l2cap_central;
 pub mod ble_l2cap_peripheral;
 #[cfg(feature = "scan")]
 pub mod ble_scanner;
+#[cfg(all(feature = "shorter-connection-intervals", feature = "central"))]
+pub mod ble_sci_central;
+#[cfg(feature = "shorter-connection-intervals")]
+pub mod ble_sci_peripheral;
 #[cfg(feature = "central")]
 pub mod high_throughput_ble_l2cap_central;
 pub mod high_throughput_ble_l2cap_peripheral;

--- a/examples/nrf52/Cargo.toml
+++ b/examples/nrf52/Cargo.toml
@@ -90,6 +90,10 @@ nrf52840 = [
 security = [
     "trouble-example-apps/security",
 ]
+shorter-connection-intervals = [
+    "trouble-host/shorter-connection-intervals",
+    "trouble-example-apps/shorter-connection-intervals",
+]
 
 [[bin]]
 name = "ble_advertise_multiple"
@@ -138,3 +142,11 @@ required-features = ["security", "nrf52840", "central"]
 [[bin]]
 name = "ble_bas_peripheral_bonding"
 required-features = ["security", "nrf52840"]
+
+[[bin]]
+name = "ble_sci_central"
+required-features = ["shorter-connection-intervals", "central"]
+
+[[bin]]
+name = "ble_sci_peripheral"
+required-features = ["shorter-connection-intervals"]

--- a/examples/nrf52/src/bin/ble_sci_central.rs
+++ b/examples/nrf52/src/bin/ble_sci_central.rs
@@ -1,0 +1,74 @@
+#![no_std]
+#![no_main]
+
+use defmt::unwrap;
+use embassy_executor::Spawner;
+use embassy_nrf::mode::Async;
+use embassy_nrf::peripherals::RNG;
+use embassy_nrf::{bind_interrupts, rng};
+use nrf_sdc::mpsl::MultiprotocolServiceLayer;
+use nrf_sdc::{self as sdc, mpsl};
+use static_cell::StaticCell;
+use trouble_example_apps::ble_sci_central;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<RNG>;
+    EGU0_SWI0 => nrf_sdc::mpsl::LowPrioInterruptHandler;
+    CLOCK_POWER => nrf_sdc::mpsl::ClockInterruptHandler;
+    RADIO => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    TIMER0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    RTC0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+});
+
+#[embassy_executor::task]
+async fn mpsl_task(mpsl: &'static MultiprotocolServiceLayer<'static>) -> ! {
+    mpsl.run().await
+}
+
+fn build_sdc<'d, const N: usize>(
+    p: nrf_sdc::Peripherals<'d>,
+    rng: &'d mut rng::Rng<Async>,
+    mpsl: &'d MultiprotocolServiceLayer,
+    mem: &'d mut sdc::Mem<N>,
+) -> Result<nrf_sdc::SoftdeviceController<'d>, nrf_sdc::Error> {
+    sdc::Builder::new()?
+        .support_scan()
+        .support_central()
+        .support_dle_central()
+        .support_phy_update_central()
+        .support_le_2m_phy()
+        .support_extended_feature_set()
+        .support_connection_subrating_central()
+        .support_shorter_connection_intervals_central()
+        .central_count(1)?
+        .build(p, rng, mpsl, mem)
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    let mpsl_p = mpsl::Peripherals::new(p.RTC0, p.TIMER0, p.TEMP, p.PPI_CH19, p.PPI_CH30, p.PPI_CH31);
+    let lfclk_cfg = mpsl::raw::mpsl_clock_lfclk_cfg_t {
+        source: mpsl::raw::MPSL_CLOCK_LF_SRC_RC as u8,
+        rc_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_CTIV as u8,
+        rc_temp_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_TEMP_CTIV as u8,
+        accuracy_ppm: mpsl::raw::MPSL_DEFAULT_CLOCK_ACCURACY_PPM as u16,
+        skip_wait_lfclk_started: mpsl::raw::MPSL_DEFAULT_SKIP_WAIT_LFCLK_STARTED != 0,
+    };
+    static MPSL: StaticCell<MultiprotocolServiceLayer> = StaticCell::new();
+    let mpsl = MPSL.init(unwrap!(mpsl::MultiprotocolServiceLayer::new(mpsl_p, Irqs, lfclk_cfg)));
+    spawner.spawn(unwrap!(mpsl_task(&*mpsl)));
+
+    let sdc_p = sdc::Peripherals::new(
+        p.PPI_CH17, p.PPI_CH18, p.PPI_CH20, p.PPI_CH21, p.PPI_CH22, p.PPI_CH23, p.PPI_CH24, p.PPI_CH25, p.PPI_CH26,
+        p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
+    );
+
+    let mut rng = rng::Rng::new(p.RNG, Irqs);
+
+    let mut sdc_mem = sdc::Mem::<2904>::new();
+    let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
+
+    ble_sci_central::run(sdc).await;
+}

--- a/examples/nrf52/src/bin/ble_sci_peripheral.rs
+++ b/examples/nrf52/src/bin/ble_sci_peripheral.rs
@@ -1,0 +1,72 @@
+#![no_std]
+#![no_main]
+
+use defmt::unwrap;
+use embassy_executor::Spawner;
+use embassy_nrf::mode::Async;
+use embassy_nrf::peripherals::RNG;
+use embassy_nrf::{bind_interrupts, rng};
+use nrf_sdc::mpsl::MultiprotocolServiceLayer;
+use nrf_sdc::{self as sdc, mpsl};
+use static_cell::StaticCell;
+use trouble_example_apps::ble_sci_peripheral;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<RNG>;
+    EGU0_SWI0 => nrf_sdc::mpsl::LowPrioInterruptHandler;
+    CLOCK_POWER => nrf_sdc::mpsl::ClockInterruptHandler;
+    RADIO => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    TIMER0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    RTC0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+});
+
+#[embassy_executor::task]
+async fn mpsl_task(mpsl: &'static MultiprotocolServiceLayer<'static>) -> ! {
+    mpsl.run().await
+}
+
+fn build_sdc<'d, const N: usize>(
+    p: nrf_sdc::Peripherals<'d>,
+    rng: &'d mut rng::Rng<Async>,
+    mpsl: &'d MultiprotocolServiceLayer,
+    mem: &'d mut sdc::Mem<N>,
+) -> Result<nrf_sdc::SoftdeviceController<'d>, nrf_sdc::Error> {
+    sdc::Builder::new()?
+        .support_adv()
+        .support_peripheral()
+        .support_dle_peripheral()
+        .support_phy_update_peripheral()
+        .support_le_2m_phy()
+        .support_extended_feature_set()
+        .support_connection_subrating_peripheral()
+        .support_shorter_connection_intervals_peripheral()
+        .build(p, rng, mpsl, mem)
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    let mpsl_p = mpsl::Peripherals::new(p.RTC0, p.TIMER0, p.TEMP, p.PPI_CH19, p.PPI_CH30, p.PPI_CH31);
+    let lfclk_cfg = mpsl::raw::mpsl_clock_lfclk_cfg_t {
+        source: mpsl::raw::MPSL_CLOCK_LF_SRC_RC as u8,
+        rc_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_CTIV as u8,
+        rc_temp_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_TEMP_CTIV as u8,
+        accuracy_ppm: mpsl::raw::MPSL_DEFAULT_CLOCK_ACCURACY_PPM as u16,
+        skip_wait_lfclk_started: mpsl::raw::MPSL_DEFAULT_SKIP_WAIT_LFCLK_STARTED != 0,
+    };
+    static MPSL: StaticCell<MultiprotocolServiceLayer> = StaticCell::new();
+    let mpsl = MPSL.init(unwrap!(mpsl::MultiprotocolServiceLayer::new(mpsl_p, Irqs, lfclk_cfg)));
+    spawner.spawn(unwrap!(mpsl_task(&*mpsl)));
+
+    let sdc_p = sdc::Peripherals::new(
+        p.PPI_CH17, p.PPI_CH18, p.PPI_CH20, p.PPI_CH21, p.PPI_CH22, p.PPI_CH23, p.PPI_CH24, p.PPI_CH25, p.PPI_CH26,
+        p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
+    );
+
+    let mut rng = rng::Rng::new(p.RNG, Irqs);
+    let mut sdc_mem = sdc::Mem::<2704>::new();
+    let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
+
+    ble_sci_peripheral::run(sdc).await;
+}


### PR DESCRIPTION
Adds central and peripheral example applications that demonstrate the LE Connection Rate Request procedure (Shorter Connection Intervals, SCI).

The example walks through a four-step negotiation:
1. Central locks the connection interval at exactly 2.5 ms (min=max).
2. Peripheral requests 875 µs (the SCI minimum for nrf52840), which is below the central's minimum of 2.5 ms. The LL rejects the request because the ranges [875 µs, 875 µs] and [2.5 ms, 2.5 ms] do not overlap. Unlike subrate rejections (which always generate a sentinel event), SCI rejection behaviour is controller-defined: the controller may silently drop the request or send ConnectionRateChanged with the previous interval unchanged. The example handles both cases.
3. Central widens the acceptable range to [875 µs, 2.5 ms].
4. Peripheral requests 875 µs again. The intersection is [875 µs, 875 µs] so the LL accepts and both sides receive ConnectionRateChanged.