### PR TITLE
feat(examples): add ble_subrate_central and ble_subrate_peripheral

### DIFF
--- a/examples/apps/Cargo.toml
+++ b/examples/apps/Cargo.toml
@@ -50,3 +50,4 @@ security = [
     "dep:serde"
 ]
 std = []
+subrating = ["trouble-host/subrating"]

--- a/examples/apps/src/ble_subrate_central.rs
+++ b/examples/apps/src/ble_subrate_central.rs
@@ -1,0 +1,124 @@
+//! BLE Connection Subrating — Central role.
+//!
+//! Demonstrates the LE Subrate Request procedure from the central side.
+//! Unlike a connection parameter update, a subrate change takes effect within
+//! only a **few base connection intervals** — making it much faster to apply.
+//!
+//! Run alongside `ble_subrate_peripheral` to observe the full negotiation.
+//!
+//! # Steps
+//! 1. Central sets an acceptable subrate factor range of [4, 12].
+//! 2. Peripheral requests an out-of-range factor (50), which is rejected.
+//! 3. Peripheral requests a valid factor (10), which is accepted.
+//! 4. Peripheral requests a range [1, 5] that overlaps with the central's range,
+//!    leading to an accepted factor (e.g., 4 or 5).
+//!
+//! The two sides use the `SubratingParamsUpdated` event to stay synchronised.
+
+use bt_hci::controller::ControllerCmdAsync;
+use embassy_futures::join::join;
+use embassy_time::{Duration, Timer};
+use trouble_host::prelude::*;
+
+const CONNECTIONS_MAX: usize = 1;
+const L2CAP_CHANNELS_MAX: usize = 2;
+
+pub async fn run<C>(controller: C)
+where
+    C: Controller + ControllerCmdAsync<bt_hci::cmd::le::LeSubrateRequest>,
+{
+    let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
+    info!("Central address = {:?}", address);
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources)
+        .set_random_address(address)
+        .build();
+    let mut central = stack.central();
+    let mut runner = stack.runner();
+
+    // Match the address advertised by the peripheral example.
+    let target: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    let config = ConnectConfig {
+        connect_params: Default::default(),
+        scan_config: ScanConfig {
+            filter_accept_list: &[target],
+            ..Default::default()
+        },
+    };
+
+    let _ = join(runner.run(), async {
+        info!("Scanning for peripheral...");
+        let conn = central.connect(&config).await.unwrap();
+        info!("Connected!");
+
+        // Give the link layer a moment to settle before issuing subrate commands.
+        Timer::after(Duration::from_millis(500)).await;
+
+        // ── Step 1 ────────────────────────────────────────────────────────────
+        // Set an acceptable subrate factor range of [4, 12].
+        //
+        // Subrate factor N means data is exchanged only on every Nth base
+        // connection event; the remaining N-1 events are skipped. Factor 4
+        // therefore reduces air-time by 75 % while maintaining the same
+        // supervision timeout.
+        //
+        // Because a subrate change is applied directly at the Link Layer level,
+        // it takes effect within a few base connection intervals — far quicker
+        // than a full connection parameter update, which must wait at least
+        // 6 * (1 + latency) connection events before the controller is allowed
+        // to apply the new parameters.
+        info!("Setting acceptable subrate factor range (min=4, max=12).");
+        conn.request_conn_subrate(
+            &stack,
+            4,                           // subrate_min
+            12,                          // subrate_max
+            0,                           // max_latency in subrated connection events
+            0,                           // continuation_number: stay awake for 0 extra events after data
+            Duration::from_millis(2000), // supervision_timeout
+        )
+        .await
+        .unwrap_or_else(|e| error!("subrate request failed: {:?}", e));
+
+        // Both sides receive SubratingParamsUpdated once the LL has agreed.
+        loop {
+            if let ConnectionEvent::SubratingParamsUpdated { subrate_factor, .. } = conn.next().await {
+                info!("Step 1 confirmed: subrate_factor={}", subrate_factor);
+                break;
+            }
+        }
+
+        // ── Step 2 ────────────────────────────────────────────────────────────
+        // Peripheral tries to request an invalid subrate factor -> unnoticed by central
+
+        // ── Step 3 ────────────────────────────────────────────────────────────
+        // Wait for peripheral to request valid subrate factor and trigger a subrate change
+        loop {
+            if let ConnectionEvent::SubratingParamsUpdated { subrate_factor, .. } = conn.next().await {
+                info!(
+                    "Peripheral caused a change to subrate_factor={}",
+                    subrate_factor
+                );
+                break;
+            }
+        }
+
+        // ── Step 4 ────────────────────────────────────────────────────────────
+        // Wait for peripheral to request valid subrate factor range and trigger a subrate change
+        loop {
+            if let ConnectionEvent::SubratingParamsUpdated { subrate_factor, .. } = conn.next().await {
+                info!(
+                    "Peripheral caused a change to subrate_factor={}",
+                    subrate_factor
+                );
+                break;
+            }
+        }
+
+        info!("Negotiation complete. Staying connected.");
+        loop {
+            Timer::after(Duration::from_secs(60)).await;
+        }
+    })
+    .await;
+}

