### PR TITLE
fix(gatt): ReadEvent: use correct data length in accept_unprocessed

### DIFF
--- a/host/src/gatt.rs
+++ b/host/src/gatt.rs
@@ -554,7 +554,7 @@ impl<'stack, P: PacketPool> ReadEvent<'stack, '_, P> {
         // packet-pool buffer and then post-hoc truncated, which can split an
         // entry in half and produce a malformed PDU.
         let mtu = self.data.connection.get_att_mtu() as usize;
-        let len = payload.len().saturating_sub(offset).min(mtu - 1);
+        let len = data.as_gatt().len().saturating_sub(offset).min(mtu - 1);
 
         payload.write(rsp)?;
         payload.append(&data.as_gatt()[offset..][..len])?;


### PR DESCRIPTION
Use the data length when constructing the reply packet.

Fixes: https://github.com/embassy-rs/trouble/issues/662
Fixes: 69a840fe "feat(gatt): Add accept_unprocessed() method to gatt::ReadEvent and gatt::WriteEvent"