--- a/examples/apps/src/ble_subrate_peripheral.rs
+++ b/examples/apps/src/ble_subrate_peripheral.rs
@@ -1,0 +1,174 @@
+//! BLE Connection Subrating — Peripheral role.
+//!
+//! Demonstrates the LE Subrate Request procedure from the peripheral side.
+//! Run alongside `ble_subrate_central` to observe the full negotiation.
+//!
+//! # Steps
+//! 1. Wait for the central to set a subrate factor range of [4, 12].
+//! 2. Request an out-of-range factor (50), which is rejected.
+//! 3. Request a valid factor (10), which is accepted.
+//! 4. Request an overlapping range [1, 5], leading to an accepted factor (e.g., 4 or 5).
+use bt_hci::controller::ControllerCmdAsync;
+use embassy_futures::join::join;
+use embassy_time::{Duration, Timer, WithTimeout};
+use trouble_host::prelude::*;
+
+const CONNECTIONS_MAX: usize = 1;
+const L2CAP_CHANNELS_MAX: usize = 2;
+
+pub async fn run<C>(controller: C)
+where
+    C: Controller + ControllerCmdAsync<bt_hci::cmd::le::LeSubrateRequest>,
+{
+    let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    info!("Peripheral address = {:?}", address);
+    Timer::after(embassy_time::Duration::from_millis(50)).await;
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources)
+        .set_random_address(address)
+        .build();
+    let mut peripheral = stack.peripheral();
+    let mut runner = stack.runner();
+
+    let mut adv_data = [0u8; 31];
+    let adv_len = AdStructure::encode_slice(
+        &[AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED)],
+        &mut adv_data[..],
+    )
+    .unwrap();
+
+    info!("Starting main loop");
+    Timer::after(Duration::from_millis(50)).await;
+
+    let _ = join(
+        async {
+            if let Err(e) = runner.run().await {
+                error!("runner died with error: {:?}", e);
+            } else {
+                info!("Runner stopped without error!")
+            }
+        },
+        async {
+            info!("Advertising...");
+            Timer::after(Duration::from_millis(50)).await;
+
+            let advertiser = peripheral
+                .advertise(
+                    &Default::default(),
+                    Advertisement::ConnectableScannableUndirected {
+                        adv_data: &adv_data[..adv_len],
+                        scan_data: &[],
+                    },
+                )
+                .await
+                .unwrap();
+
+            let conn = advertiser.accept().await.unwrap();
+            info!("Connected!");
+
+            // ── Wait for Step 1 ───────────────────────────────────────────────
+            // The central will set a subrate factor range of [4, 12].
+            // We wait for SubratingParamsUpdated once the LL has agreed on the new factor.
+            info!("Waiting for central to establish a subrate factor...");
+            loop {
+                if let ConnectionEvent::SubratingParamsUpdated { subrate_factor, .. } = conn.next().await {
+                    info!("Central set subrate_factor={}", subrate_factor);
+                    break;
+                }
+            }
+
+            // Brief delay so the central is ready to process our request.
+            Timer::after(Duration::from_millis(500)).await;
+
+            // ── Step 2 ────────────────────────────────────────────────────────
+            // Request an out-of-range subrate factor (50).
+            //
+            // The central's current range is [4, 12]. Our requested range is
+            // [50, 50]. The intersection is empty, so the Link Layer MUST
+            // reject the request.
+            info!("Requesting a subrate factor of 50, that is out of range");
+            conn.request_conn_subrate(
+                &stack,
+                50, // subrate_min
+                50, // subrate_max (min == max == 50: request exactly factor 50)
+                0,  // max_latency
+                0,  // continuation_number
+                Duration::from_millis(2000),
+            )
+            .await
+            .unwrap_or_else(|e| info!("Subrate request failed as expected: {:?}", e));
+
+            async {
+                // Check for update event.
+                loop {
+                    if let ConnectionEvent::SubratingParamsUpdated { subrate_factor, .. } = conn.next().await {
+                        error!(
+                            "Successfully requested out of range subrate factor: {}",
+                            subrate_factor
+                        );
+                        break;
+                    }
+                }
+            }
+            .with_timeout(Duration::from_millis(500))
+            .await
+            .unwrap_or_else(|_e| info!("No subrate change event for 500ms, as expected."));
+
+            // ── Step 3 ────────────────────────────────────────────────────────
+            info!("Request a valid subrate in range.");
+            conn.request_conn_subrate(
+                &stack,
+                10, // subrate_min
+                10, // subrate_max
+                0,  // max_latency
+                0,  // continuation_number
+                Duration::from_millis(2000),
+            )
+            .await
+            .unwrap_or_else(|e| error!("Subrate request failed unexpectedly: {:?}", e));
+
+            loop {
+                if let ConnectionEvent::SubratingParamsUpdated { subrate_factor, .. } = conn.next().await {
+                    info!(
+                        "Successfully requested subrate factor 10, got {}",
+                        subrate_factor
+                    );
+                    break;
+                }
+            }
+
+            // Brief delay so the controller is ready to process our request.
+            Timer::after(Duration::from_millis(500)).await;
+
+            // ── Step 4 ────────────────────────────────────────────────────────
+            info!("Request an overlapping range: Central: 4-12, Peripheral: 1-5.");
+            conn.request_conn_subrate(
+                &stack,
+                1, // subrate_min
+                5, // subrate_max
+                0, // max_latency
+                0, // continuation_number
+                Duration::from_millis(2000),
+            )
+            .await
+            .unwrap_or_else(|e| error!("Subrate request failed unexpectedly: {:?}", e));
+
+            loop {
+                if let ConnectionEvent::SubratingParamsUpdated { subrate_factor, .. } = conn.next().await {
+                    info!(
+                        "Successfully requested subrate factor in range 1 to 5, got: {}",
+                        subrate_factor
+                    );
+                    break;
+                }
+            }
+
+            info!("Negotiation complete. Staying connected.");
+            loop {
+                Timer::after(Duration::from_secs(60)).await;
+            }
+        },
+    )
+    .await;
+}

--- a/examples/apps/src/lib.rs
+++ b/examples/apps/src/lib.rs
@@ -37,6 +37,10 @@ pub mod ble_l2cap_central;
 pub mod ble_l2cap_peripheral;
 #[cfg(feature = "scan")]
 pub mod ble_scanner;
+#[cfg(all(feature = "subrating", feature = "central"))]
+pub mod ble_subrate_central;
+#[cfg(feature = "subrating")]
+pub mod ble_subrate_peripheral;
 #[cfg(feature = "central")]
 pub mod high_throughput_ble_l2cap_central;
 pub mod high_throughput_ble_l2cap_peripheral;

--- a/examples/nrf52/Cargo.toml
+++ b/examples/nrf52/Cargo.toml
@@ -90,6 +90,10 @@ nrf52840 = [
 security = [
     "trouble-example-apps/security",
 ]
+subrating = [
+    "trouble-host/subrating",
+    "trouble-example-apps/subrating",
+]
 
 [[bin]]
 name = "ble_advertise_multiple"
@@ -138,3 +142,11 @@ required-features = ["security", "nrf52840", "central"]
 [[bin]]
 name = "ble_bas_peripheral_bonding"
 required-features = ["security", "nrf52840"]
+
+[[bin]]
+name = "ble_subrate_central"
+required-features = ["subrating", "central"]
+
+[[bin]]
+name = "ble_subrate_peripheral"
+required-features = ["subrating"]

--- a/examples/nrf52/src/bin/ble_subrate_central.rs
+++ b/examples/nrf52/src/bin/ble_subrate_central.rs
@@ -1,0 +1,67 @@
+#![no_std]
+#![no_main]
+
+use defmt::unwrap;
+use embassy_executor::Spawner;
+use embassy_nrf::mode::Async;
+use embassy_nrf::peripherals::RNG;
+use embassy_nrf::{bind_interrupts, rng};
+use nrf_sdc::mpsl::MultiprotocolServiceLayer;
+use nrf_sdc::{self as sdc, mpsl};
+use static_cell::StaticCell;
+use trouble_example_apps::ble_subrate_central;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<RNG>;
+    EGU0_SWI0 => nrf_sdc::mpsl::LowPrioInterruptHandler;
+    CLOCK_POWER => nrf_sdc::mpsl::ClockInterruptHandler;
+    RADIO => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    TIMER0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    RTC0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+});
+
+#[embassy_executor::task]
+async fn mpsl_task(mpsl: &'static MultiprotocolServiceLayer<'static>) -> ! {
+    mpsl.run().await
+}
+
+fn build_sdc<'d, const N: usize>(
+    p: nrf_sdc::Peripherals<'d>,
+    rng: &'d mut rng::Rng<Async>,
+    mpsl: &'d MultiprotocolServiceLayer,
+    mem: &'d mut sdc::Mem<N>,
+) -> Result<nrf_sdc::SoftdeviceController<'d>, nrf_sdc::Error> {
+    sdc::Builder::new()?
+        .support_scan()
+        .support_central()
+        .support_connection_subrating_central()
+        .build(p, rng, mpsl, mem)
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    let mpsl_p = mpsl::Peripherals::new(p.RTC0, p.TIMER0, p.TEMP, p.PPI_CH19, p.PPI_CH30, p.PPI_CH31);
+    let lfclk_cfg = mpsl::raw::mpsl_clock_lfclk_cfg_t {
+        source: mpsl::raw::MPSL_CLOCK_LF_SRC_RC as u8,
+        rc_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_CTIV as u8,
+        rc_temp_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_TEMP_CTIV as u8,
+        accuracy_ppm: mpsl::raw::MPSL_DEFAULT_CLOCK_ACCURACY_PPM as u16,
+        skip_wait_lfclk_started: mpsl::raw::MPSL_DEFAULT_SKIP_WAIT_LFCLK_STARTED != 0,
+    };
+    static MPSL: StaticCell<MultiprotocolServiceLayer> = StaticCell::new();
+    let mpsl = MPSL.init(unwrap!(mpsl::MultiprotocolServiceLayer::new(mpsl_p, Irqs, lfclk_cfg)));
+    spawner.spawn(unwrap!(mpsl_task(mpsl)));
+
+    let sdc_p = sdc::Peripherals::new(
+        p.PPI_CH17, p.PPI_CH18, p.PPI_CH20, p.PPI_CH21, p.PPI_CH22, p.PPI_CH23, p.PPI_CH24, p.PPI_CH25, p.PPI_CH26,
+        p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
+    );
+    let mut rng = rng::Rng::new(p.RNG, Irqs);
+    static MEM: StaticCell<sdc::Mem<4096>> = StaticCell::new();
+    let mem = MEM.init(sdc::Mem::new());
+    let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, mem));
+
+    ble_subrate_central::run(sdc).await;
+}

--- a/examples/nrf52/src/bin/ble_subrate_peripheral.rs
+++ b/examples/nrf52/src/bin/ble_subrate_peripheral.rs
@@ -1,0 +1,66 @@
+#![no_std]
+#![no_main]
+
+use defmt::unwrap;
+use embassy_executor::Spawner;
+use embassy_nrf::mode::Async;
+use embassy_nrf::peripherals::RNG;
+use embassy_nrf::{bind_interrupts, rng};
+use nrf_sdc::mpsl::MultiprotocolServiceLayer;
+use nrf_sdc::{self as sdc, mpsl};
+use static_cell::StaticCell;
+use trouble_example_apps::ble_subrate_peripheral;
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<RNG>;
+    EGU0_SWI0 => nrf_sdc::mpsl::LowPrioInterruptHandler;
+    CLOCK_POWER => nrf_sdc::mpsl::ClockInterruptHandler;
+    RADIO => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    TIMER0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+    RTC0 => nrf_sdc::mpsl::HighPrioInterruptHandler;
+});
+
+#[embassy_executor::task]
+async fn mpsl_task(mpsl: &'static MultiprotocolServiceLayer<'static>) -> ! {
+    mpsl.run().await
+}
+
+fn build_sdc<'d, const N: usize>(
+    p: nrf_sdc::Peripherals<'d>,
+    rng: &'d mut rng::Rng<Async>,
+    mpsl: &'d MultiprotocolServiceLayer,
+    mem: &'d mut sdc::Mem<N>,
+) -> Result<nrf_sdc::SoftdeviceController<'d>, nrf_sdc::Error> {
+    sdc::Builder::new()?
+        .support_adv()
+        .support_peripheral()
+        .support_connection_subrating_peripheral()
+        .build(p, rng, mpsl, mem)
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let p = embassy_nrf::init(Default::default());
+    let mpsl_p = mpsl::Peripherals::new(p.RTC0, p.TIMER0, p.TEMP, p.PPI_CH19, p.PPI_CH30, p.PPI_CH31);
+    let lfclk_cfg = mpsl::raw::mpsl_clock_lfclk_cfg_t {
+        source: mpsl::raw::MPSL_CLOCK_LF_SRC_RC as u8,
+        rc_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_CTIV as u8,
+        rc_temp_ctiv: mpsl::raw::MPSL_RECOMMENDED_RC_TEMP_CTIV as u8,
+        accuracy_ppm: mpsl::raw::MPSL_DEFAULT_CLOCK_ACCURACY_PPM as u16,
+        skip_wait_lfclk_started: mpsl::raw::MPSL_DEFAULT_SKIP_WAIT_LFCLK_STARTED != 0,
+    };
+    static MPSL: StaticCell<MultiprotocolServiceLayer> = StaticCell::new();
+    let mpsl = MPSL.init(unwrap!(mpsl::MultiprotocolServiceLayer::new(mpsl_p, Irqs, lfclk_cfg)));
+    spawner.spawn(unwrap!(mpsl_task(&*mpsl)));
+
+    let sdc_p = sdc::Peripherals::new(
+        p.PPI_CH17, p.PPI_CH18, p.PPI_CH20, p.PPI_CH21, p.PPI_CH22, p.PPI_CH23, p.PPI_CH24, p.PPI_CH25, p.PPI_CH26,
+        p.PPI_CH27, p.PPI_CH28, p.PPI_CH29,
+    );
+    let mut rng = rng::Rng::new(p.RNG, Irqs);
+    let mut sdc_mem = sdc::Mem::<4720>::new();
+    let sdc = unwrap!(build_sdc(sdc_p, &mut rng, mpsl, &mut sdc_mem));
+
+    ble_subrate_peripheral::run(sdc).await;
+}

--- a/host/src/connection.rs
+++ b/host/src/connection.rs
@@ -1,5 +1,7 @@
 //! BLE connection.
 
+#[cfg(feature = "subrating")]
+use bt_hci::cmd::le::LeSubrateRequest;
 use bt_hci::cmd::le::{
     LeConnUpdate, LeConnectionRateRequest, LeFrameSpaceUpdate, LeReadLocalSupportedFeatures, LeReadPhy,
     LeSetDataLength, LeSetPhy,
@@ -964,6 +966,47 @@ impl<'stack, P: PacketPool> Connection<'stack, P> {
                 frame_space_max_dur,
                 phys,
                 spacing_types,
+            ))
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(BleHostError::BleHost(crate::Error::Hci(bt_hci::param::Error::UNKNOWN_CONN_IDENTIFIER))) => {
+                Err(crate::Error::Disconnected.into())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Request a change in connection subrate for this connection.
+    ///
+    /// Uses the LE Subrate Request HCI command (0x007e), which may be issued by both the
+    /// central and the peripheral, unlike [`request_connection_rate`][Self::request_connection_rate]
+    /// which is central-only. The subrate change takes effect within a few base connection
+    /// intervals, much faster than a full connection parameter update.
+    ///
+    /// Requires the `subrating` feature.
+    #[cfg(feature = "subrating")]
+    pub async fn request_conn_subrate<T>(
+        &self,
+        stack: &Stack<'_, T, P>,
+        subrate_min: u16,
+        subrate_max: u16,
+        max_latency: u16,
+        continuation_number: u16,
+        supervision_timeout: Duration,
+    ) -> Result<(), BleHostError<T::Error>>
+    where
+        T: ControllerCmdAsync<LeSubrateRequest>,
+    {
+        match stack
+            .host()
+            .async_command(LeSubrateRequest::new(
+                self.handle(),
+                subrate_min,
+                subrate_max,
+                max_latency,
+                continuation_number,
+                bt_hci_duration(supervision_timeout),
             ))
             .await
         {


### PR DESCRIPTION
Adds central and peripheral example applications that demonstrate the
LE Subrate Request procedure (HCI command 0x007e, Connection::request_conn_subrate).

The example walks through a four-step negotiation:
1. Central sets an subrate factor range of [4, 12].
2. Peripheral requests an out-of-range factor (50). The Link Layer
   rejects the request (ranges do not overlap).
3. Peripheral requests a valid factor (10), which is accepted.
4. Peripheral requests a range [1, 5] that overlaps with the central's range,
   leading to an accepted factor (e.g. 4 or 5).

based on #678 